### PR TITLE
feat: electricity price conditions in automations and DB price storage

### DIFF
--- a/Controllers/AutomationController.cs
+++ b/Controllers/AutomationController.cs
@@ -75,6 +75,10 @@ namespace garge_api.Controllers
                 Threshold = dto.Threshold,
                 Action = dto.Action,
                 IsEnabled = dto.IsEnabled,
+                ElectricityPriceCondition = dto.ElectricityPriceCondition,
+                ElectricityPriceThreshold = dto.ElectricityPriceThreshold,
+                ElectricityPriceArea = dto.ElectricityPriceArea,
+                ElectricityPriceOperator = dto.ElectricityPriceOperator,
             };
 
             if (!await UserHasAccessToAutomationAsync(rule))
@@ -97,6 +101,10 @@ namespace garge_api.Controllers
                 Action = rule.Action,
                 IsEnabled = rule.IsEnabled,
                 LastTriggeredAt = rule.LastTriggeredAt,
+                ElectricityPriceCondition = rule.ElectricityPriceCondition,
+                ElectricityPriceThreshold = rule.ElectricityPriceThreshold,
+                ElectricityPriceArea = rule.ElectricityPriceArea,
+                ElectricityPriceOperator = rule.ElectricityPriceOperator,
             };
 
             return Ok(result);
@@ -148,6 +156,10 @@ namespace garge_api.Controllers
                         Action = rule.Action,
                         IsEnabled = rule.IsEnabled,
                         LastTriggeredAt = rule.LastTriggeredAt,
+                        ElectricityPriceCondition = rule.ElectricityPriceCondition,
+                        ElectricityPriceThreshold = rule.ElectricityPriceThreshold,
+                        ElectricityPriceArea = rule.ElectricityPriceArea,
+                        ElectricityPriceOperator = rule.ElectricityPriceOperator,
                     });
                 }
             }
@@ -196,6 +208,10 @@ namespace garge_api.Controllers
             rule.Threshold = dto.Threshold;
             rule.Action = dto.Action;
             rule.IsEnabled = dto.IsEnabled;
+            rule.ElectricityPriceCondition = dto.ElectricityPriceCondition;
+            rule.ElectricityPriceThreshold = dto.ElectricityPriceThreshold;
+            rule.ElectricityPriceArea = dto.ElectricityPriceArea;
+            rule.ElectricityPriceOperator = dto.ElectricityPriceOperator;
 
             await _context.SaveChangesAsync();
 
@@ -211,6 +227,10 @@ namespace garge_api.Controllers
                 Action = rule.Action,
                 IsEnabled = rule.IsEnabled,
                 LastTriggeredAt = rule.LastTriggeredAt,
+                ElectricityPriceCondition = rule.ElectricityPriceCondition,
+                ElectricityPriceThreshold = rule.ElectricityPriceThreshold,
+                ElectricityPriceArea = rule.ElectricityPriceArea,
+                ElectricityPriceOperator = rule.ElectricityPriceOperator,
             };
 
             return Ok(result);

--- a/Controllers/ElectricityController.cs
+++ b/Controllers/ElectricityController.cs
@@ -6,6 +6,9 @@ using System.Security.Claims;
 using garge_api.Constants;
 using AutoMapper;
 using garge_api.Dtos.Electricity;
