### PR TITLE
fix: silence CS0618 obsolete HasCheckConstraint warning

### DIFF
--- a/Models/ApplicationDbContext.cs
+++ b/Models/ApplicationDbContext.cs
@@ -220,7 +220,7 @@ namespace garge_api.Models
                 .ValueGeneratedNever();
 
             modelBuilder.Entity<AppSettings>()
-                .HasCheckConstraint("CK_AppSettings_SingleRow", "\"Id\" = 1");
+                .ToTable(t => t.HasCheckConstraint("CK_AppSettings_SingleRow", "\"Id\" = 1"));
 
             modelBuilder.Entity<AppSettings>()
                 .HasData(new AppSettings { Id = 1, CookieBannerEnabled = true });


### PR DESCRIPTION
## Summary
- Replace .HasCheckConstraint() with .ToTable(t => t.HasCheckConstraint()) per EF Core 10 guidance
- Eliminates the CS0618 warning in CI build