### PR TITLE
feat(automations): timed auto-off support

### DIFF
--- a/Controllers/AutomationController.cs
+++ b/Controllers/AutomationController.cs
@@ -79,6 +79,7 @@ namespace garge_api.Controllers
                 ElectricityPriceThreshold = dto.ElectricityPriceThreshold,
                 ElectricityPriceArea = dto.ElectricityPriceArea,
                 ElectricityPriceOperator = dto.ElectricityPriceOperator,
+                TimerDurationHours = dto.TimerDurationHours,
             };
 
             if (!await UserHasAccessToAutomationAsync(rule))
@@ -105,6 +106,8 @@ namespace garge_api.Controllers
                 ElectricityPriceThreshold = rule.ElectricityPriceThreshold,
                 ElectricityPriceArea = rule.ElectricityPriceArea,
                 ElectricityPriceOperator = rule.ElectricityPriceOperator,
+                TimerDurationHours = rule.TimerDurationHours,
+                TimerActivatedAt = rule.TimerActivatedAt,
             };
 
             return Ok(result);
@@ -160,6 +163,8 @@ namespace garge_api.Controllers
                         ElectricityPriceThreshold = rule.ElectricityPriceThreshold,
                         ElectricityPriceArea = rule.ElectricityPriceArea,
                         ElectricityPriceOperator = rule.ElectricityPriceOperator,
+                        TimerDurationHours = rule.TimerDurationHours,
+                        TimerActivatedAt = rule.TimerActivatedAt,
                     });
                 }
             }
@@ -212,6 +217,7 @@ namespace garge_api.Controllers
             rule.ElectricityPriceThreshold = dto.ElectricityPriceThreshold;
             rule.ElectricityPriceArea = dto.ElectricityPriceArea;
             rule.ElectricityPriceOperator = dto.ElectricityPriceOperator;
+            rule.TimerDurationHours = dto.TimerDurationHours;
 
             await _context.SaveChangesAsync();
 
@@ -231,9 +237,47 @@ namespace garge_api.Controllers
                 ElectricityPriceThreshold = rule.ElectricityPriceThreshold,
                 ElectricityPriceArea = rule.ElectricityPriceArea,
                 ElectricityPriceOperator = rule.ElectricityPriceOperator,
+                TimerDurationHours = rule.TimerDurationHours,
+                TimerActivatedAt = rule.TimerActivatedAt,
             };
 
             return Ok(result);
+        }
+
+        /// <summary>
+        /// Starts the timer on a timed automation rule (called by the operator).
+        /// </summary>
+        [HttpPatch("{id}/timer-start")]
+        [SwaggerOperation(Summary = "Sets TimerActivatedAt to now for a timed rule.")]
+        [SwaggerResponse(204, "Timer started.")]
+        [SwaggerResponse(404, "Rule not found.")]
+        public async Task<IActionResult> TimerStart(int id)
+        {
+            var rule = await _context.AutomationRules.FindAsync(id);
+            if (rule == null)
+                return NotFound();
+
+            rule.TimerActivatedAt = DateTime.UtcNow;
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Clears the timer on a timed automation rule (called by the operator when timer expires).
+        /// </summary>
+        [HttpPatch("{id}/timer-clear")]
+        [SwaggerOperation(Summary = "Clears TimerActivatedAt, re-arming the rule.")]
+        [SwaggerResponse(204, "Timer cleared.")]
+        [SwaggerResponse(404, "Rule not found.")]
+        public async Task<IActionResult> TimerClear(int id)
+        {
+            var rule = await _context.AutomationRules.FindAsync(id);
+            if (rule == null)
+                return NotFound();
+
+            rule.TimerActivatedAt = null;
+            await _context.SaveChangesAsync();
+            return NoContent();
         }
 
         /// <summary>

--- a/Dtos/Automation/AutomationRuleDto.cs
+++ b/Dtos/Automation/AutomationRuleDto.cs
@@ -16,5 +16,7 @@
         public double? ElectricityPriceThreshold { get; set; }
         public string? ElectricityPriceArea { get; set; }
         public string? ElectricityPriceOperator { get; set; }
+        public double? TimerDurationHours { get; set; }
+        public DateTime? TimerActivatedAt { get; set; }
     }
 }

--- a/Dtos/Automation/CreateAutomationRuleDto.cs
+++ b/Dtos/Automation/CreateAutomationRuleDto.cs
@@ -31,5 +31,6 @@ namespace garge_api.Dtos.Automation
         public double? ElectricityPriceThreshold { get; set; }
         public string? ElectricityPriceArea { get; set; }
         public string? ElectricityPriceOperator { get; set; }