+using garge_api.Models;
+using Microsoft.EntityFrameworkCore;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace garge_api.Controllers
 {
@@ -18,22 +21,24 @@ namespace garge_api.Controllers
         private readonly NordPoolService _nordPoolService;
         private readonly IMapper _mapper;
         private readonly ILogger<ElectricityController> _logger;
+        private readonly ApplicationDbContext _context;
 
-        public ElectricityController(NordPoolService nordPoolService, IMapper mapper, ILogger<ElectricityController> logger)
+        public ElectricityController(NordPoolService nordPoolService, IMapper mapper, ILogger<ElectricityController> logger, ApplicationDbContext context)
         {
             _nordPoolService = nordPoolService;
             _mapper = mapper;
             _logger = logger;
+            _context = context;
         }
 
         /// <summary>
-        /// Retrieves electricity prices for a given type, area, and date.
+        /// Retrieves electricity prices for a given type, area, and date. Values are in kr/kWh.
         /// </summary>
-        /// <param name="type">The type of price data (e.g., "spot").</param>
+        /// <param name="type">The resolution: HOURLY, DAILY, or MONTHLY.</param>
         /// <param name="area">The area code (e.g., "NO1").</param>
         /// <param name="date">The date for which to retrieve prices.</param>
         /// <param name="currency">The currency (default: NOK).</param>
-        /// <returns>Electricity price data for the specified parameters.</returns>
+        /// <returns>Electricity price data in kr/kWh for the specified parameters.</returns>
         [HttpGet("prices")]
         public async Task<IActionResult> GetPrices([FromQuery] string type, [FromQuery] string area, [FromQuery] DateTime? date, [FromQuery] string currency = "NOK")
         {
@@ -56,10 +61,21 @@ namespace garge_api.Controllers
                 return BadRequest("Type and area parameters are required.");
             }
 
-            var areas = new List<string> { area };
-            _logger.LogInformation("Fetching prices from NordPoolService {@LogData}", new { type, area, date, currency });
+            var resolution = type.ToUpper();
+            var queryDate = date ?? DateTime.UtcNow;
 
-            var data = await _nordPoolService.FetchPricesAsync(type.ToUpper(), date, areas, currency);
+            // Try serving from DB first
+            var storedEntries = await GetStoredPricesAsync(resolution, area, queryDate);
+            if (storedEntries.Count > 0)
+            {
+                _logger.LogInformation("Serving {Count} {Resolution} price entries from DB for area {Area}", storedEntries.Count, resolution, area);
+                var dbDto = BuildPriceResponseDto(storedEntries, area, currency);
+                return Ok(dbDto);
+            }
+
+            // Fall back to NordPool
+            _logger.LogInformation("No DB data found, fetching from NordPool {@LogData}", new { type, area, date, currency });
+            var data = await _nordPoolService.FetchPricesAsync(resolution, queryDate, new List<string> { area }, currency);
 
             if (data == null)
             {
@@ -67,10 +83,93 @@ namespace garge_api.Controllers
                 return NotFound(new { message = "No price data found." });
             }
 
-            var dto = _mapper.Map<PriceResponseDto>(data);
+            // Convert NordPool values (NOK/MWh) to kr/kWh before returning
+            foreach (var areaPrices in data.Areas.Values)
+                foreach (var entry in areaPrices.Values)
+                    entry.Value /= 1000m;
 
-            _logger.LogInformation("Returning price data {@LogData}", new { type, area, date, currency });
+            var dto = _mapper.Map<PriceResponseDto>(data);
+            _logger.LogInformation("Returning NordPool price data {@LogData}", new { type, area, date, currency });
             return Ok(dto);
+        }
+
+        private async Task<List<garge_api.Models.Electricity.StoredElectricityPrice>> GetStoredPricesAsync(string resolution, string area, DateTime date)
+        {
+            var utcDate = date.ToUniversalTime();
+
+            if (resolution == "HOURLY")
+            {
+                var dayStart = new DateTime(utcDate.Year, utcDate.Month, utcDate.Day, 0, 0, 0, DateTimeKind.Utc);
+                var dayEnd = dayStart.AddDays(1);
+                return await _context.StoredElectricityPrices
+                    .Where(p => p.Area == area && p.Resolution == "HOURLY" && p.DeliveryStart >= dayStart && p.DeliveryStart < dayEnd)
+                    .OrderBy(p => p.DeliveryStart)
+                    .ToListAsync();
+            }
+            else
+            {
+                var year = utcDate.Year;
+                return await _context.StoredElectricityPrices
+                    .Where(p => p.Area == area && p.Resolution == resolution && p.DeliveryStart.Year == year)
+                    .OrderBy(p => p.DeliveryStart)
+                    .ToListAsync();
+            }
+        }
+
+        private static PriceResponseDto BuildPriceResponseDto(
+            List<garge_api.Models.Electricity.StoredElectricityPrice> entries, string area, string currency)
+        {
+            var areaPricesDto = new AreaPricesDto
+            {
+                Values = entries.Select(e => new PriceEntryDto
+                {
+                    Start = e.DeliveryStart,
+                    End = e.DeliveryEnd,
+                    Value = (decimal)e.Value,  // already in kr/kWh
+                }).ToList()
+            };
+
+            return new PriceResponseDto
+            {
+                Start = entries.First().DeliveryStart,
+                End = entries.Last().DeliveryEnd,
+                Updated = entries.Max(e => e.FetchedAt),
+                Currency = currency,
+                Areas = new Dictionary<string, AreaPricesDto> { [area] = areaPricesDto }
+            };
+        }
+
+        /// <summary>
+        /// Returns the current hour's electricity price for the given area from stored data.
+        /// </summary>
+        /// <param name="area">The NordPool area code (e.g. "NO2").</param>
+        /// <returns>Current price entry in kr/kWh.</returns>
+        [HttpGet("current-price")]
+        [SwaggerOperation(Summary = "Gets the current hour's stored electricity price for an area.")]
+        [SwaggerResponse(200, "Current price entry.")]
+        [SwaggerResponse(404, "No price data found for current hour.")]
+        public async Task<IActionResult> GetCurrentPrice([FromQuery] string area)
+        {
+            if (string.IsNullOrEmpty(area))
+                return BadRequest("Area parameter is required.");
+
+            var now = DateTime.UtcNow;
+            var entry = await _context.StoredElectricityPrices
+                .Where(p => p.Area == area && p.Resolution == "HOURLY" && p.DeliveryStart <= now && p.DeliveryEnd > now)
+                .OrderByDescending(p => p.FetchedAt)
+                .FirstOrDefaultAsync();
+
+            if (entry == null)
+                return NotFound(new { message = $"No stored price found for area '{area}' at current time." });
+
+            return Ok(new
+            {
+                area = entry.Area,
+                value = entry.Value,
+                currency = entry.Currency,
+                deliveryStart = entry.DeliveryStart,
+                deliveryEnd = entry.DeliveryEnd,
+            });
         }
     }
 }

