### PR TITLE
fix: log warning when VAPID config missing instead of silent 503

### DIFF
--- a/Controllers/PushSubscriptionController.cs
+++ b/Controllers/PushSubscriptionController.cs
@@ -19,7 +19,8 @@ namespace garge_api.Controllers
     public class PushSubscriptionController(
         ApplicationDbContext db,
         IConfiguration configuration,
-        IWebPushService webPushService) : ControllerBase
+        IWebPushService webPushService,
+        ILogger<PushSubscriptionController> logger) : ControllerBase
     {
         /// <summary>Returns the VAPID public key needed by the browser to subscribe.</summary>
         [HttpGet("vapid-public-key")]
@@ -28,7 +29,10 @@ namespace garge_api.Controllers
         {
             var key = configuration["Vapid:PublicKey"];
             if (string.IsNullOrEmpty(key))
+            {
+                logger.LogWarning("VAPID public key not configured — push notifications unavailable");
                 return StatusCode(503, new { message = "Push notifications not configured." });
+            }
             return Ok(new { publicKey = key });
         }
 

--- a/garge-api.Tests/PushSubscriptionControllerTests.cs
+++ b/garge-api.Tests/PushSubscriptionControllerTests.cs
@@ -5,6 +5,7 @@ using garge_api.Models.Push;
 using garge_api.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 
@@ -25,8 +26,9 @@ public class PushSubscriptionControllerTests : ControllerTestBase
             .Build();
 
         var push = new Mock<IWebPushService>();
+        var logger = new Mock<ILogger<PushSubscriptionController>>();
 
-        var controller = new PushSubscriptionController(db, config, push.Object);
+        var controller = new PushSubscriptionController(db, config, push.Object, logger.Object);
         controller.ControllerContext = MakeControllerContext(userId);
         return controller;
     }


### PR DESCRIPTION
## Summary
- Adds `ILogger` to `PushSubscriptionController`
- Logs `LogWarning` when `Vapid:PublicKey` is not configured before returning 503