### PR TITLE
chore: add migration for merged admin page and sensor photo models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.0.4](https://github.com/sondresjolyst/garge-api/compare/v2.0.3...v2.0.4) (2026-04-23)
+
+
+### Bug Fixes
+
+* **electricity:** surface NordPool warnings and refresh today+tomorrow on daily run ([8fd04f1](https://github.com/sondresjolyst/garge-api/commit/8fd04f1ac351f89972267e93017a86c378bd1435))
+* **electricity:** surface NordPool warnings and refresh today+tomorrow on daily run ([#114](https://github.com/sondresjolyst/garge-api/issues/114)) ([2420724](https://github.com/sondresjolyst/garge-api/commit/24207249c7ae7aa0813043673e5f3685eb9da805))
+
 ## [2.0.3](https://github.com/sondresjolyst/garge-api/compare/v2.0.2...v2.0.3) (2026-04-21)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [2.1.0](https://github.com/sondresjolyst/garge-api/compare/v2.0.4...v2.1.0) (2026-04-27)
+
+
+### Features
+
+* activities ([#126](https://github.com/sondresjolyst/garge-api/issues/126)) ([22b5675](https://github.com/sondresjolyst/garge-api/commit/22b5675c7ad3a540ab54eca7b53f35f6f5db7eea))
+* admin page, sensor activities, and CreatedAt tracking ([#124](https://github.com/sondresjolyst/garge-api/issues/124)) ([0902b8e](https://github.com/sondresjolyst/garge-api/commit/0902b8efa8eae55f30d845a9c88155b93d251fd6))
+* **sensor:** photo upload endpoint and SensorPhoto model ([#125](https://github.com/sondresjolyst/garge-api/issues/125)) ([7c2ce1d](https://github.com/sondresjolyst/garge-api/commit/7c2ce1d7fa73ef3f084dbe31b4be36f18d800a82))
+
 ## [2.0.4](https://github.com/sondresjolyst/garge-api/compare/v2.0.3...v2.0.4) (2026-04-23)
 
 

--- a/Migrations/20260427195427_MergeAdminAndSensorPhoto.Designer.cs
+++ b/Migrations/20260427195427_MergeAdminAndSensorPhoto.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260427195427_MergeAdminAndSensorPhoto")]
+    partial class MergeAdminAndSensorPhoto
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260427195427_MergeAdminAndSensorPhoto.cs
+++ b/Migrations/20260427195427_MergeAdminAndSensorPhoto.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class MergeAdminAndSensorPhoto : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "OdometerKm",
+                table: "SensorActivities");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "OdometerKm",
+                table: "SensorActivities",
+                type: "integer",
+                nullable: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the EF Core migration `MergeAdminAndSensorPhoto` that covers the combined model changes from `feat/admin-page` and `feat/sensor-photo`
- Required after both feature branches were merged — the individual migrations existed on each branch but the merged snapshot had pending changes

## Test plan
- [ ] `dotnet ef database update` completes without errors
- [ ] No further pending model changes after applying