--- a/Dtos/Automation/AutomationRuleDto.cs
+++ b/Dtos/Automation/AutomationRuleDto.cs
@@ -12,5 +12,9 @@
         public required string Action { get; set; }
         public bool IsEnabled { get; set; }
         public DateTime? LastTriggeredAt { get; set; }
+        public string? ElectricityPriceCondition { get; set; }
+        public double? ElectricityPriceThreshold { get; set; }
+        public string? ElectricityPriceArea { get; set; }
+        public string? ElectricityPriceOperator { get; set; }
     }
 }

--- a/Dtos/Automation/CreateAutomationRuleDto.cs
+++ b/Dtos/Automation/CreateAutomationRuleDto.cs
@@ -26,5 +26,10 @@ namespace garge_api.Dtos.Automation
         public required string Action { get; set; }
 
         public bool IsEnabled { get; set; } = true;
+
+        public string? ElectricityPriceCondition { get; set; }
+        public double? ElectricityPriceThreshold { get; set; }
+        public string? ElectricityPriceArea { get; set; }
+        public string? ElectricityPriceOperator { get; set; }
     }
 }

--- a/Dtos/Automation/UpdateAutomationRuleDto.cs
+++ b/Dtos/Automation/UpdateAutomationRuleDto.cs
@@ -20,5 +20,10 @@ namespace garge_api.Dtos.Automation
         public required string Action { get; set; }
 
         public bool IsEnabled { get; set; } = true;
+
+        public string? ElectricityPriceCondition { get; set; }
+        public double? ElectricityPriceThreshold { get; set; }
+        public string? ElectricityPriceArea { get; set; }
+        public string? ElectricityPriceOperator { get; set; }
     }
 }

--- a/Migrations/20260414143352_AddElectricityPriceConditionAndStoredPrices.Designer.cs
+++ b/Migrations/20260414143352_AddElectricityPriceConditionAndStoredPrices.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260414143352_AddElectricityPriceConditionAndStoredPrices")]
+    partial class AddElectricityPriceConditionAndStoredPrices
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -410,16 +413,12 @@ namespace garge_api.Migrations
                     b.Property<DateTime>("FetchedAt")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<string>("Resolution")
-                        .IsRequired()
-                        .HasColumnType("text");
-
                     b.Property<double>("Value")
                         .HasColumnType("double precision");
 
                     b.HasKey("Id");
 
-                    b.HasIndex("Area", "Resolution", "DeliveryStart")
+                    b.HasIndex("Area", "DeliveryStart")
                         .IsUnique();
 
                     b.ToTable("StoredElectricityPrices");

