### PR TITLE
fix: replace string.Equals with ToUpper comparison in SwitchesController

### DIFF
--- a/Controllers/SwitchesController.cs
+++ b/Controllers/SwitchesController.cs
@@ -71,7 +71,7 @@ namespace garge_api.Controllers
             _logger.LogInformation("GetAllSwitches called by {@LogData}", new { User = User.Identity?.Name });
 
             var allSwitches = await _context.Switches
-                .Where(sw => sw.Type.Equals("SOCKET", StringComparison.OrdinalIgnoreCase))
+                .Where(sw => sw.Type.ToUpper() == "SOCKET")
                 .ToListAsync();
             var accessibleSwitches = new List<Switch>();
 


### PR DESCRIPTION
## Problem
GetAllSwitches was crashing with a 500 error because EF Core cannot translate string.Equals with StringComparison to SQL.

## Fix
Replaced .Equals with .ToUpper() == "SOCKET" which EF Core can translate to valid SQL.