### PR TITLE
fix(switches): exclude SHRGBC light bulbs from GET /api/switches

### DIFF
--- a/Controllers/SwitchesController.cs
+++ b/Controllers/SwitchesController.cs
@@ -70,7 +70,9 @@ namespace garge_api.Controllers
         {
             _logger.LogInformation("GetAllSwitches called by {@LogData}", new { User = User.Identity?.Name });
 
-            var allSwitches = await _context.Switches.ToListAsync();
+            var allSwitches = await _context.Switches
+                .Where(sw => sw.Type.Equals("SOCKET", StringComparison.OrdinalIgnoreCase))
+                .ToListAsync();
             var accessibleSwitches = new List<Switch>();
 
             foreach (var sw in allSwitches)


### PR DESCRIPTION
SHRGBC devices are RGB light bulbs, not switches. Filter them out of the switches endpoint so they never appear in the automation dropdown, devices list, or any other switch context.