### PR TITLE
feat: add Brevo email stats endpoint to admin API

### DIFF
--- a/Controllers/AdminController.cs
+++ b/Controllers/AdminController.cs
@@ -21,19 +21,22 @@ namespace garge_api.Controllers
         private readonly ApplicationDbContext _context;
         private readonly ILogger<AdminController> _logger;
         private readonly IMapper _mapper;
+        private readonly IEmailService _emailService;
 
         public AdminController(
             RoleManager<IdentityRole> roleManager,
             UserManager<User> userManager,
             ApplicationDbContext context,
             ILogger<AdminController> logger,
-            IMapper mapper)
+            IMapper mapper,
+            IEmailService emailService)
         {
             _roleManager = roleManager;
             _userManager = userManager;
             _context = context;
             _logger = logger;
             _mapper = mapper;
+            _emailService = emailService;
         }
 
         /// <summary>
@@ -256,6 +259,27 @@ namespace garge_api.Controllers
                 .OrderByDescending(d => d.Timestamp)
                 .ToListAsync();
             return Ok(devices);
+        }
+
+        /// <summary>
+        /// Gets Brevo transactional email stats for the last N days.
+        /// </summary>
+        [HttpGet("/api/admin/email-stats")]
+        [SwaggerOperation(Summary = "Gets Brevo email stats.")]
+        [SwaggerResponse(200, "Email stats retrieved successfully.", typeof(EmailStatsDto))]
+        public async Task<IActionResult> GetEmailStats([FromQuery] int days = 30)
+        {
+            _logger.LogInformation("GetEmailStats called by {@LogData}", new { User = User.Identity?.Name });
+            try
+            {
+                var stats = await _emailService.GetEmailStatsAsync(days);
+                return Ok(stats);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError("GetEmailStats failed: {Error}", ex.Message);
+                return StatusCode(502, new { message = "Failed to fetch email stats from Brevo." });
+            }
         }
 
         /// <summary>

--- a/Dtos/Admin/EmailStatsDto.cs
+++ b/Dtos/Admin/EmailStatsDto.cs
@@ -1,0 +1,14 @@
+namespace garge_api.Dtos.Admin
+{
+    public class EmailStatsDto
+    {
+        public long Requests { get; set; }
+        public long Delivered { get; set; }
+        public long HardBounces { get; set; }
+        public long SoftBounces { get; set; }
+        public long SpamReports { get; set; }
+        public long Blocked { get; set; }
+        public long Invalid { get; set; }
+        public int Days { get; set; }
+    }
+}

--- a/Services/EmailService.cs
+++ b/Services/EmailService.cs
@@ -2,6 +2,7 @@
 using brevo_csharp.Api;
 using brevo_csharp.Client;
 using brevo_csharp.Model;
+using garge_api.Dtos.Admin;
 
 public class EmailService : IEmailService
 {
@@ -49,6 +50,31 @@ public class EmailService : IEmailService
         {
             _logger.LogError("Failed to send email. Error: {Error}", ex.Message);
         }
+    }
+
+    public async Task<EmailStatsDto> GetEmailStatsAsync(int days = 30)
+    {
+        var brevoSettings = _configuration.GetSection("BrevoSettings").Get<BrevoSettings>();
+        brevo_csharp.Client.Configuration.Default.ApiKey["api-key"] = brevoSettings!.ApiKey;
+
+        var apiInstance = new TransactionalEmailsApi();
+        var report = await apiInstance.GetSmtpReportAsync(limit: days, days: days);
+
+        var stats = new EmailStatsDto { Days = days };
+        if (report?.Reports != null)
+        {
+            foreach (var r in report.Reports)
+            {
+                stats.Requests += r.Requests ?? 0;
+                stats.Delivered += r.Delivered ?? 0;
+                stats.HardBounces += r.HardBounces ?? 0;
+                stats.SoftBounces += r.SoftBounces ?? 0;
+                stats.SpamReports += r.SpamReports ?? 0;
+                stats.Blocked += r.Blocked ?? 0;
+                stats.Invalid += r.Invalid ?? 0;
+            }
+        }
+        return stats;
     }
 }
 

--- a/Services/IEmailService.cs
+++ b/Services/IEmailService.cs
@@ -1,4 +1,7 @@
+using garge_api.Dtos.Admin;
+
 public interface IEmailService
 {
     Task SendEmailAsync(string email, string subject, string message);
+    Task<EmailStatsDto> GetEmailStatsAsync(int days = 30);
 }


### PR DESCRIPTION
## Summary
- Adds `GET /api/admin/email-stats?days=30` endpoint (Admin role required)
- `GetEmailStatsAsync` on `IEmailService`/`EmailService` calls Brevo `GetSmtpReport` with `limit: days` to ensure full data for 7/30/90 day ranges
- Returns `EmailStatsDto` with requests, delivered, hardBounces, softBounces, spamReports, blocked, invalid, days