### PR TITLE
chore: remove dead code and stale csproj entries

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -35,16 +35,6 @@ namespace garge_api
             var jwtKey = builder.Configuration.GetSection("Jwt:Key").Get<string>() ?? string.Empty;
             builder.Configuration.AddEnvironmentVariables();
 
-            //builder.Logging.ClearProviders();
-            //builder.Logging.AddConfiguration(builder.Configuration.GetSection("Logging"));
-            //builder.Logging.AddSimpleConsole(options =>
-            //{
-            //    options.TimestampFormat = "yyyy-MM-dd HH:mm:ss ";
-            //    options.IncludeScopes = false; // disables the extra scope/tracing info
-            //    options.SingleLine = true;
-            //});
-            //builder.Logging.AddFilter(DbLoggerCategory.Database.Command.Name, LogLevel.None);
-
             builder.Services.AddResponseCompression(options =>
             {
                 options.EnableForHttps = true;

--- a/garge-api.csproj
+++ b/garge-api.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
     <PackageReference Include="brevo_csharp" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.26" />
-    <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.3.9" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.26" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.26" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.15" />
@@ -25,7 +24,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.15">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -40,16 +39,5 @@
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.4.0" />
   </ItemGroup>
 
-  <ItemGroup>
-	<Folder Include="Migrations\" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <EditorConfigFiles Remove="E:\Sondre C Disk bilde osv\Documents\go\src\github.com\sondresjolyst\garge-api\.editorconfig" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="E:\Sondre C Disk bilde osv\Documents\go\src\github.com\sondresjolyst\garge-api\.editorconfig" />
-  </ItemGroup>                      
 
 </Project>


### PR DESCRIPTION
## Summary
- Delete commented-out logging block in `Program.cs` (Serilog already handles this)
- Remove legacy `Microsoft.AspNetCore.Cors` 2.3.9 (CORS is built into .NET 8 framework)
- Align `EntityFrameworkCore.Tools` to `9.0.15` (was `9.0.2`, mismatched with main EFCore package)
- Remove stale hardcoded Windows `editorconfig` paths from `.csproj`
- Remove empty `Migrations` folder `ItemGroup`

## Test plan
- [x] Build succeeds
- [x] EF migrations still work (`dotnet ef migrations add Test`)
- [x] CORS still functions in dev