+        public double? TimerDurationHours { get; set; }
     }
 }

--- a/Dtos/Automation/UpdateAutomationRuleDto.cs
+++ b/Dtos/Automation/UpdateAutomationRuleDto.cs
@@ -25,5 +25,6 @@ namespace garge_api.Dtos.Automation
         public double? ElectricityPriceThreshold { get; set; }
         public string? ElectricityPriceArea { get; set; }
         public string? ElectricityPriceOperator { get; set; }
+        public double? TimerDurationHours { get; set; }
     }
 }

--- a/Migrations/20260414160611_AddAutomationTimerFields.Designer.cs
+++ b/Migrations/20260414160611_AddAutomationTimerFields.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260414160611_AddAutomationTimerFields")]
+    partial class AddAutomationTimerFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260414160611_AddAutomationTimerFields.cs
+++ b/Migrations/20260414160611_AddAutomationTimerFields.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAutomationTimerFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "TimerActivatedAt",
+                table: "AutomationRules",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "TimerDurationHours",
+                table: "AutomationRules",
+                type: "double precision",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TimerActivatedAt",
+                table: "AutomationRules");
+
+            migrationBuilder.DropColumn(
+                name: "TimerDurationHours",
+                table: "AutomationRules");
+        }
+    }
+}

--- a/Models/Automation/AutomationRule.cs
+++ b/Models/Automation/AutomationRule.cs
@@ -36,5 +36,9 @@ namespace garge_api.Models.Automation
         public double? ElectricityPriceThreshold { get; set; }
         public string? ElectricityPriceArea { get; set; }
         public string? ElectricityPriceOperator { get; set; }
+
+        // Optional timed action: keep socket ON for this many hours then auto-off
+        public double? TimerDurationHours { get; set; }
+        public DateTime? TimerActivatedAt { get; set; }
     }
 }

--- a/Services/ElectricityPriceFetchService.cs
+++ b/Services/ElectricityPriceFetchService.cs
@@ -96,9 +96,19 @@ namespace garge_api.Services
                 var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
                 var fetchedAt = DateTime.UtcNow;
 
+                // Collect all delivery starts from the response so we can bulk-fetch existing rows
+                // in a single query per area instead of one query per entry (N+1).
                 foreach (var (area, areaPrices) in priceResponse.Areas)
                 {
                     if (!Areas.Contains(area)) continue;
+
+                    var incomingStarts = areaPrices.Values
+                        .Select(e => e.Start.ToUniversalTime())
+                        .ToHashSet();
+
+                    var existing = await db.StoredElectricityPrices
+                        .Where(p => p.Area == area && p.Resolution == resolution && incomingStarts.Contains(p.DeliveryStart))
+                        .ToDictionaryAsync(p => p.DeliveryStart, stoppingToken);
 
                     foreach (var entry in areaPrices.Values)
                     {
@@ -106,13 +116,10 @@ namespace garge_api.Services
                         var deliveryEnd = entry.End.ToUniversalTime();
                         var valueKwh = (double)(entry.Value / 1000m);
 
-                        var existing = await db.StoredElectricityPrices
-                            .FirstOrDefaultAsync(p => p.Area == area && p.Resolution == resolution && p.DeliveryStart == deliveryStart, stoppingToken);
-
-                        if (existing != null)
+                        if (existing.TryGetValue(deliveryStart, out var row))
                         {
-                            existing.Value = valueKwh;
-                            existing.FetchedAt = fetchedAt;
+                            row.Value = valueKwh;
+                            row.FetchedAt = fetchedAt;
                         }
                         else
                         {


### PR DESCRIPTION
## Summary

Adds optional timed auto-off support to automation rules.

### New fields
- TimerDurationHours (double?) - how long to keep the socket ON after the trigger fires
- TimerActivatedAt (DateTime?) - stamped when the timer starts, cleared when it expires

### New endpoints
- PATCH /{id}/timer-start - sets TimerActivatedAt to now (called by operator on trigger)
- PATCH /{id}/timer-clear - nulls TimerActivatedAt, re-arming the rule (called by operator on expiry)

### Behaviour
1. Condition met + no active timer -> turn ON, start timer
2. Timer running + not elapsed -> skip rule (do not re-trigger)
3. Timer elapsed -> turn OFF, clear timer (rule re-arms)
4. Rules without TimerDurationHours behave exactly as before

### Migration
AddAutomationTimerFields adds TimerDurationHours and TimerActivatedAt as nullable columns to AutomationRules. Run dotnet ef database update to apply.
