### PR TITLE
chore: add xUnit test project and CI test step

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,12 +12,33 @@ on:
   push:
     branches:
       - development
+  pull_request:
 
 permissions:
   contents: read
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          dotnet-version: '10.x'
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore
+
+      - name: Test
+        run: dotnet test --no-build --verbosity normal
+
   dev:
+    needs: test
     if: github.ref == 'refs/heads/development'
     uses: equinor/ops-actions/.github/workflows/docker.yml@39749d0c32762076499120f881e963687374420c # v9.37.1
     secrets:
@@ -30,6 +51,7 @@ jobs:
       tag: dev
 
   prod:
+    needs: test
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     uses: equinor/ops-actions/.github/workflows/docker.yml@39749d0c32762076499120f881e963687374420c # v9.37.1
     secrets:

--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -28,7 +28,7 @@ namespace garge_api.Controllers
         private readonly SignInManager<User> _signInManager;
         private readonly IConfiguration _configuration;
         private readonly ApplicationDbContext _context;
-        private readonly EmailService _emailService;
+        private readonly IEmailService _emailService;
         private readonly IMapper _mapper;
         private readonly ILogger<AuthController> _logger;
 
@@ -37,7 +37,7 @@ namespace garge_api.Controllers
             SignInManager<User> signInManager,
             IConfiguration configuration,
             ApplicationDbContext context,