--- a/Migrations/20260414143352_AddElectricityPriceConditionAndStoredPrices.cs
+++ b/Migrations/20260414143352_AddElectricityPriceConditionAndStoredPrices.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddElectricityPriceConditionAndStoredPrices : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ElectricityPriceArea",
+                table: "AutomationRules",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ElectricityPriceCondition",
+                table: "AutomationRules",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ElectricityPriceOperator",
+                table: "AutomationRules",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "ElectricityPriceThreshold",
+                table: "AutomationRules",
+                type: "double precision",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "StoredElectricityPrices",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Area = table.Column<string>(type: "text", nullable: false),
+                    DeliveryStart = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    DeliveryEnd = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Value = table.Column<double>(type: "double precision", nullable: false),
+                    Currency = table.Column<string>(type: "text", nullable: false),
+                    FetchedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StoredElectricityPrices", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StoredElectricityPrices_Area_DeliveryStart",
+                table: "StoredElectricityPrices",
+                columns: new[] { "Area", "DeliveryStart" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "StoredElectricityPrices");
+
+            migrationBuilder.DropColumn(
+                name: "ElectricityPriceArea",
+                table: "AutomationRules");
+
+            migrationBuilder.DropColumn(
+                name: "ElectricityPriceCondition",
+                table: "AutomationRules");
+
+            migrationBuilder.DropColumn(
+                name: "ElectricityPriceOperator",
+                table: "AutomationRules");
+
+            migrationBuilder.DropColumn(
+                name: "ElectricityPriceThreshold",
+                table: "AutomationRules");
+        }
+    }
+}

--- a/Migrations/20260414150302_AddElectricityPriceResolution.Designer.cs
+++ b/Migrations/20260414150302_AddElectricityPriceResolution.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260414150302_AddElectricityPriceResolution")]
+    partial class AddElectricityPriceResolution
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260414150302_AddElectricityPriceResolution.cs
+++ b/Migrations/20260414150302_AddElectricityPriceResolution.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddElectricityPriceResolution : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_StoredElectricityPrices_Area_DeliveryStart",
+                table: "StoredElectricityPrices");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Resolution",
+                table: "StoredElectricityPrices",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StoredElectricityPrices_Area_Resolution_DeliveryStart",
+                table: "StoredElectricityPrices",
+                columns: new[] { "Area", "Resolution", "DeliveryStart" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_StoredElectricityPrices_Area_Resolution_DeliveryStart",
+                table: "StoredElectricityPrices");
+
+            migrationBuilder.DropColumn(
+                name: "Resolution",
+                table: "StoredElectricityPrices");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StoredElectricityPrices_Area_DeliveryStart",
+                table: "StoredElectricityPrices",
+                columns: new[] { "Area", "DeliveryStart" },
+                unique: true);
+        }
+    }
+}

--- a/Models/ApplicationDbContext.cs
+++ b/Models/ApplicationDbContext.cs
@@ -1,6 +1,7 @@
 ﻿using garge_api.Models.Admin;
 using garge_api.Models.Auth;
 using garge_api.Models.Automation;
+using garge_api.Models.Electricity;
 using garge_api.Models.Group;
 using garge_api.Models.Mqtt;
 using garge_api.Models.Sensor;
@@ -34,6 +35,7 @@ namespace garge_api.Models
         public DbSet<UserSwitchCustomName> UserSwitchCustomNames { get; set; }
         public DbSet<UserSensor> UserSensors { get; set; }
         public DbSet<UserSwitch> UserSwitches { get; set; }
+        public DbSet<StoredElectricityPrice> StoredElectricityPrices { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -167,6 +169,10 @@ namespace garge_api.Models
                 .WithMany()
                 .HasForeignKey(x => x.SwitchId)
                 .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<StoredElectricityPrice>()
+                .HasIndex(p => new { p.Area, p.Resolution, p.DeliveryStart })
+                .IsUnique();
         }
         public void EnsureTriggers()
         {

--- a/Models/Automation/AutomationRule.cs
+++ b/Models/Automation/AutomationRule.cs
@@ -30,5 +30,11 @@ namespace garge_api.Models.Automation
         public bool IsEnabled { get; set; } = true;
 
         public DateTime? LastTriggeredAt { get; set; }
+
+        // Optional electricity price condition
+        public string? ElectricityPriceCondition { get; set; }
+        public double? ElectricityPriceThreshold { get; set; }
+        public string? ElectricityPriceArea { get; set; }
+        public string? ElectricityPriceOperator { get; set; }
     }
 }

