### PR TITLE
fix: replace per-controller Sanitize with shared LogSanitizer helper

### DIFF
--- a/Controllers/BatteryHealthController.cs
+++ b/Controllers/BatteryHealthController.cs
@@ -1,5 +1,6 @@
 using AutoMapper;
 using garge_api.Dtos.Sensor;
+using garge_api.Helpers;
 using garge_api.Models;
 using garge_api.Models.Sensor;
 using Microsoft.AspNetCore.Authorization;
@@ -40,9 +41,6 @@ namespace garge_api.Controllers
             return await _context.UserSensors.AnyAsync(us => us.UserId == userId && us.SensorId == sensorId);
         }
 
-        private static string Sanitize(string input) => input.Replace("\r", "", StringComparison.Ordinal)
-                                                              .Replace("\n", "", StringComparison.Ordinal);
-
         /// <summary>
         /// Stores a battery health reading for the voltage sensor identified by name.
         /// Called by the operator when a battery health MQTT state message arrives.
@@ -54,18 +52,18 @@ namespace garge_api.Controllers
         [SwaggerResponse(403, "User does not have the required role.")]
         public async Task<IActionResult> CreateBatteryHealth(string sensorName, [FromBody] CreateBatteryHealthDto dto)
         {
-            _logger.LogInformation("CreateBatteryHealth called by {@LogData}", new { User = User.Identity?.Name, SensorName = Sanitize(sensorName) });
+            _logger.LogInformation("CreateBatteryHealth called by {@LogData}", new { User = User.Identity?.Name, SensorName = LogSanitizer.Sanitize(sensorName) });
 
             var sensor = await _context.Sensors.FirstOrDefaultAsync(s => s.Name == sensorName);
             if (sensor == null)
             {
-                _logger.LogWarning("CreateBatteryHealth voltage sensor not found: {SensorName}", Sanitize(sensorName));
+                _logger.LogWarning("CreateBatteryHealth voltage sensor not found: {SensorName}", LogSanitizer.Sanitize(sensorName));
                 return NotFound(new { message = "Sensor not found!" });
             }
 
             if (!await UserCanAccessSensorAsync(sensor.Id))
             {
-                _logger.LogWarning("CreateBatteryHealth forbidden for {@LogData}", new { User = User.Identity?.Name, SensorName = Sanitize(sensorName) });
+                _logger.LogWarning("CreateBatteryHealth forbidden for {@LogData}", new { User = User.Identity?.Name, SensorName = LogSanitizer.Sanitize(sensorName) });
                 return Forbid();
             }
 
@@ -91,7 +89,7 @@ namespace garge_api.Controllers
             await _context.SaveChangesAsync();
 
             var result = _mapper.Map<BatteryHealthDto>(record);
-            _logger.LogInformation("Battery health record created: {@LogData}", new { record.Id, SensorName = Sanitize(sensorName), record.Status });
+            _logger.LogInformation("Battery health record created: {@LogData}", new { record.Id, SensorName = LogSanitizer.Sanitize(sensorName), record.Status });
             return CreatedAtAction(nameof(GetLatestBatteryHealth), new { sensorName }, result);
         }
 