-            EmailService emailService,
+            IEmailService emailService,
             IMapper mapper,
             ILogger<AuthController> logger)
         {

--- a/Program.cs
+++ b/Program.cs
@@ -70,7 +70,7 @@ namespace garge_api
             builder.Services.AddHostedService<PostgresNotificationService>();
             builder.Services.AddSingleton<PostgresNotificationService>();
             builder.Services.AddHostedService<garge_api.Services.RefreshTokenCleanupService>();
-            builder.Services.AddScoped<EmailService>();
+            builder.Services.AddScoped<IEmailService, EmailService>();
             builder.Services.AddEndpointsApiExplorer();
 
             builder.Services.AddAuthentication(options =>

--- a/Services/EmailService.cs
+++ b/Services/EmailService.cs
@@ -3,7 +3,7 @@ using brevo_csharp.Api;
 using brevo_csharp.Client;
 using brevo_csharp.Model;
 
-public class EmailService
+public class EmailService : IEmailService
 {
     private readonly IConfiguration _configuration;
     private readonly ILogger<EmailService> _logger;

--- a/Services/IEmailService.cs
+++ b/Services/IEmailService.cs
@@ -1,0 +1,4 @@
+public interface IEmailService
+{
+    Task SendEmailAsync(string email, string subject, string message);
+}

--- a/garge-api.Tests/AuthControllerTests.cs
+++ b/garge-api.Tests/AuthControllerTests.cs
@@ -1,0 +1,187 @@
+using garge_api.Dtos.Auth;
+using garge_api.Models.Auth;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using SignInResult = Microsoft.AspNetCore.Identity.SignInResult;
+using Moq;
+using System.Security.Cryptography;
+using System.Text;
+using Xunit;
+
+namespace garge_api.Tests;
+
+public class AuthControllerTests : ControllerTestBase
+{
+    [Fact]
+    public async Task Login_MissingEmail_ReturnsBadRequest()
+    {
+        var result = await CreateAuthController().Login(new LoginModel { Email = "", Password = "pass" });
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Login_MissingPassword_ReturnsBadRequest()
+    {
+        var result = await CreateAuthController().Login(new LoginModel { Email = "test@test.com", Password = "" });
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Login_UserNotFound_ReturnsUnauthorized()
+    {
+        MockUserManager.Setup(m => m.FindByEmailAsync(It.IsAny<string>())).ReturnsAsync((User?)null);
+
+        var result = await CreateAuthController().Login(new LoginModel { Email = "x@x.com", Password = "pass" });
+
+        Assert.IsType<UnauthorizedObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Login_InvalidPassword_ReturnsUnauthorized()
+    {
+        var user = MakeUser();
+        MockUserManager.Setup(m => m.FindByEmailAsync(user.Email!)).ReturnsAsync(user);
+        MockSignInManager
+            .Setup(m => m.PasswordSignInAsync(user.UserName!, It.IsAny<string>(), false, true))
+            .ReturnsAsync(SignInResult.Failed);
+
+        var result = await CreateAuthController().Login(new LoginModel { Email = user.Email!, Password = "wrong" });
+
+        Assert.IsType<UnauthorizedObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Login_ValidCredentials_ReturnsOkWithTokenAndRefreshToken()
+    {
+        var user = MakeUser();
+        var db = CreateDbContext();
+        MockUserManager.Setup(m => m.FindByEmailAsync(user.Email!)).ReturnsAsync(user);
+        MockSignInManager
+            .Setup(m => m.PasswordSignInAsync(user.UserName!, It.IsAny<string>(), false, true))
+            .ReturnsAsync(SignInResult.Success);
+        MockUserManager.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "Default" });
+
+        var result = await CreateAuthController(db).Login(new LoginModel { Email = user.Email!, Password = "pass" });
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var token = ok.Value!.GetType().GetProperty("token")?.GetValue(ok.Value) as string;
+        var refreshToken = ok.Value!.GetType().GetProperty("refreshToken")?.GetValue(ok.Value) as string;
+        Assert.NotNull(token);
+        Assert.NotNull(refreshToken);
+        Assert.Single(db.RefreshTokens);
+    }
+
+    [Fact]
+    public async Task Login_AtRefreshTokenLimit_RemovesOldestBeforeAdding()
+    {
+        var user = MakeUser();
+        var db = CreateDbContext();
+
+        for (int i = 0; i < 5; i++)
+        {
+            db.RefreshTokens.Add(new RefreshToken
+            {
+                Token = $"token-{i}",
+                UserId = user.Id,
+                Expires = DateTime.UtcNow.AddMonths(1),
+                Created = DateTime.UtcNow.AddMinutes(-i)
+            });
+        }
+        await db.SaveChangesAsync();
+
+        MockUserManager.Setup(m => m.FindByEmailAsync(user.Email!)).ReturnsAsync(user);
+        MockSignInManager
+            .Setup(m => m.PasswordSignInAsync(user.UserName!, It.IsAny<string>(), false, true))
+            .ReturnsAsync(SignInResult.Success);
+        MockUserManager.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string>());
+
+        await CreateAuthController(db).Login(new LoginModel { Email = user.Email!, Password = "pass" });
+
+        Assert.Equal(5, db.RefreshTokens.Count());
+    }
+
+    [Fact]
+    public async Task RefreshToken_InvalidJwt_ReturnsBadRequest()
+    {
+        var result = await CreateAuthController().RefreshToken(
+            new RefreshTokenRequestDto { Token = "not-a-jwt", RefreshToken = "anything" });
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task RefreshToken_ExpiredRefreshToken_ReturnsUnauthorized()
+    {
+        var user = MakeUser();
+        var db = CreateDbContext();
+        var jwt = GenerateTestJwt(user.Id, expired: true);
+        MockUserManager.Setup(m => m.FindByIdAsync(user.Id)).ReturnsAsync(user);
+
+        var result = await CreateAuthController(db).RefreshToken(
+            new RefreshTokenRequestDto { Token = jwt, RefreshToken = "no-such-token" });
+
+        Assert.IsType<UnauthorizedObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task RefreshToken_ValidToken_ReturnsOkWithNewTokens()
+    {
+        var user = MakeUser();
+        var db = CreateDbContext();
+        var jwt = GenerateTestJwt(user.Id, expired: true);
+
+        var rawRefreshToken = "raw-refresh-token";
+        var hash = Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(rawRefreshToken)));
+        db.RefreshTokens.Add(new RefreshToken
+        {
+            Token = hash,
+            UserId = user.Id,
+            Expires = DateTime.UtcNow.AddMonths(1),
+            Created = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+
+        MockUserManager.Setup(m => m.FindByIdAsync(user.Id)).ReturnsAsync(user);
+        MockUserManager.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string>());
+
+        var result = await CreateAuthController(db).RefreshToken(
+            new RefreshTokenRequestDto { Token = jwt, RefreshToken = rawRefreshToken });
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var newToken = ok.Value!.GetType().GetProperty("token")?.GetValue(ok.Value) as string;
+        Assert.NotNull(newToken);
+        Assert.Equal(1, db.RefreshTokens.Count(t => t.Revoked == null));
+    }
+
+    [Fact]
+    public async Task Register_MissingEmail_ReturnsBadRequest()
+    {
+        var result = await CreateAuthController().Register(new RegisterUserDto
+        {
+            Email = "",
+            UserName = "user",
+            Password = "pass",
+            FirstName = "First",
+            LastName = "Last"
+        });
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Register_EmailAlreadyExists_ReturnsConflict()
+    {
+        MockUserManager.Setup(m => m.FindByEmailAsync("exists@test.com")).ReturnsAsync(MakeUser());
+
+        var result = await CreateAuthController().Register(new RegisterUserDto
+        {
+            Email = "exists@test.com",
+            UserName = "user",
+            Password = "pass",
+            FirstName = "First",
+            LastName = "Last"
+        });
+
+        Assert.IsType<ConflictObjectResult>(result);
+    }
+}

--- a/garge-api.Tests/AutomationControllerTests.cs
+++ b/garge-api.Tests/AutomationControllerTests.cs
@@ -1,0 +1,123 @@
+using garge_api.Dtos.Automation;
+using garge_api.Models.Automation;
+using garge_api.Models.Mqtt;
+using garge_api.Models.Sensor;
+using garge_api.Models.Switch;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace garge_api.Tests;
+
+public class AutomationControllerTests : ControllerTestBase
+{
+    private static AutomationRule MakeRule(int targetId = 10, int sensorId = 5) => new()
+    {
+        TargetType = "switch",
+        TargetId = targetId,
+        SensorType = "sensor",
+        SensorId = sensorId,
+        Condition = ">",
+        Threshold = 20,
+        Action = "on"
+    };
+
+    [Fact]
+    public async Task GetRules_AdminUser_ReturnsAllRules()
+    {
+        var db = CreateDbContext();
+        db.AutomationRules.AddRange(MakeRule(), MakeRule(targetId: 20, sensorId: 6));
+        await db.SaveChangesAsync();
+
+        var result = await CreateAutomationController(db, isAdmin: true).GetRules();
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var rules = Assert.IsAssignableFrom<IEnumerable<AutomationRuleDto>>(ok.Value);
+        Assert.Equal(2, rules.Count());
+    }
+
+    [Fact]
+    public async Task GetRules_RegularUser_ReturnsOnlyAccessibleRules()
+    {
+        var db = CreateDbContext();
+
+        db.Switches.Add(new Switch { Id = 10, Name = "switch-a", Type = "socket", Role = "switch" });
+        db.Sensors.Add(new Sensor
+        {
+            Id = 5, Name = "sensor-1", Type = "temperature", Role = "sensor",
+            RegistrationCode = "reg-1", DefaultName = "Sensor 1", ParentName = "hub-1"
+        });
+        db.UserSensors.Add(new UserSensor { UserId = "user-1", SensorId = 5 });
+        db.DiscoveredDevices.Add(new DiscoveredDevice
+        {
+            DiscoveredBy = "hub-1", Target = "switch-a", Type = "socket", Timestamp = DateTime.UtcNow
+        });
+        db.AutomationRules.AddRange(
+            MakeRule(targetId: 10, sensorId: 5),   // accessible
+            MakeRule(targetId: 99, sensorId: 99)    // not accessible
+        );
+        await db.SaveChangesAsync();
+
+        var result = await CreateAutomationController(db, userId: "user-1", isAdmin: false).GetRules();
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var rules = Assert.IsAssignableFrom<IEnumerable<AutomationRuleDto>>(ok.Value);
+        Assert.Single(rules);
+    }
+
+    [Fact]
+    public async Task GetRules_UserWithNoAccess_ReturnsEmpty()
+    {
+        var db = CreateDbContext();
+        db.AutomationRules.Add(MakeRule());
+        await db.SaveChangesAsync();
+
+        var result = await CreateAutomationController(db, userId: "user-1", isAdmin: false).GetRules();
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var rules = Assert.IsAssignableFrom<IEnumerable<AutomationRuleDto>>(ok.Value);
+        Assert.Empty(rules);
+    }
+
+    [Fact]
+    public async Task CreateRule_AdminUser_ReturnsCreatedRule()
+    {
+        var db = CreateDbContext();
+        var dto = new CreateAutomationRuleDto
+        {
+            TargetType = "switch", TargetId = 10, SensorType = "sensor", SensorId = 5,
+            Condition = ">", Threshold = 25, Action = "on", IsEnabled = true
+        };
+
+        var result = await CreateAutomationController(db, isAdmin: true).CreateRule(dto);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var rule = Assert.IsType<AutomationRuleDto>(ok.Value);
+        Assert.Equal("on", rule.Action);
+        Assert.Equal(25, rule.Threshold);
+        Assert.Single(db.AutomationRules);
+    }
+
+    [Fact]
+    public async Task MarkTriggered_RuleNotFound_ReturnsNotFound()
+    {
+        var db = CreateDbContext();
+
+        var result = await CreateAutomationController(db, isAdmin: true).MarkTriggered(999);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task MarkTriggered_AdminUser_SetsLastTriggeredAtAndReturnsNoContent()
+    {
+        var db = CreateDbContext();
+        var rule = MakeRule();
+        db.AutomationRules.Add(rule);
+        await db.SaveChangesAsync();
+
+        var result = await CreateAutomationController(db, isAdmin: true).MarkTriggered(rule.Id);
+
+        Assert.IsType<NoContentResult>(result);
+        Assert.NotNull(db.AutomationRules.Find(rule.Id)!.LastTriggeredAt);
+    }
+}

--- a/garge-api.Tests/ControllerTestBase.cs
+++ b/garge-api.Tests/ControllerTestBase.cs
@@ -1,0 +1,125 @@
+using AutoMapper;
+using garge_api.Controllers;
+using garge_api.Models;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using Moq;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+
+namespace garge_api.Tests;
+
+public abstract class ControllerTestBase
+{
+    protected const string TestJwtKey = "test-secret-key-that-is-long-enough-for-hmacsha256-algorithm!";
+    protected const string TestJwtIssuer = "test-issuer";
+
+    protected Mock<UserManager<User>> MockUserManager { get; }
+    protected Mock<SignInManager<User>> MockSignInManager { get; }
+    protected Mock<IEmailService> MockEmailService { get; } = new();
+    protected Mock<IMapper> MockMapper { get; } = new();
+    protected IConfiguration Configuration { get; }
+
+    protected ControllerTestBase()
+    {
+        MockUserManager = CreateUserManagerMock();
+        MockSignInManager = CreateSignInManagerMock(MockUserManager);
+        Configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Jwt:Key"] = TestJwtKey,
+                ["Jwt:Issuer"] = TestJwtIssuer
+            })
+            .Build();
+    }
+
+    protected ApplicationDbContext CreateDbContext() =>
+        new(new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+    protected AuthController CreateAuthController(ApplicationDbContext? db = null) =>
+        new(MockUserManager.Object, MockSignInManager.Object, Configuration,
+            db ?? CreateDbContext(), MockEmailService.Object, MockMapper.Object,
+            NullLogger<AuthController>.Instance);
+
+    protected static AutomationController CreateAutomationController(
+        ApplicationDbContext db, string userId = "user-1", bool isAdmin = false)
+    {
+        var controller = new AutomationController(db, NullLogger<AutomationController>.Instance);
+        controller.ControllerContext = MakeControllerContext(userId, isAdmin);
+        return controller;
+    }
+
+    protected static ControllerContext MakeControllerContext(string userId = "user-1", bool isAdmin = false)
+    {
+        var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, userId) };
+        if (isAdmin)
+            claims.Add(new(ClaimTypes.Role, "admin"));
+        return new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"))
+            }
+        };
+    }
+
+    protected string GenerateTestJwt(string userId, bool expired = false)
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(TestJwtKey));
+        var handler = new JwtSecurityTokenHandler();
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity(new[] { new Claim(JwtRegisteredClaimNames.Sub, userId) }),
+            NotBefore = expired ? DateTime.UtcNow.AddDays(-2) : DateTime.UtcNow.AddSeconds(-10),
+            Expires = expired ? DateTime.UtcNow.AddDays(-1) : DateTime.UtcNow.AddDays(7),
+            SigningCredentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256Signature),
+            Issuer = TestJwtIssuer,
+            Audience = TestJwtIssuer
+        };
+        return handler.WriteToken(handler.CreateToken(descriptor));
+    }
+
+    protected static User MakeUser(string id = "user-1", string email = "test@example.com") => new()
+    {
+        Id = id,
+        Email = email,
+        UserName = "testuser",
+        FirstName = "Test",
+        LastName = "User",
+        EmailConfirmed = true
+    };
+
+    private static Mock<UserManager<User>> CreateUserManagerMock()
+    {
+        var store = new Mock<IUserStore<User>>();
+        return new Mock<UserManager<User>>(
+            store.Object,
+            Mock.Of<IOptions<IdentityOptions>>(),
+            Mock.Of<IPasswordHasher<User>>(),
+            Array.Empty<IUserValidator<User>>(),
+            Array.Empty<IPasswordValidator<User>>(),
+            Mock.Of<ILookupNormalizer>(),
+            new IdentityErrorDescriber(),
+            Mock.Of<IServiceProvider>(),
+            NullLogger<UserManager<User>>.Instance);
+    }
+
+    private static Mock<SignInManager<User>> CreateSignInManagerMock(Mock<UserManager<User>> um) =>
+        new(um.Object,
+            Mock.Of<IHttpContextAccessor>(),
+            Mock.Of<IUserClaimsPrincipalFactory<User>>(),
+            Mock.Of<IOptions<IdentityOptions>>(),
+            NullLogger<SignInManager<User>>.Instance,
+            Mock.Of<IAuthenticationSchemeProvider>(),
+            Mock.Of<IUserConfirmation<User>>());
+}

