### PR TITLE
fix: return 200 null instead of 404 when no data exists

### DIFF
--- a/Controllers/BatteryHealthController.cs
+++ b/Controllers/BatteryHealthController.cs
@@ -96,8 +96,8 @@ namespace garge_api.Controllers
         /// </summary>
         [HttpGet("name/{sensorName}/latest")]
         [SwaggerOperation(Summary = "Returns the latest battery health record for a voltage sensor by name.")]
-        [SwaggerResponse(200, "The latest battery health record.", typeof(BatteryHealthDto))]
-        [SwaggerResponse(404, "Voltage sensor or battery health data not found.")]
+        [SwaggerResponse(200, "The latest battery health record, or null if no data exists yet.", typeof(BatteryHealthDto))]
+        [SwaggerResponse(404, "Voltage sensor not found.")]
         [SwaggerResponse(403, "User does not have the required role.")]
         public async Task<IActionResult> GetLatestBatteryHealth(string sensorName)
         {
@@ -123,8 +123,8 @@ namespace garge_api.Controllers
 
             if (latest == null)
             {
-                _logger.LogWarning("GetLatestBatteryHealth no data for sensor: {SensorName}", Sanitize(sensorName));
-                return NotFound(new { message = "No battery health data found for this sensor." });
+                _logger.LogInformation("GetLatestBatteryHealth no data for sensor: {SensorName}", Sanitize(sensorName));
+                return Ok((BatteryHealthDto?)null);
             }
 
             return Ok(_mapper.Map<BatteryHealthDto>(latest));

--- a/Controllers/SwitchesController.cs
+++ b/Controllers/SwitchesController.cs
@@ -305,7 +305,7 @@ namespace garge_api.Controllers
         /// </summary>
         [HttpGet("{switchId}/state")]
         [SwaggerOperation(Summary = "Retrieves state for a specific switch.")]
-        [SwaggerResponse(200, "The state for the specified switch.", typeof(IEnumerable<SwitchDataDto>))]
+        [SwaggerResponse(200, "The state for the specified switch, or null if no data exists yet.", typeof(SwitchDataDto))]
         [SwaggerResponse(404, "Switch not found.")]
         [SwaggerResponse(403, "User does not have the required role.")]
         public async Task<IActionResult> GetSwitchState(int switchId)
@@ -332,8 +332,8 @@ namespace garge_api.Controllers
 
             if (query == null)
             {
-                _logger.LogWarning("GetSwitchState no data found for {@LogData}", new { switchId });
-                return NotFound(new { message = "No data found for this switch!" });
+                _logger.LogInformation("GetSwitchState no data found for {@LogData}", new { switchId });
+                return Ok((SwitchDataDto?)null);
             }
 
             var dto = _mapper.Map<SwitchDataDto>(query);


### PR DESCRIPTION
## Problem
`GET /switches/{id}/state` and `GET /battery-health/name/{name}/latest` returned HTTP 404 when the device existed but had no data yet. This caused noisy 404 errors in the browser for all inactive devices on the dashboard.

## Fix
Both endpoints now return `200 OK` with a `null` body when the device exists but has no data. A 404 is only returned when the device itself is not found.

### Endpoints changed
- `GET /api/switches/{switchId}/state` - SwitchesController
- `GET /api/battery-health/name/{sensorName}/latest` - BatteryHealthController
