### PR TITLE
fix: only record offline notification if push was actually sent

### DIFF
--- a/Controllers/PushSubscriptionController.cs
+++ b/Controllers/PushSubscriptionController.cs
@@ -19,7 +19,8 @@ namespace garge_api.Controllers
     public class PushSubscriptionController(
         ApplicationDbContext db,
         IConfiguration configuration,
-        IWebPushService webPushService) : ControllerBase
+        IWebPushService webPushService,
+        ILogger<PushSubscriptionController> logger) : ControllerBase
     {
         /// <summary>Returns the VAPID public key needed by the browser to subscribe.</summary>
         [HttpGet("vapid-public-key")]
@@ -28,7 +29,10 @@ namespace garge_api.Controllers
         {
             var key = configuration["Vapid:PublicKey"];
             if (string.IsNullOrEmpty(key))
+            {
+                logger.LogWarning("VAPID public key not configured — push notifications unavailable");
                 return StatusCode(503, new { message = "Push notifications not configured." });
+            }
             return Ok(new { publicKey = key });
         }
 

--- a/Services/SensorOfflineCheckService.cs
+++ b/Services/SensorOfflineCheckService.cs
@@ -67,9 +67,10 @@ namespace garge_api.Services
                         var sensor = await db.Sensors.FindAsync([sensorId], ct);
                         var name = customName ?? sensor?.DefaultName ?? $"Sensor #{sensorId}";
 
+                        bool sent;
                         try
                         {
-                            await push.SendAsync(
+                            sent = await push.SendAsync(
                                 user.Id,
                                 "Sensor offline",
                                 $"{name} has not reported in over {user.OfflineAlertThresholdHours}h.",
@@ -81,15 +82,18 @@ namespace garge_api.Services
                             continue;
                         }
 
-                        db.SensorOfflineNotifications.Add(new SensorOfflineNotification
+                        if (sent)
                         {
-                            UserId = user.Id,
-                            SensorId = sensorId,
-                            NotifiedAt = now,
-                        });
-                        await db.SaveChangesAsync(ct);
+                            db.SensorOfflineNotifications.Add(new SensorOfflineNotification
+                            {
+                                UserId = user.Id,
+                                SensorId = sensorId,
+                                NotifiedAt = now,
+                            });
+                            await db.SaveChangesAsync(ct);
 
-                        logger.LogInformation("Offline notification sent: sensor {SensorId} user {UserId}", sensorId, user.Id);
+                            logger.LogInformation("Offline notification sent: sensor {SensorId} user {UserId}", sensorId, user.Id);
+                        }
                     }
                     else if (!isOffline && activeNotification != null)
                     {

--- a/Services/WebPushService.cs
+++ b/Services/WebPushService.cs
@@ -12,7 +12,7 @@ namespace garge_api.Services
 {
     public interface IWebPushService
     {
-        Task SendAsync(string userId, string title, string body, CancellationToken ct = default);
+        Task<bool> SendAsync(string userId, string title, string body, CancellationToken ct = default);
     }
 
     public class WebPushService(
@@ -21,7 +21,7 @@ namespace garge_api.Services
         IConfiguration configuration,
         ILogger<WebPushService> logger) : IWebPushService
     {
-        public async Task SendAsync(string userId, string title, string body, CancellationToken ct = default)
+        public async Task<bool> SendAsync(string userId, string title, string body, CancellationToken ct = default)
         {
             var publicKey = configuration["Vapid:PublicKey"] ?? string.Empty;
             var privateKey = configuration["Vapid:PrivateKey"] ?? string.Empty;
@@ -30,14 +30,14 @@ namespace garge_api.Services
             if (string.IsNullOrEmpty(publicKey) || string.IsNullOrEmpty(privateKey))
             {
                 logger.LogWarning("VAPID keys not configured — push skipped");
-                return;
+                return false;
             }
 
             var subscriptions = await db.PushSubscriptions
                 .Where(s => s.UserId == userId)
                 .ToListAsync(ct);
 
-            if (subscriptions.Count == 0) return;
+            if (subscriptions.Count == 0) return false;
 
             var payload = JsonSerializer.SerializeToUtf8Bytes(new { title, body });
             var toRemove = new List<int>();
@@ -74,6 +74,8 @@ namespace garge_api.Services
 
             if (successCount == 0 && lastError != null)
                 throw lastError;
+
+            return successCount > 0;
         }
 
         private async Task SendToSubscriptionAsync(

--- a/garge-api.Tests/PushSubscriptionControllerTests.cs
+++ b/garge-api.Tests/PushSubscriptionControllerTests.cs
@@ -5,6 +5,7 @@ using garge_api.Models.Push;
 using garge_api.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 
@@ -25,8 +26,9 @@ public class PushSubscriptionControllerTests : ControllerTestBase
             .Build();
 
         var push = new Mock<IWebPushService>();
+        var logger = new Mock<ILogger<PushSubscriptionController>>();
 
-        var controller = new PushSubscriptionController(db, config, push.Object);
+        var controller = new PushSubscriptionController(db, config, push.Object, logger.Object);
         controller.ControllerContext = MakeControllerContext(userId);
         return controller;
     }

--- a/garge-api.Tests/SensorOfflineCheckServiceTests.cs
+++ b/garge-api.Tests/SensorOfflineCheckServiceTests.cs
@@ -21,6 +21,8 @@ public class SensorOfflineCheckServiceTests : ControllerTestBase
     private static (TestableService service, Mock<IWebPushService> push) BuildService(ApplicationDbContext db)
     {
         var push = new Mock<IWebPushService>();
+        push.Setup(p => p.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
 
         var sp = new Mock<IServiceProvider>();
         sp.Setup(x => x.GetService(typeof(ApplicationDbContext))).Returns(db);


### PR DESCRIPTION
## Summary

- SendAsync returns bool — true if at least one subscription was reached
- CheckAsync only writes SensorOfflineNotification when push was delivered
- Previously: silent no-op (no VAPID keys, no subscriptions) still wrote the record, permanently blocking future alerts for that sensor