--- a/garge-api.Tests/garge-api.Tests.csproj
+++ b/garge-api.Tests/garge-api.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\garge-api.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/garge-api.csproj
+++ b/garge-api.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>
+    <DefaultItemExcludes>$(DefaultItemExcludes);garge-api.Tests\**</DefaultItemExcludes>
     <RootNamespace>garge_api</RootNamespace>
     <UserSecretsId>a0e33732-a687-460d-ae97-563565a27798</UserSecretsId>
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/garge-api.sln
+++ b/garge-api.sln
@@ -1,20 +1,46 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.13.35806.99 d17.13
+VisualStudioVersion = 17.13.35806.99
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "garge-api", "garge-api.csproj", "{A71F0FC3-449C-A05A-5E4B-EC06EC201217}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "garge-api.Tests", "garge-api.Tests\garge-api.Tests.csproj", "{98E44077-9863-4047-BDAB-E6450E9FF701}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A71F0FC3-449C-A05A-5E4B-EC06EC201217}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A71F0FC3-449C-A05A-5E4B-EC06EC201217}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A71F0FC3-449C-A05A-5E4B-EC06EC201217}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A71F0FC3-449C-A05A-5E4B-EC06EC201217}.Debug|x64.Build.0 = Debug|Any CPU
+		{A71F0FC3-449C-A05A-5E4B-EC06EC201217}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A71F0FC3-449C-A05A-5E4B-EC06EC201217}.Debug|x86.Build.0 = Debug|Any CPU
 		{A71F0FC3-449C-A05A-5E4B-EC06EC201217}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A71F0FC3-449C-A05A-5E4B-EC06EC201217}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A71F0FC3-449C-A05A-5E4B-EC06EC201217}.Release|x64.ActiveCfg = Release|Any CPU
