### PR TITLE
feat(sensor): photo upload endpoint and SensorPhoto model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.0.4](https://github.com/sondresjolyst/garge-api/compare/v2.0.3...v2.0.4) (2026-04-23)
+
+
+### Bug Fixes
+
+* **electricity:** surface NordPool warnings and refresh today+tomorrow on daily run ([8fd04f1](https://github.com/sondresjolyst/garge-api/commit/8fd04f1ac351f89972267e93017a86c378bd1435))
+* **electricity:** surface NordPool warnings and refresh today+tomorrow on daily run ([#114](https://github.com/sondresjolyst/garge-api/issues/114)) ([2420724](https://github.com/sondresjolyst/garge-api/commit/24207249c7ae7aa0813043673e5f3685eb9da805))
+
 ## [2.0.3](https://github.com/sondresjolyst/garge-api/compare/v2.0.2...v2.0.3) (2026-04-21)
 
 

--- a/Controllers/SensorController.cs
+++ b/Controllers/SensorController.cs
@@ -1066,5 +1066,79 @@ namespace garge_api.Controllers
             var dto = _mapper.Map<SensorDataDto>(latestData);
             return Ok(dto);
         }
+
+        [HttpPost("{sensorId}/photo")]
+        [SwaggerOperation(Summary = "Upload or replace a photo for a sensor.")]
+        [SwaggerResponse(200, "Photo saved.")]
+        [SwaggerResponse(400, "Invalid request.")]
+        [SwaggerResponse(403, "No access to sensor.")]
+        public async Task<IActionResult> UploadSensorPhoto(int sensorId, [FromBody] UploadSensorPhotoDto dto)
+        {
+            if (!await UserCanAccessSensorAsync(sensorId))
+                return Forbid();
+
+            if (string.IsNullOrWhiteSpace(dto.Data) || string.IsNullOrWhiteSpace(dto.ContentType))
+                return BadRequest(new { message = "Data and ContentType are required." });
+
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+
+            var existing = await _context.SensorPhotos.FirstOrDefaultAsync(sp => sp.SensorId == sensorId);
+            if (existing != null)
+            {
+                existing.Data = dto.Data;
+                existing.ContentType = dto.ContentType;
+                existing.UserId = userId;
+                existing.CreatedAt = DateTime.UtcNow;
+            }
+            else
+            {
+                _context.SensorPhotos.Add(new Models.Sensor.SensorPhoto
+                {
+                    SensorId = sensorId,
+                    UserId = userId,
+                    Data = dto.Data,
+                    ContentType = dto.ContentType
+                });
+            }
+
+            await _context.SaveChangesAsync();
+            return Ok(new { message = "Photo saved." });
+        }
+
+        [HttpGet("{sensorId}/photo")]
+        [SwaggerOperation(Summary = "Get the photo for a sensor.")]
+        [SwaggerResponse(200, "Photo data.")]
+        [SwaggerResponse(403, "No access to sensor.")]
+        [SwaggerResponse(404, "No photo found.")]
+        public async Task<IActionResult> GetSensorPhoto(int sensorId)
+        {
+            if (!await UserCanAccessSensorAsync(sensorId))
+                return Forbid();
+
+            var photo = await _context.SensorPhotos.FirstOrDefaultAsync(sp => sp.SensorId == sensorId);
+            if (photo == null)
+                return NotFound(new { message = "No photo found." });
+
+            return Ok(new { data = photo.Data, contentType = photo.ContentType });
+        }
+
+        [HttpDelete("{sensorId}/photo")]
+        [SwaggerOperation(Summary = "Delete the photo for a sensor.")]
+        [SwaggerResponse(200, "Photo deleted.")]
+        [SwaggerResponse(403, "No access to sensor.")]
+        [SwaggerResponse(404, "No photo found.")]
+        public async Task<IActionResult> DeleteSensorPhoto(int sensorId)
+        {
+            if (!await UserCanAccessSensorAsync(sensorId))
+                return Forbid();
+
+            var photo = await _context.SensorPhotos.FirstOrDefaultAsync(sp => sp.SensorId == sensorId);
+            if (photo == null)
+                return NotFound(new { message = "No photo found." });
+
+            _context.SensorPhotos.Remove(photo);
+            await _context.SaveChangesAsync();
+            return Ok(new { message = "Photo deleted." });
+        }
     }
 }

--- a/Dtos/Sensor/UploadSensorPhotoDto.cs
+++ b/Dtos/Sensor/UploadSensorPhotoDto.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace garge_api.Dtos.Sensor
+{
+    public class UploadSensorPhotoDto
+    {
+        [Required]
+        public required string Data { get; set; }
+
+        [Required]
+        [MaxLength(50)]
+        public required string ContentType { get; set; }
+    }
+}

--- a/Migrations/20260427164549_AddSensorPhoto.Designer.cs
+++ b/Migrations/20260427164549_AddSensorPhoto.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260427164549_AddSensorPhoto")]
+    partial class AddSensorPhoto
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260427164549_AddSensorPhoto.cs
+++ b/Migrations/20260427164549_AddSensorPhoto.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSensorPhoto : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "SensorPhotos",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    SensorId = table.Column<int>(type: "integer", nullable: false),
+                    UserId = table.Column<string>(type: "text", nullable: false),
+                    Data = table.Column<string>(type: "text", nullable: false),
+                    ContentType = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SensorPhotos", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SensorPhotos_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_SensorPhotos_Sensors_SensorId",
+                        column: x => x.SensorId,
+                        principalTable: "Sensors",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SensorPhotos_SensorId",
+                table: "SensorPhotos",
+                column: "SensorId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SensorPhotos_UserId",
+                table: "SensorPhotos",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SensorPhotos");
+        }
+    }
+}

