### PR TITLE
fix: bump LastChargedAt offset to 24h to match firmware

### DIFF
--- a/Controllers/BatteryHealthController.cs
+++ b/Controllers/BatteryHealthController.cs
@@ -78,8 +78,12 @@ namespace garge_api.Controllers
                 .OrderByDescending(bh => bh.Timestamp)
                 .FirstOrDefaultAsync();
 
+            // Offset matches firmware BatteryHealthController.h:
+            //   DISCONNECT_CONFIRM_CYCLES (18) + POST_CHARGE_WAIT_CYCLES (6) = 24h
+            // from real charger removal to record creation. Update both in
+            // lockstep if firmware constants change.
             if (previous != null && dto.ChargesRecorded > previous.ChargesRecorded)
-                record.LastChargedAt = DateTime.UtcNow.AddHours(-4);
+                record.LastChargedAt = DateTime.UtcNow.AddHours(-24);
             else
                 record.LastChargedAt = previous?.LastChargedAt;
 


### PR DESCRIPTION
## Summary

Server-side `LastChargedAt` back-date moves from `-4h` → `-24h` to match the new firmware battery-health state machine.

The firmware now uses cycle-over-cycle voltage-rise tracking to detect real charger disconnect. It tolerates OptiMate maintenance pulses (30 min on / 30 min off) and voltage-retention tests (~8h rest periods) without false-triggering. As a result, the firmware waits longer between actual charger removal and emitting a new `BatteryHealth` record:

- `DISCONNECT_CONFIRM_CYCLES = 18` (cycles without significant voltage rise)
- `POST_CHARGE_WAIT_CYCLES = 6` (post-confirmation settling)
- Total: 24h disconnect → record

The server back-dates `LastChargedAt` so the UI shows when the charger was actually removed, not when the record was inserted.

## Changes

- `Controllers/BatteryHealthController.cs:82` — `DateTime.UtcNow.AddHours(-4)` → `DateTime.UtcNow.AddHours(-24)`
- Comment added linking the constant to the firmware constants so future tuning stays in lockstep.

## Paired PR

Firmware: sondresjolyst/liz-sensors#118 — must deploy first or simultaneously. The two are coupled by the offset constant.

## Test plan

- [ ] After deploy, trigger a real charge cycle on a device running the new firmware.
- [ ] Verify the new `BatteryHealth` row's `LastChargedAt` is ≈ 24h before `Timestamp` (matches actual charger-removal moment).
- [ ] Verify subsequent rows in the same session keep the same `LastChargedAt` (carried forward from previous when `ChargesRecorded` doesn't increment).