@@ -105,18 +103,18 @@ namespace garge_api.Controllers
         [SwaggerResponse(403, "User does not have the required role.")]
         public async Task<IActionResult> GetLatestBatteryHealth(string sensorName)
         {
-            _logger.LogInformation("GetLatestBatteryHealth called by {@LogData}", new { User = User.Identity?.Name, SensorName = Sanitize(sensorName) });
+            _logger.LogInformation("GetLatestBatteryHealth called by {@LogData}", new { User = User.Identity?.Name, SensorName = LogSanitizer.Sanitize(sensorName) });
 
             var sensor = await _context.Sensors.FirstOrDefaultAsync(s => s.Name == sensorName);
             if (sensor == null)
             {
-                _logger.LogWarning("GetLatestBatteryHealth voltage sensor not found: {SensorName}", Sanitize(sensorName));
+                _logger.LogWarning("GetLatestBatteryHealth voltage sensor not found: {SensorName}", LogSanitizer.Sanitize(sensorName));
                 return NotFound(new { message = "Sensor not found!" });
             }
 
             if (!await UserCanAccessSensorAsync(sensor.Id))
             {
-                _logger.LogWarning("GetLatestBatteryHealth forbidden for {@LogData}", new { User = User.Identity?.Name, SensorName = Sanitize(sensorName) });
+                _logger.LogWarning("GetLatestBatteryHealth forbidden for {@LogData}", new { User = User.Identity?.Name, SensorName = LogSanitizer.Sanitize(sensorName) });
                 return Forbid();
             }
 
@@ -127,7 +125,7 @@ namespace garge_api.Controllers
 
             if (latest == null)
             {
-                _logger.LogInformation("GetLatestBatteryHealth no data for sensor: {SensorName}", Sanitize(sensorName));
+                _logger.LogInformation("GetLatestBatteryHealth no data for sensor: {SensorName}", LogSanitizer.Sanitize(sensorName));
                 return Ok((BatteryHealthDto?)null);
             }
 

--- a/Controllers/ElectricityController.cs
+++ b/Controllers/ElectricityController.cs
@@ -1,4 +1,5 @@
 ﻿using garge_api.Services;
+using garge_api.Helpers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
@@ -23,9 +24,6 @@ namespace garge_api.Controllers
         private readonly ILogger<ElectricityController> _logger;
         private readonly ApplicationDbContext _context;
 
-        private static string Sanitize(string input) => input.Replace("\r", "", StringComparison.Ordinal)
-                                                              .Replace("\n", "", StringComparison.Ordinal);
-
         public ElectricityController(NordPoolService nordPoolService, IMapper mapper, ILogger<ElectricityController> logger, ApplicationDbContext context)
         {
             _nordPoolService = nordPoolService;
@@ -45,7 +43,7 @@ namespace garge_api.Controllers
         [HttpGet("prices")]
         public async Task<IActionResult> GetPrices([FromQuery] string type, [FromQuery] string area, [FromQuery] DateTime? date, [FromQuery] string currency = "NOK")
         {
-            _logger.LogInformation("GetPrices called by {@LogData}", new { User = User.Identity?.Name, type = Sanitize(type), area = Sanitize(area), date, currency });
+            _logger.LogInformation("GetPrices called by {@LogData}", new { User = User.Identity?.Name, type = LogSanitizer.Sanitize(type), area = LogSanitizer.Sanitize(area), date, currency });
 
             var userRoles = User.FindAll(ClaimTypes.Role).Select(r => r.Value).ToList();
 
@@ -71,13 +69,13 @@ namespace garge_api.Controllers
             var storedEntries = await GetStoredPricesAsync(resolution, area, queryDate);
             if (storedEntries.Count > 0)
             {
-                _logger.LogInformation("Serving {Count} {Resolution} price entries from DB for area {Area}", storedEntries.Count, Sanitize(resolution), Sanitize(area));
+                _logger.LogInformation("Serving {Count} {Resolution} price entries from DB for area {Area}", storedEntries.Count, LogSanitizer.Sanitize(resolution), LogSanitizer.Sanitize(area));
                 var dbDto = BuildPriceResponseDto(storedEntries, area, currency);
                 return Ok(dbDto);
             }
 
             // Fall back to NordPool
-            _logger.LogInformation("No DB data found, fetching from NordPool {@LogData}", new { type = Sanitize(type), area = Sanitize(area), date, currency });
+            _logger.LogInformation("No DB data found, fetching from NordPool {@LogData}", new { type = LogSanitizer.Sanitize(type), area = LogSanitizer.Sanitize(area), date, currency });
             var data = await _nordPoolService.FetchPricesAsync(resolution, queryDate, new List<string> { area }, currency);
 
             if (data == null)
@@ -92,7 +90,7 @@ namespace garge_api.Controllers
                     entry.Value /= 1000m;
 
             var dto = _mapper.Map<PriceResponseDto>(data);
-            _logger.LogInformation("Returning NordPool price data {@LogData}", new { type = Sanitize(type), area = Sanitize(area), date, currency });
+            _logger.LogInformation("Returning NordPool price data {@LogData}", new { type = LogSanitizer.Sanitize(type), area = LogSanitizer.Sanitize(area), date, currency });
             return Ok(dto);
         }
 

--- a/Controllers/GroupsController.cs
+++ b/Controllers/GroupsController.cs
@@ -1,4 +1,5 @@
 using garge_api.Dtos.Group;
+using garge_api.Helpers;
 using garge_api.Models;
 using garge_api.Models.Group;
 using Microsoft.AspNetCore.Authorization;
@@ -67,7 +68,7 @@ namespace garge_api.Controllers
             _context.Groups.Add(group);
             await _context.SaveChangesAsync();
 
-            _logger.LogInformation("Group {Name} created by {UserId}", group.Name, userId);
+            _logger.LogInformation("Group {Name} created by {UserId}", LogSanitizer.Sanitize(group.Name), userId);
 
             return CreatedAtAction(nameof(GetGroups), new GroupDto
             {

--- a/Controllers/UserController.cs
+++ b/Controllers/UserController.cs
@@ -1,5 +1,6 @@
 using AutoMapper;
 using garge_api.Dtos.User;
+using garge_api.Helpers;
 using garge_api.Models;
 using garge_api.Models.Auth;
 using Microsoft.AspNetCore.Authorization;
@@ -114,11 +115,11 @@ namespace garge_api.Controllers
             var result = await _userManager.DeleteAsync(user);
             if (!result.Succeeded)
             {
-                _logger.LogError("DeleteOwnAccount failed for {UserId}: {Errors}", SanitizeForLog(id), result.Errors);
+                _logger.LogError("DeleteOwnAccount failed for {UserId}: {Errors}", LogSanitizer.Sanitize(id), result.Errors);
                 return BadRequest(result.Errors);
             }
 
-            _logger.LogInformation("Account deleted by user {UserId}", SanitizeForLog(id));
+            _logger.LogInformation("Account deleted by user {UserId}", LogSanitizer.Sanitize(id));
             return NoContent();
         }
 
@@ -244,7 +245,7 @@ namespace garge_api.Controllers
                 })
             };
 
-            _logger.LogInformation("Data exported for user {UserId}", SanitizeForLog(id));
+            _logger.LogInformation("Data exported for user {UserId}", LogSanitizer.Sanitize(id));
             return Ok(export);
         }
 
@@ -277,6 +278,5 @@ namespace garge_api.Controllers
             return Ok(response);
         }
 
-        private static string SanitizeForLog(string value) => value.Replace('\n', '_').Replace('\r', '_');
     }
 }

--- a/Helpers/LogSanitizer.cs
+++ b/Helpers/LogSanitizer.cs
@@ -1,0 +1,9 @@
+namespace garge_api.Helpers
+{
+    public static class LogSanitizer
+    {
+        public static string Sanitize(string input) => input
+            .Replace("\r", "", StringComparison.Ordinal)
+            .Replace("\n", "", StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `Helpers/LogSanitizer.cs` — single shared static `Sanitize()` that strips `\r`/`\n` from user input before logging
- Removes duplicate private `Sanitize()`/`SanitizeForLog()` from `ElectricityController`, `BatteryHealthController`, `UserController`
- Fixes CWE-117 log forging (CodeQL alert #318) in `GroupsController.CreateGroup`