--- a/Models/ApplicationDbContext.cs
+++ b/Models/ApplicationDbContext.cs
@@ -36,6 +36,7 @@ namespace garge_api.Models
         public DbSet<UserSensor> UserSensors { get; set; }
         public DbSet<UserSwitch> UserSwitches { get; set; }
         public DbSet<StoredElectricityPrice> StoredElectricityPrices { get; set; }
+        public DbSet<SensorPhoto> SensorPhotos { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -172,6 +173,22 @@ namespace garge_api.Models
 
             modelBuilder.Entity<StoredElectricityPrice>()
                 .HasIndex(p => new { p.Area, p.Resolution, p.DeliveryStart })
+                .IsUnique();
+
+            modelBuilder.Entity<SensorPhoto>()
+                .HasOne(sp => sp.Sensor)
+                .WithMany()
+                .HasForeignKey(sp => sp.SensorId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<SensorPhoto>()
+                .HasOne(sp => sp.User)
+                .WithMany()
+                .HasForeignKey(sp => sp.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<SensorPhoto>()
+                .HasIndex(sp => sp.SensorId)
                 .IsUnique();
         }
         public void EnsureTriggers()

--- a/Models/Sensor/SensorPhoto.cs
+++ b/Models/Sensor/SensorPhoto.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using garge_api.Models.Admin;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace garge_api.Models.Sensor
+{
+    public class SensorPhoto
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        [SwaggerSchema(ReadOnly = true)]
+        public int Id { get; set; }
+
+        [Required]
+        public int SensorId { get; set; }
+
+        [Required]
+        public required string UserId { get; set; }
+
+        [Required]
+        public required string Data { get; set; }
+
+        [Required]
+        [MaxLength(50)]
+        public required string ContentType { get; set; }
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+        [ForeignKey(nameof(SensorId))]
+        public Sensor? Sensor { get; set; }
+
+        [ForeignKey(nameof(UserId))]
+        public User? User { get; set; }
+    }
+}

--- a/Services/ElectricityPriceFetchService.cs
+++ b/Services/ElectricityPriceFetchService.cs
@@ -11,15 +11,18 @@ namespace garge_api.Services
         private readonly IServiceScopeFactory _scopeFactory;
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILogger<ElectricityPriceFetchService> _logger;
+        private readonly ILoggerFactory _loggerFactory;
 
         public ElectricityPriceFetchService(
             IServiceScopeFactory scopeFactory,
             IHttpClientFactory httpClientFactory,
-            ILogger<ElectricityPriceFetchService> logger)
+            ILogger<ElectricityPriceFetchService> logger,
+            ILoggerFactory loggerFactory)
         {
             _scopeFactory = scopeFactory;
             _httpClientFactory = httpClientFactory;
             _logger = logger;
+            _loggerFactory = loggerFactory;
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -69,7 +72,8 @@ namespace garge_api.Services
             var now = DateTime.UtcNow;
             var currYear = now.Year;
 
-            // HOURLY: next day
+            // HOURLY: today (refreshes any slots published after startup) + next day
+            await FetchAndStoreAsync("HOURLY", now, stoppingToken);
             await FetchAndStoreAsync("HOURLY", now.AddDays(1), stoppingToken);
             // DAILY + MONTHLY: refresh current year
             await FetchAndStoreAsync("DAILY", new DateTime(currYear, 12, 31, 0, 0, 0, DateTimeKind.Utc), stoppingToken);
@@ -82,8 +86,8 @@ namespace garge_api.Services
             try
             {
                 var httpClient = _httpClientFactory.CreateClient();
-                var nordPoolService = new NordPoolService(httpClient,
-                    Microsoft.Extensions.Logging.Abstractions.NullLogger<NordPoolService>.Instance);
+                // Use real logger so NordPool parse warnings (e.g. missing JSON keys) are visible.
+                var nordPoolService = new NordPoolService(httpClient, _loggerFactory.CreateLogger<NordPoolService>());
 
                 var priceResponse = await nordPoolService.FetchPricesAsync(resolution, date, Areas.ToList(), "NOK");
                 if (priceResponse == null)
@@ -92,15 +96,28 @@ namespace garge_api.Services
                     return;
                 }
 
+                if (priceResponse.Areas.Count == 0)
+                {
+                    _logger.LogWarning("ElectricityPriceFetchService: NordPool returned empty areas for {Resolution} on {Date:yyyy-MM-dd} — no entries stored.", resolution, date);
+                    return;
+                }
+
                 using var scope = _scopeFactory.CreateScope();
                 var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
                 var fetchedAt = DateTime.UtcNow;
+                var totalStored = 0;
 
                 // Collect all delivery starts from the response so we can bulk-fetch existing rows
                 // in a single query per area instead of one query per entry (N+1).
                 foreach (var (area, areaPrices) in priceResponse.Areas)
                 {
                     if (!Areas.Contains(area)) continue;
+
+                    if (areaPrices.Values.Count == 0)
+                    {
+                        _logger.LogWarning("ElectricityPriceFetchService: 0 entries for area {Area} {Resolution} on {Date:yyyy-MM-dd}.", area, resolution, date);
+                        continue;
+                    }
 
                     var incomingStarts = areaPrices.Values
                         .Select(e => e.Start)
@@ -134,11 +151,12 @@ namespace garge_api.Services
                                 FetchedAt = fetchedAt,
                             });
                         }
+                        totalStored++;
                     }
                 }
 
                 await db.SaveChangesAsync(stoppingToken);
-                _logger.LogInformation("ElectricityPriceFetchService: stored {Resolution} prices for {Date:yyyy-MM-dd}", resolution, date);
+                _logger.LogInformation("ElectricityPriceFetchService: stored {Count} {Resolution} entries for {Date:yyyy-MM-dd}", totalStored, resolution, date);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- New SensorPhoto model: SensorId, UserId, Data (base64 text), ContentType, CreatedAt
- Unique index on SensorId — one photo per sensor
- Cascade delete on both Sensor and User for GDPR compliance
- Three endpoints: POST /api/sensors/{id}/photo, GET /api/sensors/{id}/photo, DELETE /api/sensors/{id}/photo
- EF Core migration included (AddSensorPhoto)

## Test plan
- [ ] POST — upload a photo, verify it is stored
- [ ] GET — retrieve the photo for a sensor
- [ ] DELETE — remove the photo
- [ ] POST again on the same sensor — should replace, not duplicate
- [ ] Delete user — verify SensorPhoto rows are cascade-deleted