--- a/Models/Electricity/StoredElectricityPrice.cs
+++ b/Models/Electricity/StoredElectricityPrice.cs
@@ -1,0 +1,16 @@
+namespace garge_api.Models.Electricity
+{
+    public class StoredElectricityPrice
+    {
+        public int Id { get; set; }
+        public required string Area { get; set; }
+        /// <summary>Resolution of the price entry: HOURLY, DAILY, or MONTHLY.</summary>
+        public required string Resolution { get; set; }
+        public DateTime DeliveryStart { get; set; }
+        public DateTime DeliveryEnd { get; set; }
+        /// <summary>Price in kr/kWh (NordPool value divided by 1000).</summary>
+        public double Value { get; set; }
+        public required string Currency { get; set; }
+        public DateTime FetchedAt { get; set; }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -80,6 +80,7 @@ namespace garge_api
                     options.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
                 });
             builder.Services.AddHttpClient<NordPoolService>();
+            builder.Services.AddHostedService<ElectricityPriceFetchService>();
             builder.Services.AddHttpClient<WebhookNotificationService>();
             builder.Services.AddHostedService<PostgresNotificationService>();
             builder.Services.AddSingleton<PostgresNotificationService>();

--- a/Services/ElectricityPriceFetchService.cs
+++ b/Services/ElectricityPriceFetchService.cs
@@ -1,0 +1,142 @@
+using garge_api.Models;
+using garge_api.Models.Electricity;
+using garge_api.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace garge_api.Services
+{
+    public class ElectricityPriceFetchService : BackgroundService
+    {
+        private static readonly string[] Areas = ["NO1", "NO2", "NO3", "NO4", "NO5"];
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ILogger<ElectricityPriceFetchService> _logger;
+
+        public ElectricityPriceFetchService(
+            IServiceScopeFactory scopeFactory,
+            IHttpClientFactory httpClientFactory,
+            ILogger<ElectricityPriceFetchService> logger)
+        {
+            _scopeFactory = scopeFactory;
+            _httpClientFactory = httpClientFactory;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            await FetchAllOnStartupAsync(stoppingToken);
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                var now = DateTime.UtcNow;
+                var next14 = new DateTime(now.Year, now.Month, now.Day, 14, 0, 0, DateTimeKind.Utc);
+                if (now >= next14)
+                    next14 = next14.AddDays(1);
+
+                _logger.LogInformation("ElectricityPriceFetchService: next fetch at {Next14} UTC", next14);
+
+                try { await Task.Delay(next14 - now, stoppingToken); }
+                catch (OperationCanceledException) { break; }
+
+                await FetchDailyRefreshAsync(stoppingToken);
+            }
+        }
+
+        private async Task FetchAllOnStartupAsync(CancellationToken stoppingToken)
+        {
+            var now = DateTime.UtcNow;
+            var prevYear = now.Year - 1;
+            var currYear = now.Year;
+
+            var tasks = new List<Task>
+            {
+                // HOURLY: today + tomorrow
+                FetchAndStoreAsync("HOURLY", now, stoppingToken),
+                FetchAndStoreAsync("HOURLY", now.AddDays(1), stoppingToken),
+                // DAILY: previous + current year
+                FetchAndStoreAsync("DAILY", new DateTime(prevYear, 12, 31, 0, 0, 0, DateTimeKind.Utc), stoppingToken),
+                FetchAndStoreAsync("DAILY", new DateTime(currYear, 12, 31, 0, 0, 0, DateTimeKind.Utc), stoppingToken),
+                // MONTHLY: previous + current year
+                FetchAndStoreAsync("MONTHLY", new DateTime(prevYear, 12, 31, 0, 0, 0, DateTimeKind.Utc), stoppingToken),
+                FetchAndStoreAsync("MONTHLY", new DateTime(currYear, 12, 31, 0, 0, 0, DateTimeKind.Utc), stoppingToken),
+            };
+
+            await Task.WhenAll(tasks);
+        }
+
+        private async Task FetchDailyRefreshAsync(CancellationToken stoppingToken)
+        {
+            var now = DateTime.UtcNow;
+            var currYear = now.Year;
+
+            // HOURLY: next day
+            await FetchAndStoreAsync("HOURLY", now.AddDays(1), stoppingToken);
+            // DAILY + MONTHLY: refresh current year
+            await FetchAndStoreAsync("DAILY", new DateTime(currYear, 12, 31, 0, 0, 0, DateTimeKind.Utc), stoppingToken);
+            await FetchAndStoreAsync("MONTHLY", new DateTime(currYear, 12, 31, 0, 0, 0, DateTimeKind.Utc), stoppingToken);
+        }
+
+        private async Task FetchAndStoreAsync(string resolution, DateTime date, CancellationToken stoppingToken)
+        {
+            _logger.LogInformation("ElectricityPriceFetchService: fetching {Resolution} prices for {Date:yyyy-MM-dd}", resolution, date);
+            try
+            {
+                var httpClient = _httpClientFactory.CreateClient();
+                var nordPoolService = new NordPoolService(httpClient,
+                    Microsoft.Extensions.Logging.Abstractions.NullLogger<NordPoolService>.Instance);
+
+                var priceResponse = await nordPoolService.FetchPricesAsync(resolution, date, Areas.ToList(), "NOK");
+                if (priceResponse == null)
+                {
+                    _logger.LogWarning("ElectricityPriceFetchService: no {Resolution} data returned for {Date:yyyy-MM-dd}", resolution, date);
+                    return;
+                }
+
+                using var scope = _scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                var fetchedAt = DateTime.UtcNow;
+
+                foreach (var (area, areaPrices) in priceResponse.Areas)
+                {
+                    if (!Areas.Contains(area)) continue;
+
+                    foreach (var entry in areaPrices.Values)
+                    {
+                        var deliveryStart = entry.Start.ToUniversalTime();
+                        var deliveryEnd = entry.End.ToUniversalTime();
+                        var valueKwh = (double)(entry.Value / 1000m);
+
+                        var existing = await db.StoredElectricityPrices
+                            .FirstOrDefaultAsync(p => p.Area == area && p.Resolution == resolution && p.DeliveryStart == deliveryStart, stoppingToken);
+
+                        if (existing != null)
+                        {
+                            existing.Value = valueKwh;
+                            existing.FetchedAt = fetchedAt;
+                        }
+                        else
+                        {
+                            db.StoredElectricityPrices.Add(new StoredElectricityPrice
+                            {
+                                Area = area,
+                                Resolution = resolution,
+                                DeliveryStart = deliveryStart,
+                                DeliveryEnd = deliveryEnd,
+                                Value = valueKwh,
+                                Currency = priceResponse.Currency,
+                                FetchedAt = fetchedAt,
+                            });
+                        }
+                    }
+                }
+
+                await db.SaveChangesAsync(stoppingToken);
+                _logger.LogInformation("ElectricityPriceFetchService: stored {Resolution} prices for {Date:yyyy-MM-dd}", resolution, date);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "ElectricityPriceFetchService: error fetching {Resolution} prices for {Date:yyyy-MM-dd}", resolution, date);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

### Electricity price conditions in automations
- Add optional electricity price condition to AutomationRule with fields: ElectricityPriceCondition (AND/OR), ElectricityPriceThreshold (kr/kWh), ElectricityPriceOperator (<, >, <=, >=, ==), ElectricityPriceArea (NO1-NO5)
- Update all automation DTOs and controller to map new fields

### Electricity price DB storage
- Add StoredElectricityPrice model (Area, Resolution, DeliveryStart/End, Value in kr/kWh)
- Add ElectricityPriceFetchService background service - fetches HOURLY/DAILY/MONTHLY on startup and refreshes daily at 14:00 UTC for all NO1-NO5 areas
- Update GET /api/electricity/prices to serve from DB first, falling back to NordPool (converting NOK/MWh to kr/kWh)
- Add GET /api/electricity/current-price endpoint for the current hour's stored price
- Add EF migrations: AddElectricityPriceConditionAndStoredPrices and AddElectricityPriceResolution

## Migration
Run dotnet ef database update to apply.