+		{A71F0FC3-449C-A05A-5E4B-EC06EC201217}.Release|x64.Build.0 = Release|Any CPU
+		{A71F0FC3-449C-A05A-5E4B-EC06EC201217}.Release|x86.ActiveCfg = Release|Any CPU
+		{A71F0FC3-449C-A05A-5E4B-EC06EC201217}.Release|x86.Build.0 = Release|Any CPU
+		{98E44077-9863-4047-BDAB-E6450E9FF701}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{98E44077-9863-4047-BDAB-E6450E9FF701}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{98E44077-9863-4047-BDAB-E6450E9FF701}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{98E44077-9863-4047-BDAB-E6450E9FF701}.Debug|x64.Build.0 = Debug|Any CPU
+		{98E44077-9863-4047-BDAB-E6450E9FF701}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{98E44077-9863-4047-BDAB-E6450E9FF701}.Debug|x86.Build.0 = Debug|Any CPU
+		{98E44077-9863-4047-BDAB-E6450E9FF701}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{98E44077-9863-4047-BDAB-E6450E9FF701}.Release|Any CPU.Build.0 = Release|Any CPU
+		{98E44077-9863-4047-BDAB-E6450E9FF701}.Release|x64.ActiveCfg = Release|Any CPU
+		{98E44077-9863-4047-BDAB-E6450E9FF701}.Release|x64.Build.0 = Release|Any CPU
+		{98E44077-9863-4047-BDAB-E6450E9FF701}.Release|x86.ActiveCfg = Release|Any CPU
+		{98E44077-9863-4047-BDAB-E6450E9FF701}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- Adds `garge-api.Tests` xUnit project with 17 tests covering `AuthController` and `AutomationController`
- Extracts `IEmailService` interface to make `EmailService` mockable in tests
- Adds test + build job to `docker.yml` CI workflow (matches garge-operator pattern); `dev`/`prod` Docker jobs now require passing tests