### PR TITLE
feat: Vipps payments - subscriptions and sensor shop

### DIFF
--- a/Authorization/ActiveSubscriptionHandler.cs
+++ b/Authorization/ActiveSubscriptionHandler.cs
@@ -1,0 +1,43 @@
+using garge_api.Constants;
+using garge_api.Models;
+using garge_api.Models.Subscription;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
+
+namespace garge_api.Authorization
+{
+    public class ActiveSubscriptionHandler : AuthorizationHandler<ActiveSubscriptionRequirement>
+    {
+        private readonly IServiceScopeFactory _scopeFactory;
+
+        public ActiveSubscriptionHandler(IServiceScopeFactory scopeFactory)
+        {
+            _scopeFactory = scopeFactory;
+        }
+
+        protected override async Task HandleRequirementAsync(
+            AuthorizationHandlerContext context,
+            ActiveSubscriptionRequirement requirement)
+        {
+            var userId = context.User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null) return;
+
+            if (RoleNames.SubscriptionBypassRoles.Any(r => context.User.IsInRole(r)))
+            {
+                context.Succeed(requirement);
+                return;
+            }
+
+            using var scope = _scopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+            var hasActive = await db.Subscriptions.AnyAsync(s =>
+                s.UserId == userId &&
+                s.Status == SubscriptionStatus.Active);
+
+            if (hasActive)
+                context.Succeed(requirement);
+        }
+    }
+}

--- a/Authorization/ActiveSubscriptionHandler.cs
+++ b/Authorization/ActiveSubscriptionHandler.cs
@@ -32,9 +32,13 @@ namespace garge_api.Authorization
             using var scope = _scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
+            var settings = await db.AppSettings.FindAsync(1);
+            var isTestMode = settings?.VippsTestMode ?? false;
+
             var hasActive = await db.Subscriptions.AnyAsync(s =>
                 s.UserId == userId &&
-                s.Status == SubscriptionStatus.Active);
+                s.Status == SubscriptionStatus.Active &&
+                (!s.IsTest || isTestMode));
 
             if (hasActive)
                 context.Succeed(requirement);

--- a/Authorization/ActiveSubscriptionHandler.cs
+++ b/Authorization/ActiveSubscriptionHandler.cs
@@ -3,6 +3,7 @@ using garge_api.Models;
 using garge_api.Models.Subscription;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 using System.Security.Claims;
 
 namespace garge_api.Authorization
@@ -10,10 +11,14 @@ namespace garge_api.Authorization
     public class ActiveSubscriptionHandler : AuthorizationHandler<ActiveSubscriptionRequirement>
     {
         private readonly IServiceScopeFactory _scopeFactory;
+        private readonly IMemoryCache _cache;
 
-        public ActiveSubscriptionHandler(IServiceScopeFactory scopeFactory)
+        private const string TestModeCacheKey = "vipps_test_mode";
+
+        public ActiveSubscriptionHandler(IServiceScopeFactory scopeFactory, IMemoryCache cache)
         {
             _scopeFactory = scopeFactory;
+            _cache = cache;
         }
 
         protected override async Task HandleRequirementAsync(
@@ -32,8 +37,12 @@ namespace garge_api.Authorization
             using var scope = _scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
-            var settings = await db.AppSettings.FindAsync(1);
-            var isTestMode = settings?.VippsTestMode ?? false;
+            if (!_cache.TryGetValue(TestModeCacheKey, out bool isTestMode))
+            {
+                var settings = await db.AppSettings.FindAsync(1);
+                isTestMode = settings?.VippsTestMode ?? false;
+                _cache.Set(TestModeCacheKey, isTestMode, TimeSpan.FromSeconds(30));
+            }
 
             var hasActive = await db.Subscriptions.AnyAsync(s =>
                 s.UserId == userId &&

--- a/Authorization/ActiveSubscriptionHandler.cs
+++ b/Authorization/ActiveSubscriptionHandler.cs
@@ -1,5 +1,6 @@
 using garge_api.Constants;
 using garge_api.Models;
+using garge_api.Models.Sensor;
 using garge_api.Models.Subscription;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
@@ -44,12 +45,21 @@ namespace garge_api.Authorization
                 _cache.Set(TestModeCacheKey, isTestMode, TimeSpan.FromSeconds(30));
             }
 
-            var hasActive = await db.Subscriptions.AnyAsync(s =>
+            var ownedSensorCount = await db.UserSensors.CountAsync(us => us.UserId == userId && us.IsOwner);
+
+            // Pure viewer (no owned sensors) — shared access only, allow through
+            if (ownedSensorCount == 0)
+            {
+                context.Succeed(requirement);
+                return;
+            }
+
+            var subscriptionCount = await db.Subscriptions.CountAsync(s =>
                 s.UserId == userId &&
                 s.Status == SubscriptionStatus.Active &&
                 (!s.IsTest || isTestMode));
 
-            if (hasActive)
+            if (subscriptionCount >= ownedSensorCount)
                 context.Succeed(requirement);
         }
     }

--- a/Authorization/ActiveSubscriptionRequirement.cs
+++ b/Authorization/ActiveSubscriptionRequirement.cs
@@ -1,0 +1,6 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace garge_api.Authorization
+{
+    public class ActiveSubscriptionRequirement : IAuthorizationRequirement { }
+}

--- a/Constants/RoleNames.cs
+++ b/Constants/RoleNames.cs
@@ -1,12 +1,21 @@
-﻿namespace garge_api.Constants
+namespace garge_api.Constants
 {
     public static class RoleNames
     {
-        public static readonly string[] AllRoles = { "Default", "Electricity", "Admin", "SensorAdmin", "MqttAdmin", "AutomationAdmin", "SwitchAdmin" };
+        public static readonly string[] AllRoles =
+        {
+            "Default", "Electricity",
+            "Admin", "SensorAdmin", "MqttAdmin", "AutomationAdmin", "SwitchAdmin",
+            "ComplimentaryUser"
+        };
 
-        // Roles that bypass the subscription requirement — these accounts manage infrastructure, not end-user features
-        public static readonly string[] SubscriptionBypassRoles = { "Admin", "SensorAdmin", "MqttAdmin", "AutomationAdmin", "SwitchAdmin" };
-        public static readonly Dictionary<string, string[]> RolePermissions = new Dictionary<string, string[]>
+        public static readonly string[] SubscriptionBypassRoles =
+        {
+            "Admin", "SensorAdmin", "MqttAdmin", "AutomationAdmin", "SwitchAdmin",
+            "ComplimentaryUser"
+        };
+
+        public static readonly Dictionary<string, string[]> RolePermissions = new()
         {
             { "Default", new string[] { "Electricity" } },
         };

--- a/Constants/RoleNames.cs
+++ b/Constants/RoleNames.cs
@@ -3,6 +3,9 @@
     public static class RoleNames
     {
         public static readonly string[] AllRoles = { "Default", "Electricity", "Admin", "SensorAdmin", "MqttAdmin", "AutomationAdmin", "SwitchAdmin" };
+
+        // Roles that bypass the subscription requirement — these accounts manage infrastructure, not end-user features
+        public static readonly string[] SubscriptionBypassRoles = { "Admin", "SensorAdmin", "MqttAdmin", "AutomationAdmin", "SwitchAdmin" };
         public static readonly Dictionary<string, string[]> RolePermissions = new Dictionary<string, string[]>
         {
             { "Default", new string[] { "Electricity" } },

--- a/Constants/VippsEvents.cs
+++ b/Constants/VippsEvents.cs
@@ -1,0 +1,34 @@
+namespace garge_api.Constants
+{
+    public static class VippsEvents
+    {
+        public const string PaymentAuthorized = "epayments.payment.authorized.v1";
+        public const string PaymentCaptured   = "epayments.payment.captured.v1";
+        public const string PaymentRefunded   = "epayments.payment.refunded.v1";
+        public const string PaymentTerminated = "epayments.payment.terminated.v1";
+        public const string PaymentAborted    = "epayments.payment.aborted.v1";
+        public const string PaymentExpired    = "epayments.payment.expired.v1";
+        public const string PaymentCancelled  = "epayments.payment.cancelled.v1";
+        public const string PaymentCreated    = "epayments.payment.created.v1";
+
+        public const string AgreementActivated = "recurring.agreement-activated.v1";
+        public const string AgreementStopped   = "recurring.agreement-stopped.v1";
+        public const string AgreementExpired   = "recurring.agreement-expired.v1";
+        public const string AgreementRejected  = "recurring.agreement-rejected.v1";
+        public const string ChargeCaptured     = "recurring.charge-captured.v1";
+        public const string ChargeFailed       = "recurring.charge-failed.v1";
+        public const string ChargeCreationFailed = "recurring.charge-creation-failed.v1";
+
+        public static readonly string[] ShopEvents =
+        {
+            PaymentAuthorized, PaymentCaptured, PaymentRefunded, PaymentTerminated,
+            PaymentAborted, PaymentExpired, PaymentCancelled
+        };
+
+        public static readonly string[] SubscriptionEvents =
+        {
+            AgreementActivated, AgreementStopped, AgreementExpired, AgreementRejected,
+            ChargeCaptured, ChargeFailed, ChargeCreationFailed
+        };
+    }
+}

--- a/Controllers/AdminController.cs
+++ b/Controllers/AdminController.cs
@@ -22,6 +22,7 @@ namespace garge_api.Controllers
         private readonly ILogger<AdminController> _logger;
         private readonly IMapper _mapper;
         private readonly IEmailService _emailService;
+        private readonly Services.IAppSettingsCache? _settingsCache;
 
         public AdminController(
             RoleManager<IdentityRole> roleManager,
@@ -29,7 +30,8 @@ namespace garge_api.Controllers
             ApplicationDbContext context,
             ILogger<AdminController> logger,
             IMapper mapper,
-            IEmailService emailService)
+            IEmailService emailService,
+            Services.IAppSettingsCache? settingsCache = null)
         {
             _roleManager = roleManager;
             _userManager = userManager;
@@ -37,6 +39,7 @@ namespace garge_api.Controllers
             _logger = logger;
             _mapper = mapper;
             _emailService = emailService;
+            _settingsCache = settingsCache;
         }
 
         /// <summary>
@@ -435,6 +438,7 @@ namespace garge_api.Controllers
 
             _mapper.Map(dto, settings);
             await _context.SaveChangesAsync();
+            _settingsCache?.Invalidate();
 
             _logger.LogInformation("AppSettings updated: {@LogData}", new { dto.CookieBannerEnabled, CallerUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) });
             return Ok(_mapper.Map<AppSettingsDto>(settings));

--- a/Controllers/AdminController.cs
+++ b/Controllers/AdminController.cs
@@ -412,8 +412,7 @@ namespace garge_api.Controllers
         [SwaggerResponse(200, "Settings retrieved.", typeof(AppSettingsDto))]
         public async Task<IActionResult> GetAppSettings()
         {
-            var settings = await _context.AppSettings.FindAsync(1)
-                ?? new AppSettings { Id = 1, CookieBannerEnabled = true };
+            var settings = await _context.AppSettings.FindAsync(1) ?? new AppSettings();
             return Ok(_mapper.Map<AppSettingsDto>(settings));
         }
 

--- a/Controllers/AutomationController.cs
+++ b/Controllers/AutomationController.cs
@@ -14,6 +14,7 @@ namespace garge_api.Controllers
     [Route("api/automation")]
     [EnableCors("AllowAllOrigins")]
     [Authorize]
+    [Authorize(Policy = "ActiveSubscription")]
     public class AutomationController : ControllerBase
     {
         private readonly ApplicationDbContext _context;

--- a/Controllers/BatteryHealthController.cs
+++ b/Controllers/BatteryHealthController.cs
@@ -16,6 +16,7 @@ namespace garge_api.Controllers
     [Route("api/battery-health")]
     [EnableCors("AllowAllOrigins")]
     [Authorize]
+    [Authorize(Policy = "ActiveSubscription")]
     public class BatteryHealthController : ControllerBase
     {
         private readonly ApplicationDbContext _context;

--- a/Controllers/ElectricityController.cs
+++ b/Controllers/ElectricityController.cs
@@ -17,6 +17,7 @@ namespace garge_api.Controllers
     [Route("api/electricity")]
     [EnableCors("AllowAllOrigins")]
     [Authorize]
+    [Authorize(Policy = "ActiveSubscription")]
     public class ElectricityController : ControllerBase
     {
         private readonly NordPoolService _nordPoolService;

--- a/Controllers/GroupsController.cs
+++ b/Controllers/GroupsController.cs
@@ -14,6 +14,7 @@ namespace garge_api.Controllers
     [Route("api/groups")]
     [EnableCors("AllowAllOrigins")]
     [Authorize]
+    [Authorize(Policy = "ActiveSubscription")]
     public class GroupsController : ControllerBase
     {
         private readonly ApplicationDbContext _context;

--- a/Controllers/MqttController.cs
+++ b/Controllers/MqttController.cs
@@ -17,6 +17,7 @@ namespace garge_api.Controllers
     [Route("api/mqtt")]
     [EnableCors("AllowAllOrigins")]
     [Authorize]
+    [Authorize(Policy = "ActiveSubscription")]
     public class MqttController : ControllerBase
     {
         private readonly ApplicationDbContext _context;

--- a/Controllers/ProductsController.cs
+++ b/Controllers/ProductsController.cs
@@ -1,0 +1,96 @@
+using AutoMapper;
+using garge_api.Dtos.Subscription;
+using garge_api.Models;
+using garge_api.Models.Subscription;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace garge_api.Controllers
+{
+    [ApiController]
+    [Route("api/products")]
+    public class ProductsController : ControllerBase
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly IMapper _mapper;
+        private readonly ILogger<ProductsController> _logger;
+
+        public ProductsController(
+            ApplicationDbContext context,
+            IMapper mapper,
+            ILogger<ProductsController> logger)
+        {
+            _context = context;
+            _mapper = mapper;
+            _logger = logger;
+        }
+
+        /// <summary>Lists all active subscription products.</summary>
+        [HttpGet]
+        [AllowAnonymous]
+        public async Task<IActionResult> GetProducts()
+        {
+            var products = await _context.Products
+                .Where(p => p.IsActive)
+                .OrderBy(p => p.PriceInOre)
+                .ToListAsync();
+
+            return Ok(_mapper.Map<List<ProductResponseDto>>(products));
+        }
+
+        /// <summary>Gets a subscription product by ID.</summary>
+        [HttpGet("{id}")]
+        [AllowAnonymous]
+        public async Task<IActionResult> GetProduct(int id)
+        {
+            var product = await _context.Products.FindAsync(id);
+            if (product == null) return NotFound();
+            return Ok(_mapper.Map<ProductResponseDto>(product));
+        }
+
+        /// <summary>Creates a new subscription product.</summary>
+        [HttpPost]
+        [Authorize(Policy = "Admin")]
+        public async Task<IActionResult> CreateProduct([FromBody] CreateProductDto dto)
+        {
+            var product = _mapper.Map<Product>(dto);
+            _context.Products.Add(product);
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("Product {ProductId} created: {Name}", product.Id, product.Name);
+            return CreatedAtAction(nameof(GetProduct), new { id = product.Id },
+                _mapper.Map<ProductResponseDto>(product));
+        }
+
+        /// <summary>Updates an existing subscription product.</summary>
+        [HttpPut("{id}")]
+        [Authorize(Policy = "Admin")]
+        public async Task<IActionResult> UpdateProduct(int id, [FromBody] UpdateProductDto dto)
+        {
+            var product = await _context.Products.FindAsync(id);
+            if (product == null) return NotFound();
+
+            _mapper.Map(dto, product);
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("Product {ProductId} updated", id);
+            return Ok(_mapper.Map<ProductResponseDto>(product));
+        }
+
+        /// <summary>Soft-deletes a subscription product (sets IsActive = false).</summary>
+        [HttpDelete("{id}")]
+        [Authorize(Policy = "Admin")]
+        public async Task<IActionResult> DeleteProduct(int id)
+        {
+            var product = await _context.Products.FindAsync(id);
+            if (product == null) return NotFound();
+
+            product.IsActive = false;
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("Product {ProductId} deactivated", id);
+            return NoContent();
+        }
+    }
+}

--- a/Controllers/PushSubscriptionController.cs
+++ b/Controllers/PushSubscriptionController.cs
@@ -16,6 +16,7 @@ namespace garge_api.Controllers
     [ApiController]
     [Route("api/push-subscriptions")]
     [EnableCors("AllowAllOrigins")]
+    [Authorize(Policy = "ActiveSubscription")]
     public class PushSubscriptionController(
         ApplicationDbContext db,
         IConfiguration configuration,

--- a/Controllers/SensorActivitiesController.cs
+++ b/Controllers/SensorActivitiesController.cs
@@ -15,6 +15,7 @@ namespace garge_api.Controllers
     [Route("api/sensors/{sensorId}/activities")]
     [EnableCors("AllowAllOrigins")]
     [Authorize]
+    [Authorize(Policy = "ActiveSubscription")]
     public class SensorActivitiesController : ControllerBase
     {
         private readonly ApplicationDbContext _context;

--- a/Controllers/SensorController.cs
+++ b/Controllers/SensorController.cs
@@ -546,7 +546,7 @@ namespace garge_api.Controllers
             var alreadyClaimed = await _context.UserSensors.AnyAsync(us => us.UserId == userId && us.SensorId == sensor.Id);
             if (!alreadyClaimed)
             {
-                _context.UserSensors.Add(new UserSensor { UserId = userId!, SensorId = sensor.Id });
+                _context.UserSensors.Add(new UserSensor { UserId = userId!, SensorId = sensor.Id, IsOwner = true });
                 await _context.SaveChangesAsync();
                 _logger.LogInformation("ClaimSensor assigned sensor to user {@LogData}", new { sensor.Id, User = User.Identity?.Name });
             }

--- a/Controllers/SensorController.cs
+++ b/Controllers/SensorController.cs
@@ -18,6 +18,7 @@ namespace garge_api.Controllers
     [Route("api/sensors")]
     [EnableCors("AllowAllOrigins")]
     [Authorize]
+    [Authorize(Policy = "ActiveSubscription")]
     public class SensorController : ControllerBase
     {
         private readonly ApplicationDbContext _context;

--- a/Controllers/SettingsController.cs
+++ b/Controllers/SettingsController.cs
@@ -1,0 +1,32 @@
+using AutoMapper;
+using garge_api.Dtos.Admin;
+using garge_api.Models;
+using garge_api.Models.Admin;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace garge_api.Controllers
+{
+    [ApiController]
+    [Route("api/settings")]
+    public class SettingsController : ControllerBase
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly IMapper _mapper;
+
+        public SettingsController(ApplicationDbContext context, IMapper mapper)
+        {
+            _context = context;
+            _mapper = mapper;
+        }
+
+        /// <summary>Returns public-facing app settings including company info.</summary>
+        [HttpGet]
+        [AllowAnonymous]
+        public async Task<IActionResult> GetPublicSettings()
+        {
+            var settings = await _context.AppSettings.FindAsync(1) ?? new AppSettings();
+            return Ok(_mapper.Map<PublicSettingsDto>(settings));
+        }
+    }
+}

--- a/Controllers/ShopController.cs
+++ b/Controllers/ShopController.cs
@@ -1,0 +1,336 @@
+using AutoMapper;
+using garge_api.Dtos.Shop;
+using garge_api.Models;
+using garge_api.Models.Shop;
+using garge_api.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
+using System.Text.Json;
+
+namespace garge_api.Controllers
+{
+    [ApiController]
+    [Route("api/shop")]
+    public class ShopController : VippsWebhookControllerBase
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly IVippsService _vipps;
+        private readonly IInvoiceService _invoice;
+        private readonly IMapper _mapper;
+        private readonly ILogger<ShopController> _logger;
+
+        public ShopController(
+            ApplicationDbContext context,
+            IVippsService vipps,
+            IInvoiceService invoice,
+            IMapper mapper,
+            ILogger<ShopController> logger)
+        {
+            _context = context;
+            _vipps = vipps;
+            _invoice = invoice;
+            _mapper = mapper;
+            _logger = logger;
+        }
+
+        /// <summary>Lists all active shop items.</summary>
+        [HttpGet("items")]
+        [AllowAnonymous]
+        public async Task<IActionResult> GetItems()
+        {
+            var items = await _context.ShopItems
+                .Where(i => i.IsActive)
+                .OrderBy(i => i.PriceInOre)
+                .ToListAsync();
+
+            return Ok(_mapper.Map<List<ShopItemResponseDto>>(items));
+        }
+
+        /// <summary>Gets a shop item by ID.</summary>
+        [HttpGet("items/{id}")]
+        [AllowAnonymous]
+        public async Task<IActionResult> GetItem(int id)
+        {
+            var item = await _context.ShopItems.FindAsync(id);
+            if (item == null) return NotFound();
+            return Ok(_mapper.Map<ShopItemResponseDto>(item));
+        }
+
+        /// <summary>Creates a new shop item.</summary>
+        [HttpPost("items")]
+        [Authorize(Policy = "Admin")]
+        public async Task<IActionResult> CreateItem([FromBody] CreateShopItemDto dto)
+        {
+            var item = _mapper.Map<ShopItem>(dto);
+            _context.ShopItems.Add(item);
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("ShopItem {ItemId} created: {Name}", item.Id, item.Name);
+            return CreatedAtAction(nameof(GetItem), new { id = item.Id },
+                _mapper.Map<ShopItemResponseDto>(item));
+        }
+
+        /// <summary>Updates an existing shop item.</summary>
+        [HttpPut("items/{id}")]
+        [Authorize(Policy = "Admin")]
+        public async Task<IActionResult> UpdateItem(int id, [FromBody] UpdateShopItemDto dto)
+        {
+            var item = await _context.ShopItems.FindAsync(id);
+            if (item == null) return NotFound();
+
+            _mapper.Map(dto, item);
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("ShopItem {ItemId} updated", id);
+            return Ok(_mapper.Map<ShopItemResponseDto>(item));
+        }
+
+        /// <summary>Soft-deletes a shop item (sets IsActive = false).</summary>
+        [HttpDelete("items/{id}")]
+        [Authorize(Policy = "Admin")]
+        public async Task<IActionResult> DeleteItem(int id)
+        {
+            var item = await _context.ShopItems.FindAsync(id);
+            if (item == null) return NotFound();
+
+            item.IsActive = false;
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("ShopItem {ItemId} deactivated", id);
+            return NoContent();
+        }
+
+        /// <summary>Creates a Vipps payment for a sensor purchase.</summary>
+        [HttpPost("checkout")]
+        [Authorize]
+        public async Task<IActionResult> Checkout([FromBody] CreateOrderDto dto)
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+
+            var shopItemIds = dto.Items.Select(i => i.ShopItemId).Distinct().ToList();
+            var shopItems = await _context.ShopItems
+                .Where(i => shopItemIds.Contains(i.Id))
+                .ToDictionaryAsync(i => i.Id);
+
+            foreach (var line in dto.Items)
+            {
+                if (!shopItems.TryGetValue(line.ShopItemId, out var shopItem) || !shopItem.IsActive)
+                    return BadRequest($"ShopItem {line.ShopItemId} not found or inactive.");
+
+                if (shopItem.StockCount != -1 && shopItem.StockCount < line.Quantity)
+                    return BadRequest($"Insufficient stock for {shopItem.Name}.");
+            }
+
+            var settings = await _context.AppSettings.FindAsync(1);
+            var vatMultiplier = (settings?.VatEnabled ?? false) ? 1.25 : 1.0;
+
+            var taxPct = (settings?.VatEnabled ?? false) ? 25 : 0;
+            var itemPrices = dto.Items.ToDictionary(
+                line => line.ShopItemId,
+                line => (int)(shopItems[line.ShopItemId].PriceInOre * vatMultiplier));
+            var total = dto.Items.Sum(line => itemPrices[line.ShopItemId] * line.Quantity);
+
+            var order = new Order
+            {
+                UserId = userId,
+                TotalInOre = total,
+                Status = OrderStatus.Pending,
+                ShippingAddress = dto.ShippingAddress
+            };
+            _context.Orders.Add(order);
+            await _context.SaveChangesAsync();
+
+            var orderItems = dto.Items.Select(line => new OrderItem
+            {
+                OrderId = order.Id,
+                ShopItemId = line.ShopItemId,
+                Quantity = line.Quantity,
+                PriceAtPurchaseInOre = itemPrices[line.ShopItemId],
+                UnitPriceExclVatInOre = shopItems[line.ShopItemId].PriceInOre,
+                VatPercentage = taxPct
+            }).ToList();
+
+            var receiptLines = dto.Items.Select(line => new VippsOrderLine
+            {
+                Name = shopItems[line.ShopItemId].Name,
+                Id = line.ShopItemId.ToString(),
+                UnitPriceInOre = itemPrices[line.ShopItemId],
+                UnitPriceExclVatInOre = shopItems[line.ShopItemId].PriceInOre,
+                Quantity = line.Quantity,
+                TaxPercentage = taxPct
+            }).ToList();
+
+            var vippsResponse = await _vipps.CreatePaymentAsync(order, receiptLines, dto.RedirectUrl, dto.PhoneNumber);
+
+            order.VippsOrderId = vippsResponse.Reference;
+            _context.OrderItems.AddRange(orderItems);
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("Order {OrderId} created for user {UserId}, total {Total}øre",
+                order.Id, userId, total);
+
+            return Ok(new CheckoutResponseDto
+            {
+                OrderId = order.Id,
+                RedirectUrl = vippsResponse.RedirectUrl
+            });
+        }
+
+        /// <summary>Returns the current user's order history.</summary>
+        [HttpGet("orders/my")]
+        [Authorize]
+        public async Task<IActionResult> GetMyOrders()
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+
+            var orders = await _context.Orders
+                .Include(o => o.OrderItems).ThenInclude(oi => oi.ShopItem)
+                .Include(o => o.Invoice)
+                .Where(o => o.UserId == userId)
+                .OrderByDescending(o => o.CreatedAt)
+                .ToListAsync();
+
+            return Ok(_mapper.Map<List<OrderResponseDto>>(orders));
+        }
+
+        /// <summary>Returns all orders for admin review.</summary>
+        [HttpGet("orders")]
+        [Authorize(Policy = "Admin")]
+        public async Task<IActionResult> GetOrders()
+        {
+            var orders = await _context.Orders
+                .Include(o => o.OrderItems).ThenInclude(oi => oi.ShopItem)
+                .Include(o => o.User)
+                .Include(o => o.Invoice)
+                .OrderByDescending(o => o.CreatedAt)
+                .ToListAsync();
+
+            return Ok(_mapper.Map<List<AdminOrderResponseDto>>(orders));
+        }
+
+        /// <summary>Captures a reserved Vipps payment after shipping and generates invoice.</summary>
+        [HttpPost("orders/{id}/capture")]
+        [Authorize(Policy = "Admin")]
+        public async Task<IActionResult> CaptureOrder(int id)
+        {
+            var order = await _context.Orders.FindAsync(id);
+            if (order == null) return NotFound();
+            if (order.Status != OrderStatus.Reserved)
+                return BadRequest("Order is not in Reserved state.");
+            if (string.IsNullOrEmpty(order.VippsOrderId))
+                return BadRequest("No Vipps reference found.");
+
+            await _vipps.CapturePaymentAsync(order.VippsOrderId, order.TotalInOre);
+
+            order.Status = OrderStatus.Paid;
+            order.ShippedAt = DateTime.UtcNow;
+            order.UpdatedAt = DateTime.UtcNow;
+            await _context.SaveChangesAsync();
+
+            try { await _invoice.GenerateAndStoreAsync(id); }
+            catch (Exception ex) { _logger.LogError(ex, "Invoice generation failed for order {OrderId}", id); }
+
+            _logger.LogInformation("Order {OrderId} captured by admin", id);
+            return Ok();
+        }
+
+        /// <summary>Returns PDF invoice for an order (admin or order owner).</summary>
+        [HttpGet("orders/{id}/invoice")]
+        [Authorize]
+        public async Task<IActionResult> GetInvoicePdf(int id)
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+            var isAdmin = User.IsInRole("Admin");
+
+            var invoice = await _context.Invoices
+                .Include(i => i.Order)
+                .FirstOrDefaultAsync(i => i.OrderId == id);
+
+            if (invoice == null) return NotFound("Invoice not yet available.");
+            if (!isAdmin && invoice.Order?.UserId != userId) return Forbid();
+
+            return File(invoice.PdfData, "application/pdf",
+                $"invoice-{invoice.Id:D4}.pdf");
+        }
+
+        /// <summary>Cancels a reserved Vipps payment.</summary>
+        [HttpPost("orders/{id}/cancel")]
+        [Authorize(Policy = "Admin")]
+        public async Task<IActionResult> CancelOrder(int id)
+        {
+            var order = await _context.Orders.FindAsync(id);
+            if (order == null) return NotFound();
+            if (order.Status != OrderStatus.Reserved)
+                return BadRequest("Order is not in Reserved state.");
+            if (string.IsNullOrEmpty(order.VippsOrderId))
+                return BadRequest("No Vipps reference found.");
+
+            await _vipps.CancelPaymentAsync(order.VippsOrderId);
+
+            order.Status = OrderStatus.Cancelled;
+            order.UpdatedAt = DateTime.UtcNow;
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("Order {OrderId} cancelled by admin", id);
+            return Ok();
+        }
+
+        /// <summary>Webhook endpoint for Vipps ePayment status changes.</summary>
+        [HttpPost("webhook")]
+        [AllowAnonymous]
+        public async Task<IActionResult> Webhook()
+        {
+            var rawBody = await ReadRawBodyAsync(Request);
+
+            var signature = Request.Headers["X-Vipps-Signature"].FirstOrDefault() ?? string.Empty;
+            var settings = await _context.AppSettings.FindAsync(1);
+            var secret = settings?.VippsShopWebhookSecret ?? string.Empty;
+            if (!_vipps.VerifyWebhookSignature(rawBody, signature, secret))
+            {
+                _logger.LogWarning("Shop webhook HMAC verification failed");
+                return Unauthorized();
+            }
+
+            VippsPaymentWebhookDto? payload;
+            try
+            {
+                payload = JsonSerializer.Deserialize<VippsPaymentWebhookDto>(rawBody, JsonOpts);
+            }
+            catch
+            {
+                return BadRequest();
+            }
+
+            if (payload == null) return BadRequest();
+
+            if (!int.TryParse(payload.Reference, out var orderId))
+            {
+                _logger.LogWarning("Shop webhook: non-integer reference {Reference}", payload.Reference);
+                return Ok();
+            }
+
+            var order = await _context.Orders.FindAsync(orderId);
+            if (order == null)
+            {
+                _logger.LogWarning("Shop webhook: unknown order {OrderId}", orderId);
+                return Ok();
+            }
+
+            order.Status = payload.Name switch
+            {
+                "AUTHORIZED" => OrderStatus.Reserved,
+                "TERMINATED" => OrderStatus.Failed,
+                "REFUNDED"   => OrderStatus.Refunded,
+                _            => order.Status
+            };
+
+            order.UpdatedAt = DateTime.UtcNow;
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("Shop webhook: order {OrderId} -> {Status}", orderId, payload.Name);
+            return Ok();
+        }
+    }
+}

--- a/Controllers/ShopController.cs
+++ b/Controllers/ShopController.cs
@@ -356,19 +356,12 @@ namespace garge_api.Controllers
                 return Ok();
             }
 
-            if (!int.TryParse(payload.Reference, out var orderId))
-            {
-                _logger.LogWarning("Shop webhook: non-integer reference {Reference}", payload.Reference);
-                await _context.SaveChangesAsync();
-                return Ok();
-            }
-
             var order = await _context.Orders
                 .Include(o => o.OrderItems)
-                .FirstOrDefaultAsync(o => o.Id == orderId);
+                .FirstOrDefaultAsync(o => o.VippsOrderId == payload.Reference);
             if (order == null)
             {
-                _logger.LogWarning("Shop webhook: unknown order {OrderId}", orderId);
+                _logger.LogWarning("Shop webhook: unknown reference {Reference}", payload.Reference);
                 await _context.SaveChangesAsync();
                 return Ok();
             }
@@ -377,7 +370,7 @@ namespace garge_api.Controllers
             if (!string.IsNullOrEmpty(payload.Msn) && !string.IsNullOrEmpty(expectedMsn) && payload.Msn != expectedMsn)
             {
                 _logger.LogWarning("Shop webhook: MSN mismatch (got {Got}, expected {Expected}) for order {OrderId}",
-                    payload.Msn, expectedMsn, orderId);
+                    payload.Msn, expectedMsn, order.Id);
                 return Unauthorized();
             }
 
@@ -385,7 +378,7 @@ namespace garge_api.Controllers
                 payload.Name is "AUTHORIZED" or "CAPTURED")
             {
                 _logger.LogWarning("Shop webhook: amount mismatch (got {Got}, expected {Expected}) for order {OrderId}",
-                    payload.Amount.Value, order.TotalInOre, orderId);
+                    payload.Amount.Value, order.TotalInOre, order.Id);
                 return Unauthorized();
             }
 
@@ -415,7 +408,7 @@ namespace garge_api.Controllers
                     break;
                 default:
                     _logger.LogWarning("Shop webhook: unknown event {Name} for order {OrderId}",
-                        payload.Name, orderId);
+                        payload.Name, order.Id);
                     break;
             }
 
@@ -443,7 +436,7 @@ namespace garge_api.Controllers
                     $"Order #{order.Id} is reserved. We'll capture payment when it ships.");
             }
 
-            _logger.LogInformation("Shop webhook: order {OrderId} -> {Status}", orderId, payload.Name);
+            _logger.LogInformation("Shop webhook: order {OrderId} -> {Status}", order.Id, payload.Name);
             return Ok();
         }
 

--- a/Controllers/ShopController.cs
+++ b/Controllers/ShopController.cs
@@ -137,7 +137,8 @@ namespace garge_api.Controllers
                 UserId = userId,
                 TotalInOre = total,
                 Status = OrderStatus.Pending,
-                ShippingAddress = dto.ShippingAddress
+                ShippingAddress = dto.ShippingAddress,
+                IsTest = settings?.VippsTestMode ?? false
             };
             _context.Orders.Add(order);
             await _context.SaveChangesAsync();

--- a/Controllers/ShopController.cs
+++ b/Controllers/ShopController.cs
@@ -1,11 +1,14 @@
 using AutoMapper;
+using garge_api.Constants;
 using garge_api.Dtos.Shop;
+using garge_api.Helpers;
 using garge_api.Models;
 using garge_api.Models.Shop;
 using garge_api.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using System.Security.Claims;
 using System.Text.Json;
 
@@ -18,6 +21,11 @@ namespace garge_api.Controllers
         private readonly ApplicationDbContext _context;
         private readonly IVippsService _vipps;
         private readonly IInvoiceService _invoice;
+        private readonly IAppSettingsCache _settingsCache;
+        private readonly IWebhookSecretProtector _protector;
+        private readonly IWebPushService _push;
+        private readonly VippsOptions _vippsOpts;
+        private readonly AppOptions _appOpts;
         private readonly IMapper _mapper;
         private readonly ILogger<ShopController> _logger;
 
@@ -25,17 +33,26 @@ namespace garge_api.Controllers
             ApplicationDbContext context,
             IVippsService vipps,
             IInvoiceService invoice,
+            IAppSettingsCache settingsCache,
+            IWebhookSecretProtector protector,
+            IWebPushService push,
+            IOptions<VippsOptions> vippsOpts,
+            IOptions<AppOptions> appOpts,
             IMapper mapper,
             ILogger<ShopController> logger)
         {
             _context = context;
             _vipps = vipps;
             _invoice = invoice;
+            _settingsCache = settingsCache;
+            _protector = protector;
+            _push = push;
+            _vippsOpts = vippsOpts.Value;
+            _appOpts = appOpts.Value;
             _mapper = mapper;
             _logger = logger;
         }
 
-        /// <summary>Lists all active shop items.</summary>
         [HttpGet("items")]
         [AllowAnonymous]
         public async Task<IActionResult> GetItems()
@@ -48,7 +65,6 @@ namespace garge_api.Controllers
             return Ok(_mapper.Map<List<ShopItemResponseDto>>(items));
         }
 
-        /// <summary>Gets a shop item by ID.</summary>
         [HttpGet("items/{id}")]
         [AllowAnonymous]
         public async Task<IActionResult> GetItem(int id)
@@ -58,7 +74,6 @@ namespace garge_api.Controllers
             return Ok(_mapper.Map<ShopItemResponseDto>(item));
         }
 
-        /// <summary>Creates a new shop item.</summary>
         [HttpPost("items")]
         [Authorize(Policy = "Admin")]
         public async Task<IActionResult> CreateItem([FromBody] CreateShopItemDto dto)
@@ -72,7 +87,6 @@ namespace garge_api.Controllers
                 _mapper.Map<ShopItemResponseDto>(item));
         }
 
-        /// <summary>Updates an existing shop item.</summary>
         [HttpPut("items/{id}")]
         [Authorize(Policy = "Admin")]
         public async Task<IActionResult> UpdateItem(int id, [FromBody] UpdateShopItemDto dto)
@@ -87,7 +101,6 @@ namespace garge_api.Controllers
             return Ok(_mapper.Map<ShopItemResponseDto>(item));
         }
 
-        /// <summary>Soft-deletes a shop item (sets IsActive = false).</summary>
         [HttpDelete("items/{id}")]
         [Authorize(Policy = "Admin")]
         public async Task<IActionResult> DeleteItem(int id)
@@ -102,14 +115,19 @@ namespace garge_api.Controllers
             return NoContent();
         }
 
-        /// <summary>Creates a Vipps payment for a sensor purchase.</summary>
         [HttpPost("checkout")]
         [Authorize]
         public async Task<IActionResult> Checkout([FromBody] CreateOrderDto dto)
         {
             var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
 
+            if (!PhoneNumber.TryNormalizeNo(dto.PhoneNumber, out var msisdn))
+                return BadRequest("Invalid Norwegian phone number.");
+
             var shopItemIds = dto.Items.Select(i => i.ShopItemId).Distinct().ToList();
+
+            await using var tx = await _context.Database.BeginTransactionAsync();
+
             var shopItems = await _context.ShopItems
                 .Where(i => shopItemIds.Contains(i.Id))
                 .ToDictionaryAsync(i => i.Id);
@@ -123,14 +141,22 @@ namespace garge_api.Controllers
                     return BadRequest($"Insufficient stock for {shopItem.Name}.");
             }
 
-            var settings = await _context.AppSettings.FindAsync(1);
-            var vatMultiplier = (settings?.VatEnabled ?? false) ? 1.25 : 1.0;
+            var settings = await _settingsCache.GetAsync();
+            var vatEnabled = settings.VatEnabled;
+            var taxBp = vatEnabled ? Pricing.VatBasisPoints : 0;
 
-            var taxPct = (settings?.VatEnabled ?? false) ? 25 : 0;
             var itemPrices = dto.Items.ToDictionary(
                 line => line.ShopItemId,
-                line => (int)(shopItems[line.ShopItemId].PriceInOre * vatMultiplier));
+                line => Pricing.EffectiveInOre(shopItems[line.ShopItemId].PriceInOre, vatEnabled));
+
             var total = dto.Items.Sum(line => itemPrices[line.ShopItemId] * line.Quantity);
+
+            foreach (var line in dto.Items)
+            {
+                var item = shopItems[line.ShopItemId];
+                if (item.StockCount != -1)
+                    item.StockCount -= line.Quantity;
+            }
 
             var order = new Order
             {
@@ -138,7 +164,7 @@ namespace garge_api.Controllers
                 TotalInOre = total,
                 Status = OrderStatus.Pending,
                 ShippingAddress = dto.ShippingAddress,
-                IsTest = settings?.VippsTestMode ?? false
+                IsTest = settings.VippsTestMode
             };
             _context.Orders.Add(order);
             await _context.SaveChangesAsync();
@@ -150,8 +176,10 @@ namespace garge_api.Controllers
                 Quantity = line.Quantity,
                 PriceAtPurchaseInOre = itemPrices[line.ShopItemId],
                 UnitPriceExclVatInOre = shopItems[line.ShopItemId].PriceInOre,
-                VatPercentage = taxPct
+                VatPercentage = vatEnabled ? Pricing.VatPercent : 0
             }).ToList();
+            _context.OrderItems.AddRange(orderItems);
+            await _context.SaveChangesAsync();
 
             var receiptLines = dto.Items.Select(line => new VippsOrderLine
             {
@@ -160,26 +188,37 @@ namespace garge_api.Controllers
                 UnitPriceInOre = itemPrices[line.ShopItemId],
                 UnitPriceExclVatInOre = shopItems[line.ShopItemId].PriceInOre,
                 Quantity = line.Quantity,
-                TaxPercentage = taxPct
+                TaxPercentageBasisPoints = taxBp
             }).ToList();
 
-            var vippsResponse = await _vipps.CreatePaymentAsync(order, receiptLines, dto.RedirectUrl, dto.PhoneNumber);
+            var redirectUrl = $"{_appOpts.FrontendBaseUrl}/shop/return";
 
-            order.VippsOrderId = vippsResponse.Reference;
-            _context.OrderItems.AddRange(orderItems);
-            await _context.SaveChangesAsync();
-
-            _logger.LogInformation("Order {OrderId} created for user {UserId}, total {Total}øre",
-                order.Id, userId, total);
-
-            return Ok(new CheckoutResponseDto
+            try
             {
-                OrderId = order.Id,
-                RedirectUrl = vippsResponse.RedirectUrl
-            });
+                var vippsResponse = await _vipps.CreatePaymentAsync(
+                    order, receiptLines, redirectUrl, msisdn, $"order-{order.Id}");
+
+                order.VippsOrderId = vippsResponse.Reference;
+                await _context.SaveChangesAsync();
+                await tx.CommitAsync();
+
+                _logger.LogInformation("Order {OrderId} created for user {UserId}, total {Total}øre",
+                    order.Id, userId, total);
+
+                return Ok(new CheckoutResponseDto
+                {
+                    OrderId = order.Id,
+                    RedirectUrl = vippsResponse.RedirectUrl
+                });
+            }
+            catch (Exception ex)
+            {
+                await tx.RollbackAsync();
+                _logger.LogError(ex, "Vipps payment creation failed for user {UserId}", userId);
+                return StatusCode(502, "Payment provider unavailable.");
+            }
         }
 
-        /// <summary>Returns the current user's order history.</summary>
         [HttpGet("orders/my")]
         [Authorize]
         public async Task<IActionResult> GetMyOrders()
@@ -196,7 +235,6 @@ namespace garge_api.Controllers
             return Ok(_mapper.Map<List<OrderResponseDto>>(orders));
         }
 
-        /// <summary>Returns all orders for admin review.</summary>
         [HttpGet("orders")]
         [Authorize(Policy = "Admin")]
         public async Task<IActionResult> GetOrders()
@@ -211,7 +249,6 @@ namespace garge_api.Controllers
             return Ok(_mapper.Map<List<AdminOrderResponseDto>>(orders));
         }
 
-        /// <summary>Captures a reserved Vipps payment after shipping and generates invoice.</summary>
         [HttpPost("orders/{id}/capture")]
         [Authorize(Policy = "Admin")]
         public async Task<IActionResult> CaptureOrder(int id)
@@ -223,7 +260,7 @@ namespace garge_api.Controllers
             if (string.IsNullOrEmpty(order.VippsOrderId))
                 return BadRequest("No Vipps reference found.");
 
-            await _vipps.CapturePaymentAsync(order.VippsOrderId, order.TotalInOre);
+            await _vipps.CapturePaymentAsync(order.VippsOrderId, order.TotalInOre, $"capture-{order.Id}");
 
             order.Status = OrderStatus.Paid;
             order.ShippedAt = DateTime.UtcNow;
@@ -233,11 +270,13 @@ namespace garge_api.Controllers
             try { await _invoice.GenerateAndStoreAsync(id); }
             catch (Exception ex) { _logger.LogError(ex, "Invoice generation failed for order {OrderId}", id); }
 
+            _ = SafePushAsync(order.UserId, "Payment captured",
+                $"Order #{order.Id} is paid. Invoice sent to your email.");
+
             _logger.LogInformation("Order {OrderId} captured by admin", id);
             return Ok();
         }
 
-        /// <summary>Returns PDF invoice for an order (admin or order owner).</summary>
         [HttpGet("orders/{id}/invoice")]
         [Authorize]
         public async Task<IActionResult> GetInvoicePdf(int id)
@@ -256,20 +295,22 @@ namespace garge_api.Controllers
                 $"invoice-{invoice.Id:D4}.pdf");
         }
 
-        /// <summary>Cancels a reserved Vipps payment.</summary>
         [HttpPost("orders/{id}/cancel")]
         [Authorize(Policy = "Admin")]
         public async Task<IActionResult> CancelOrder(int id)
         {
-            var order = await _context.Orders.FindAsync(id);
+            var order = await _context.Orders
+                .Include(o => o.OrderItems)
+                .FirstOrDefaultAsync(o => o.Id == id);
             if (order == null) return NotFound();
             if (order.Status != OrderStatus.Reserved)
                 return BadRequest("Order is not in Reserved state.");
             if (string.IsNullOrEmpty(order.VippsOrderId))
                 return BadRequest("No Vipps reference found.");
 
-            await _vipps.CancelPaymentAsync(order.VippsOrderId);
+            await _vipps.CancelPaymentAsync(order.VippsOrderId, $"cancel-{order.Id}");
 
+            await RestoreStockAsync(order);
             order.Status = OrderStatus.Cancelled;
             order.UpdatedAt = DateTime.UtcNow;
             await _context.SaveChangesAsync();
@@ -278,19 +319,18 @@ namespace garge_api.Controllers
             return Ok();
         }
 
-        /// <summary>Webhook endpoint for Vipps ePayment status changes.</summary>
         [HttpPost("webhook")]
         [AllowAnonymous]
         public async Task<IActionResult> Webhook()
         {
             var rawBody = await ReadRawBodyAsync(Request);
+            var settings = await _settingsCache.GetAsync();
+            var secret = _protector.Unprotect(settings.VippsShopWebhookSecret ?? string.Empty);
 
-            var signature = Request.Headers["X-Vipps-Signature"].FirstOrDefault() ?? string.Empty;
-            var settings = await _context.AppSettings.FindAsync(1);
-            var secret = settings?.VippsShopWebhookSecret ?? string.Empty;
-            if (!_vipps.VerifyWebhookSignature(rawBody, signature, secret))
+            var verify = _vipps.VerifyWebhookSignature(Request, rawBody, secret);
+            if (verify != WebhookVerifyResult.Valid)
             {
-                _logger.LogWarning("Shop webhook HMAC verification failed");
+                _logger.LogWarning("Shop webhook verify failed: {Reason}", verify);
                 return Unauthorized();
             }
 
@@ -306,32 +346,123 @@ namespace garge_api.Controllers
 
             if (payload == null) return BadRequest();
 
+            var eventId = !string.IsNullOrEmpty(payload.PspReference)
+                ? payload.PspReference
+                : $"{payload.Reference}:{payload.Name}";
+
+            if (!await TryRecordEventAsync(_context, "shop", eventId))
+            {
+                _logger.LogInformation("Shop webhook duplicate {EventId} skipped", eventId);
+                return Ok();
+            }
+
             if (!int.TryParse(payload.Reference, out var orderId))
             {
                 _logger.LogWarning("Shop webhook: non-integer reference {Reference}", payload.Reference);
+                await _context.SaveChangesAsync();
                 return Ok();
             }
 
-            var order = await _context.Orders.FindAsync(orderId);
+            var order = await _context.Orders
+                .Include(o => o.OrderItems)
+                .FirstOrDefaultAsync(o => o.Id == orderId);
             if (order == null)
             {
                 _logger.LogWarning("Shop webhook: unknown order {OrderId}", orderId);
+                await _context.SaveChangesAsync();
                 return Ok();
             }
 
-            order.Status = payload.Name switch
+            var expectedMsn = order.IsTest ? _vippsOpts.TestMerchantSerialNumber : _vippsOpts.MerchantSerialNumber;
+            if (!string.IsNullOrEmpty(payload.Msn) && !string.IsNullOrEmpty(expectedMsn) && payload.Msn != expectedMsn)
             {
-                "AUTHORIZED" => OrderStatus.Reserved,
-                "TERMINATED" => OrderStatus.Failed,
-                "REFUNDED"   => OrderStatus.Refunded,
-                _            => order.Status
-            };
+                _logger.LogWarning("Shop webhook: MSN mismatch (got {Got}, expected {Expected}) for order {OrderId}",
+                    payload.Msn, expectedMsn, orderId);
+                return Unauthorized();
+            }
+
+            if (payload.Amount != null && payload.Amount.Value != order.TotalInOre &&
+                payload.Name is "AUTHORIZED" or "CAPTURED")
+            {
+                _logger.LogWarning("Shop webhook: amount mismatch (got {Got}, expected {Expected}) for order {OrderId}",
+                    payload.Amount.Value, order.TotalInOre, orderId);
+                return Unauthorized();
+            }
+
+            var prevStatus = order.Status;
+
+            switch (payload.Name)
+            {
+                case "AUTHORIZED":
+                    order.Status = OrderStatus.Reserved;
+                    break;
+                case "CAPTURED":
+                    order.Status = OrderStatus.Paid;
+                    if (order.ShippedAt == null) order.ShippedAt = DateTime.UtcNow;
+                    break;
+                case "REFUNDED":
+                    order.Status = OrderStatus.Refunded;
+                    break;
+                case "ABORTED":
+                case "EXPIRED":
+                case "TERMINATED":
+                    order.Status = OrderStatus.Failed;
+                    break;
+                case "CANCELLED":
+                    order.Status = OrderStatus.Cancelled;
+                    break;
+                case "CREATED":
+                    break;
+                default:
+                    _logger.LogWarning("Shop webhook: unknown event {Name} for order {OrderId}",
+                        payload.Name, orderId);
+                    break;
+            }
 
             order.UpdatedAt = DateTime.UtcNow;
+
+            if (prevStatus == OrderStatus.Reserved &&
+                order.Status is OrderStatus.Failed or OrderStatus.Cancelled)
+            {
+                await RestoreStockAsync(order);
+            }
+
             await _context.SaveChangesAsync();
+
+            if (prevStatus != OrderStatus.Paid && order.Status == OrderStatus.Paid)
+            {
+                try { await _invoice.GenerateAndStoreAsync(order.Id); }
+                catch (Exception ex) { _logger.LogError(ex, "Invoice generation failed for order {OrderId}", order.Id); }
+
+                _ = SafePushAsync(order.UserId, "Payment captured",
+                    $"Order #{order.Id} is paid. Invoice on its way to your email.");
+            }
+            else if (prevStatus != OrderStatus.Reserved && order.Status == OrderStatus.Reserved)
+            {
+                _ = SafePushAsync(order.UserId, "Order reserved",
+                    $"Order #{order.Id} is reserved. We'll capture payment when it ships.");
+            }
 
             _logger.LogInformation("Shop webhook: order {OrderId} -> {Status}", orderId, payload.Name);
             return Ok();
+        }
+
+        private async Task SafePushAsync(string userId, string title, string body)
+        {
+            try { await _push.SendAsync(userId, title, body); }
+            catch (Exception ex) { _logger.LogWarning(ex, "Push send failed for user {UserId}", userId); }
+        }
+
+        private async Task RestoreStockAsync(Order order)
+        {
+            var ids = order.OrderItems.Select(oi => oi.ShopItemId).ToList();
+            var items = await _context.ShopItems.Where(i => ids.Contains(i.Id)).ToListAsync();
+            var byId = items.ToDictionary(i => i.Id);
+            foreach (var oi in order.OrderItems)
+            {
+                if (byId.TryGetValue(oi.ShopItemId, out var item) && item.StockCount != -1)
+                    item.StockCount += oi.Quantity;
+            }
         }
     }
 }

--- a/Controllers/SubscriptionsController.cs
+++ b/Controllers/SubscriptionsController.cs
@@ -1,0 +1,184 @@
+using AutoMapper;
+using garge_api.Dtos.Subscription;
+using garge_api.Models;
+using garge_api.Models.Subscription;
+using garge_api.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
+using System.Text.Json;
+
+namespace garge_api.Controllers
+{
+    [ApiController]
+    [Route("api/subscriptions")]
+    [Authorize]
+    public class SubscriptionsController : VippsWebhookControllerBase
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly IVippsService _vipps;
+        private readonly IMapper _mapper;
+        private readonly ILogger<SubscriptionsController> _logger;
+
+        public SubscriptionsController(
+            ApplicationDbContext context,
+            IVippsService vipps,
+            IMapper mapper,
+            ILogger<SubscriptionsController> logger)
+        {
+            _context = context;
+            _vipps = vipps;
+            _mapper = mapper;
+            _logger = logger;
+        }
+
+        /// <summary>Returns the current user's active or pending subscription.</summary>
+        [HttpGet("my")]
+        public async Task<IActionResult> GetMySubscription()
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+
+            var subscription = await _context.Subscriptions
+                .Include(s => s.Product)
+                .Where(s => s.UserId == userId &&
+                            s.Status != SubscriptionStatus.Stopped &&
+                            s.Status != SubscriptionStatus.Expired)
+                .FirstOrDefaultAsync();
+
+            if (subscription == null) return NoContent();
+            return Ok(_mapper.Map<SubscriptionResponseDto>(subscription));
+        }
+
+        /// <summary>Initiates a Vipps subscription agreement and returns the confirmation URL.</summary>
+        [HttpPost("initiate")]
+        public async Task<IActionResult> InitiateSubscription([FromBody] InitiateSubscriptionDto dto)
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+
+            var product = await _context.Products.FindAsync(dto.ProductId);
+            if (product == null || !product.IsActive)
+                return BadRequest("Product not found or inactive.");
+
+            var existing = await _context.Subscriptions.AnyAsync(s =>
+                s.UserId == userId &&
+                (s.Status == SubscriptionStatus.Active || s.Status == SubscriptionStatus.Pending));
+
+            if (existing)
+                return Conflict("User already has an active or pending subscription.");
+
+            var settings = await _context.AppSettings.FindAsync(1);
+            var effectivePriceInOre = (settings?.VatEnabled ?? false)
+                ? (int)(product.PriceInOre * 1.25)
+                : product.PriceInOre;
+
+            var vippsResponse = await _vipps.CreateAgreementAsync(
+                product, userId, dto.RedirectUrl, dto.PhoneNumber, effectivePriceInOre);
+
+            var subscription = new Subscription
+            {
+                UserId = userId,
+                ProductId = dto.ProductId,
+                VippsAgreementId = vippsResponse.AgreementId,
+                Status = SubscriptionStatus.Pending,
+                ConsentAcceptedAt = DateTime.UtcNow,
+                ConsentIp = HttpContext.Connection.RemoteIpAddress?.ToString()
+            };
+
+            _context.Subscriptions.Add(subscription);
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("Subscription {SubscriptionId} initiated for user {UserId}",
+                subscription.Id, userId);
+
+            return Ok(new InitiateSubscriptionResponseDto
+            {
+                SubscriptionId = subscription.Id,
+                VippsAgreementId = vippsResponse.AgreementId,
+                VippsConfirmationUrl = vippsResponse.VippsConfirmationUrl
+            });
+        }
+
+        /// <summary>Cancels the current user's active subscription.</summary>
+        [HttpPost("cancel")]
+        public async Task<IActionResult> CancelSubscription()
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+
+            var subscription = await _context.Subscriptions
+                .Where(s => s.UserId == userId && s.Status == SubscriptionStatus.Active)
+                .FirstOrDefaultAsync();
+
+            if (subscription == null) return NotFound("No active subscription found.");
+
+            await _vipps.CancelAgreementAsync(subscription.VippsAgreementId);
+
+            subscription.Status = SubscriptionStatus.Stopped;
+            subscription.UpdatedAt = DateTime.UtcNow;
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("Subscription {SubscriptionId} cancelled for user {UserId}",
+                subscription.Id, userId);
+
+            return Ok();
+        }
+
+        /// <summary>Webhook endpoint for Vipps agreement status changes.</summary>
+        [HttpPost("webhook")]
+        [AllowAnonymous]
+        public async Task<IActionResult> Webhook()
+        {
+            var rawBody = await ReadRawBodyAsync(Request);
+
+            var signature = Request.Headers["X-Vipps-Signature"].FirstOrDefault() ?? string.Empty;
+            var settings = await _context.AppSettings.FindAsync(1);
+            var secret = settings?.VippsSubscriptionWebhookSecret ?? string.Empty;
+            if (!_vipps.VerifyWebhookSignature(rawBody, signature, secret))
+            {
+                _logger.LogWarning("Subscription webhook HMAC verification failed");
+                return Unauthorized();
+            }
+
+            VippsAgreementWebhookDto? payload;
+            try
+            {
+                payload = JsonSerializer.Deserialize<VippsAgreementWebhookDto>(rawBody, JsonOpts);
+            }
+            catch
+            {
+                return BadRequest();
+            }
+
+            if (payload == null) return BadRequest();
+
+            var subscription = await _context.Subscriptions
+                .FirstOrDefaultAsync(s => s.VippsAgreementId == payload.AgreementId);
+
+            if (subscription == null)
+            {
+                _logger.LogWarning("Webhook: unknown agreementId {AgreementId}", payload.AgreementId);
+                return Ok();
+            }
+
+            subscription.Status = payload.EventType switch
+            {
+                "recurring.agreement-activated.v1" => SubscriptionStatus.Active,
+                "recurring.agreement-stopped.v1"   => SubscriptionStatus.Stopped,
+                "recurring.agreement-expired.v1"   => SubscriptionStatus.Expired,
+                "recurring.agreement-rejected.v1"  => SubscriptionStatus.Stopped,
+                _                                  => subscription.Status
+            };
+
+            if (subscription.Status == SubscriptionStatus.Active && subscription.StartDate == null)
+                subscription.StartDate = payload.Occurred ?? DateTime.UtcNow;
+
+            subscription.UpdatedAt = DateTime.UtcNow;
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("Webhook: agreement {AgreementId} -> {EventType}",
+                payload.AgreementId, payload.EventType);
+
+            return Ok();
+        }
+    }
+}

--- a/Controllers/SubscriptionsController.cs
+++ b/Controllers/SubscriptionsController.cs
@@ -81,6 +81,7 @@ namespace garge_api.Controllers
                 ProductId = dto.ProductId,
                 VippsAgreementId = vippsResponse.AgreementId,
                 Status = SubscriptionStatus.Pending,
+                IsTest = settings?.VippsTestMode ?? false,
                 ConsentAcceptedAt = DateTime.UtcNow,
                 ConsentIp = HttpContext.Connection.RemoteIpAddress?.ToString()
             };

--- a/Controllers/SubscriptionsController.cs
+++ b/Controllers/SubscriptionsController.cs
@@ -1,11 +1,14 @@
 using AutoMapper;
+using garge_api.Constants;
 using garge_api.Dtos.Subscription;
+using garge_api.Helpers;
 using garge_api.Models;
 using garge_api.Models.Subscription;
 using garge_api.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using System.Security.Claims;
 using System.Text.Json;
 
@@ -18,36 +21,67 @@ namespace garge_api.Controllers
     {
         private readonly ApplicationDbContext _context;
         private readonly IVippsService _vipps;
+        private readonly IAppSettingsCache _settingsCache;
+        private readonly IWebhookSecretProtector _protector;
+        private readonly IWebPushService _push;
+        private readonly AppOptions _appOpts;
         private readonly IMapper _mapper;
         private readonly ILogger<SubscriptionsController> _logger;
 
         public SubscriptionsController(
             ApplicationDbContext context,
             IVippsService vipps,
+            IAppSettingsCache settingsCache,
+            IWebhookSecretProtector protector,
+            IWebPushService push,
+            IOptions<AppOptions> appOpts,
             IMapper mapper,
             ILogger<SubscriptionsController> logger)
         {
             _context = context;
             _vipps = vipps;
+            _settingsCache = settingsCache;
+            _protector = protector;
+            _push = push;
+            _appOpts = appOpts.Value;
             _mapper = mapper;
             _logger = logger;
         }
 
-        /// <summary>Returns the current user's active or pending subscription.</summary>
+        /// <summary>Returns the current user's subscriptions. Stopped/Expired hidden once next-charge date passed (grace period).</summary>
         [HttpGet("my")]
-        public async Task<IActionResult> GetMySubscription()
+        public async Task<IActionResult> GetMySubscriptions()
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+            var now = DateTime.UtcNow;
+
+            var subscriptions = await _context.Subscriptions
+                .Include(s => s.Product)
+                .Where(s => s.UserId == userId &&
+                            (s.Status == SubscriptionStatus.Active ||
+                             s.Status == SubscriptionStatus.Pending ||
+                             ((s.Status == SubscriptionStatus.Stopped || s.Status == SubscriptionStatus.Expired) &&
+                              s.NextChargeDate != null && s.NextChargeDate > now)))
+                .ToListAsync();
+
+            return Ok(_mapper.Map<List<SubscriptionResponseDto>>(subscriptions));
+        }
+
+        /// <summary>Returns the Vipps confirmation URL for a Pending subscription so the user can resume payment.</summary>
+        [HttpGet("{id:int}/confirmation-url")]
+        public async Task<IActionResult> GetConfirmationUrl(int id)
         {
             var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
 
             var subscription = await _context.Subscriptions
-                .Include(s => s.Product)
-                .Where(s => s.UserId == userId &&
-                            s.Status != SubscriptionStatus.Stopped &&
-                            s.Status != SubscriptionStatus.Expired)
-                .FirstOrDefaultAsync();
+                .FirstOrDefaultAsync(s => s.Id == id && s.UserId == userId);
+            if (subscription == null) return NotFound();
+            if (subscription.Status != SubscriptionStatus.Pending)
+                return BadRequest("Subscription is not pending.");
+            if (string.IsNullOrEmpty(subscription.VippsConfirmationUrl))
+                return BadRequest("No confirmation URL stored.");
 
-            if (subscription == null) return NoContent();
-            return Ok(_mapper.Map<SubscriptionResponseDto>(subscription));
+            return Ok(new { vippsConfirmationUrl = subscription.VippsConfirmationUrl });
         }
 
         /// <summary>Initiates a Vipps subscription agreement and returns the confirmation URL.</summary>
@@ -56,32 +90,49 @@ namespace garge_api.Controllers
         {
             var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
 
+            if (!dto.ConsentToWaiveWithdrawal)
+                return BadRequest("Consent to waive 14-day withdrawal right is required for immediate access.");
+
+            if (!PhoneNumber.TryNormalizeNo(dto.PhoneNumber, out var msisdn))
+                return BadRequest("Invalid Norwegian phone number.");
+
             var product = await _context.Products.FindAsync(dto.ProductId);
             if (product == null || !product.IsActive)
                 return BadRequest("Product not found or inactive.");
 
-            var existing = await _context.Subscriptions.AnyAsync(s =>
-                s.UserId == userId &&
-                (s.Status == SubscriptionStatus.Active || s.Status == SubscriptionStatus.Pending));
+            if (product.Type == ProductType.Primary)
+            {
+                var hasActivePrimary = await _context.Subscriptions
+                    .Include(s => s.Product)
+                    .AnyAsync(s => s.UserId == userId &&
+                                   s.Product!.Type == ProductType.Primary &&
+                                   (s.Status == SubscriptionStatus.Active || s.Status == SubscriptionStatus.Pending));
 
-            if (existing)
-                return Conflict("User already has an active or pending subscription.");
+                if (hasActivePrimary)
+                    return Conflict("User already has an active or pending primary subscription.");
+            }
+            else
+            {
+                var hasPrimary = await _context.Subscriptions
+                    .Include(s => s.Product)
+                    .AnyAsync(s => s.UserId == userId &&
+                                   s.Product!.Type == ProductType.Primary &&
+                                   s.Status == SubscriptionStatus.Active);
 
-            var settings = await _context.AppSettings.FindAsync(1);
-            var effectivePriceInOre = (settings?.VatEnabled ?? false)
-                ? (int)(product.PriceInOre * 1.25)
-                : product.PriceInOre;
+                if (!hasPrimary)
+                    return BadRequest("A primary subscription is required before adding an add-on.");
+            }
 
-            var vippsResponse = await _vipps.CreateAgreementAsync(
-                product, userId, dto.RedirectUrl, dto.PhoneNumber, effectivePriceInOre);
+            var settings = await _settingsCache.GetAsync();
+            var effectivePriceInOre = Pricing.EffectiveInOre(product.PriceInOre, settings.VatEnabled);
 
             var subscription = new Subscription
             {
                 UserId = userId,
                 ProductId = dto.ProductId,
-                VippsAgreementId = vippsResponse.AgreementId,
+                VippsAgreementId = string.Empty,
                 Status = SubscriptionStatus.Pending,
-                IsTest = settings?.VippsTestMode ?? false,
+                IsTest = settings.VippsTestMode,
                 ConsentAcceptedAt = DateTime.UtcNow,
                 ConsentIp = HttpContext.Connection.RemoteIpAddress?.ToString()
             };
@@ -89,33 +140,77 @@ namespace garge_api.Controllers
             _context.Subscriptions.Add(subscription);
             await _context.SaveChangesAsync();
 
-            _logger.LogInformation("Subscription {SubscriptionId} initiated for user {UserId}",
-                subscription.Id, userId);
+            var redirectUrl = $"{_appOpts.FrontendBaseUrl}/profile/billing/return";
+            var idempotencyKey = $"sub-{subscription.Id}";
 
-            return Ok(new InitiateSubscriptionResponseDto
+            try
             {
-                SubscriptionId = subscription.Id,
-                VippsAgreementId = vippsResponse.AgreementId,
-                VippsConfirmationUrl = vippsResponse.VippsConfirmationUrl
-            });
+                var vippsResponse = await _vipps.CreateAgreementAsync(
+                    product, userId, redirectUrl, msisdn, effectivePriceInOre, idempotencyKey);
+
+                subscription.VippsAgreementId = vippsResponse.AgreementId;
+                subscription.VippsConfirmationUrl = vippsResponse.VippsConfirmationUrl;
+                await _context.SaveChangesAsync();
+
+                _logger.LogInformation("Subscription {SubscriptionId} initiated for user {UserId}",
+                    subscription.Id, userId);
+
+                return Ok(new InitiateSubscriptionResponseDto
+                {
+                    SubscriptionId = subscription.Id,
+                    VippsAgreementId = vippsResponse.AgreementId,
+                    VippsConfirmationUrl = vippsResponse.VippsConfirmationUrl
+                });
+            }
+            catch (Exception ex)
+            {
+                _context.Subscriptions.Remove(subscription);
+                await _context.SaveChangesAsync();
+                _logger.LogError(ex, "Vipps agreement creation failed for user {UserId}", userId);
+                return StatusCode(502, "Payment provider unavailable.");
+            }
         }
 
-        /// <summary>Cancels the current user's active subscription.</summary>
-        [HttpPost("cancel")]
-        public async Task<IActionResult> CancelSubscription()
+        /// <summary>Cancels a specific active subscription by ID.</summary>
+        [HttpPost("cancel/{id:int}")]
+        public async Task<IActionResult> CancelSubscription(int id)
         {
             var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
 
             var subscription = await _context.Subscriptions
-                .Where(s => s.UserId == userId && s.Status == SubscriptionStatus.Active)
-                .FirstOrDefaultAsync();
+                .FirstOrDefaultAsync(s => s.Id == id && s.UserId == userId && s.Status == SubscriptionStatus.Active);
 
-            if (subscription == null) return NotFound("No active subscription found.");
+            if (subscription == null) return NotFound("Active subscription not found.");
 
-            await _vipps.CancelAgreementAsync(subscription.VippsAgreementId);
-
+            await _vipps.CancelAgreementAsync(subscription.VippsAgreementId, $"cancel-{subscription.Id}");
             subscription.Status = SubscriptionStatus.Stopped;
             subscription.UpdatedAt = DateTime.UtcNow;
+
+            var product = await _context.Products.FindAsync(subscription.ProductId);
+            if (product?.Type == ProductType.Primary)
+            {
+                var addOns = await _context.Subscriptions
+                    .Include(s => s.Product)
+                    .Where(s => s.UserId == userId &&
+                                s.Product!.Type == ProductType.AddOn &&
+                                s.Status == SubscriptionStatus.Active)
+                    .ToListAsync();
+
+                foreach (var addOn in addOns)
+                {
+                    try
+                    {
+                        await _vipps.CancelAgreementAsync(addOn.VippsAgreementId, $"cancel-{addOn.Id}");
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to cancel add-on {SubId} after primary cancel", addOn.Id);
+                    }
+                    addOn.Status = SubscriptionStatus.Stopped;
+                    addOn.UpdatedAt = DateTime.UtcNow;
+                }
+            }
+
             await _context.SaveChangesAsync();
 
             _logger.LogInformation("Subscription {SubscriptionId} cancelled for user {UserId}",
@@ -130,13 +225,13 @@ namespace garge_api.Controllers
         public async Task<IActionResult> Webhook()
         {
             var rawBody = await ReadRawBodyAsync(Request);
+            var settings = await _settingsCache.GetAsync();
+            var secret = _protector.Unprotect(settings.VippsSubscriptionWebhookSecret ?? string.Empty);
 
-            var signature = Request.Headers["X-Vipps-Signature"].FirstOrDefault() ?? string.Empty;
-            var settings = await _context.AppSettings.FindAsync(1);
-            var secret = settings?.VippsSubscriptionWebhookSecret ?? string.Empty;
-            if (!_vipps.VerifyWebhookSignature(rawBody, signature, secret))
+            var verify = _vipps.VerifyWebhookSignature(Request, rawBody, secret);
+            if (verify != WebhookVerifyResult.Valid)
             {
-                _logger.LogWarning("Subscription webhook HMAC verification failed");
+                _logger.LogWarning("Subscription webhook verify failed: {Reason}", verify);
                 return Unauthorized();
             }
 
@@ -152,26 +247,55 @@ namespace garge_api.Controllers
 
             if (payload == null) return BadRequest();
 
+            var eventId = !string.IsNullOrEmpty(payload.EventId)
+                ? payload.EventId
+                : $"{payload.AgreementId}:{payload.EventType}:{payload.Occurred?.Ticks}";
+
+            if (!await TryRecordEventAsync(_context, "subscription", eventId))
+            {
+                _logger.LogInformation("Subscription webhook duplicate {EventId} skipped", eventId);
+                return Ok();
+            }
+
             var subscription = await _context.Subscriptions
                 .FirstOrDefaultAsync(s => s.VippsAgreementId == payload.AgreementId);
 
             if (subscription == null)
             {
                 _logger.LogWarning("Webhook: unknown agreementId {AgreementId}", payload.AgreementId);
+                await _context.SaveChangesAsync();
                 return Ok();
             }
 
-            subscription.Status = payload.EventType switch
-            {
-                "recurring.agreement-activated.v1" => SubscriptionStatus.Active,
-                "recurring.agreement-stopped.v1"   => SubscriptionStatus.Stopped,
-                "recurring.agreement-expired.v1"   => SubscriptionStatus.Expired,
-                "recurring.agreement-rejected.v1"  => SubscriptionStatus.Stopped,
-                _                                  => subscription.Status
-            };
+            var wasActive = subscription.Status == SubscriptionStatus.Active;
 
-            if (subscription.Status == SubscriptionStatus.Active && subscription.StartDate == null)
-                subscription.StartDate = payload.Occurred ?? DateTime.UtcNow;
+            switch (payload.EventType)
+            {
+                case VippsEvents.AgreementActivated:
+                    subscription.Status = SubscriptionStatus.Active;
+                    if (subscription.StartDate == null)
+                        subscription.StartDate = payload.Occurred ?? DateTime.UtcNow;
+                    break;
+                case VippsEvents.AgreementStopped:
+                case VippsEvents.AgreementRejected:
+                    subscription.Status = SubscriptionStatus.Stopped;
+                    break;
+                case VippsEvents.AgreementExpired:
+                    subscription.Status = SubscriptionStatus.Expired;
+                    break;
+                case VippsEvents.ChargeCaptured when payload.Occurred.HasValue:
+                    var product = await _context.Products.FindAsync(subscription.ProductId);
+                    if (product != null)
+                        subscription.NextChargeDate = product.Interval == BillingInterval.Monthly
+                            ? payload.Occurred.Value.AddMonths(1)
+                            : payload.Occurred.Value.AddYears(1);
+                    break;
+                case VippsEvents.ChargeFailed:
+                case VippsEvents.ChargeCreationFailed:
+                    _logger.LogWarning("Charge failed for subscription {SubId} agreement {AgreementId}",
+                        subscription.Id, payload.AgreementId);
+                    break;
+            }
 
             subscription.UpdatedAt = DateTime.UtcNow;
             await _context.SaveChangesAsync();
@@ -179,7 +303,21 @@ namespace garge_api.Controllers
             _logger.LogInformation("Webhook: agreement {AgreementId} -> {EventType}",
                 payload.AgreementId, payload.EventType);
 
+            if (!wasActive && subscription.Status == SubscriptionStatus.Active)
+                _ = SafePushAsync(subscription.UserId, "Subscription active",
+                    "Your Garge subscription is confirmed.");
+
+            if (payload.EventType is VippsEvents.ChargeFailed or VippsEvents.ChargeCreationFailed)
+                _ = SafePushAsync(subscription.UserId, "Payment failed",
+                    "We couldn't charge your Garge subscription. Please update your payment method in Vipps.");
+
             return Ok();
+        }
+
+        private async Task SafePushAsync(string userId, string title, string body)
+        {
+            try { await _push.SendAsync(userId, title, body); }
+            catch (Exception ex) { _logger.LogWarning(ex, "Push send failed for user {UserId}", userId); }
         }
     }
 }

--- a/Controllers/SwitchesController.cs
+++ b/Controllers/SwitchesController.cs
@@ -15,6 +15,7 @@ namespace garge_api.Controllers
     [Route("api/switches")]
     [EnableCors("AllowAllOrigins")]
     [Authorize]
+    [Authorize(Policy = "ActiveSubscription")]
     public class SwitchesController : ControllerBase
     {
         private readonly ApplicationDbContext _context;

--- a/Controllers/UserController.cs
+++ b/Controllers/UserController.cs
@@ -20,6 +20,7 @@ namespace garge_api.Controllers
     [Route("api/users")]
     [EnableCors("AllowAllOrigins")]
     [Authorize]
+    [Authorize(Policy = "ActiveSubscription")]
     public class UserController : ControllerBase
     {
         private readonly ApplicationDbContext _context;

--- a/Controllers/VippsWebhookControllerBase.cs
+++ b/Controllers/VippsWebhookControllerBase.cs
@@ -1,4 +1,8 @@
+using garge_api.Models;
+using garge_api.Models.Webhook;
+using garge_api.Services;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using System.Text;
 using System.Text.Json;
 
@@ -18,6 +22,23 @@ namespace garge_api.Controllers
             var body = await reader.ReadToEndAsync();
             request.Body.Seek(0, SeekOrigin.Begin);
             return body;
+        }
+
+        protected async Task<bool> TryRecordEventAsync(
+            ApplicationDbContext db, string source, string eventId)
+        {
+            if (string.IsNullOrEmpty(eventId)) return true;
+
+            var exists = await db.ProcessedWebhookEvents
+                .AnyAsync(e => e.Source == source && e.Id == eventId);
+            if (exists) return false;
+
+            db.ProcessedWebhookEvents.Add(new ProcessedWebhookEvent
+            {
+                Id = eventId,
+                Source = source
+            });
+            return true;
         }
     }
 }

--- a/Controllers/VippsWebhookControllerBase.cs
+++ b/Controllers/VippsWebhookControllerBase.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Mvc;
+using System.Text;
+using System.Text.Json;
+
+namespace garge_api.Controllers
+{
+    public abstract class VippsWebhookControllerBase : ControllerBase
+    {
+        protected static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
+
+        protected static async Task<string> ReadRawBodyAsync(HttpRequest request)
+        {
+            if (!request.Body.CanSeek)
+                request.EnableBuffering();
+
+            request.Body.Seek(0, SeekOrigin.Begin);
+            using var reader = new StreamReader(request.Body, Encoding.UTF8, leaveOpen: true);
+            var body = await reader.ReadToEndAsync();
+            request.Body.Seek(0, SeekOrigin.Begin);
+            return body;
+        }
+    }
+}

--- a/Controllers/WebhookController.cs
+++ b/Controllers/WebhookController.cs
@@ -10,6 +10,7 @@ namespace garge_api.Controllers
 {
     [ApiController]
     [Authorize]
+    [Authorize(Policy = "ActiveSubscription")]
     [Route("api/webhooks")]
     public class WebhookController : ControllerBase
     {

--- a/Dtos/Admin/AppSettingsDto.cs
+++ b/Dtos/Admin/AppSettingsDto.cs
@@ -4,6 +4,7 @@ namespace garge_api.Dtos.Admin
     {
         public bool CookieBannerEnabled { get; set; }
         public bool VatEnabled { get; set; }
+        public bool VippsTestMode { get; set; }
         public string CompanyName { get; set; } = string.Empty;
         public string CompanyLegalName { get; set; } = string.Empty;
         public string CompanyOrgNumber { get; set; } = string.Empty;
@@ -15,6 +16,7 @@ namespace garge_api.Dtos.Admin
     {
         public bool CookieBannerEnabled { get; set; }
         public bool VatEnabled { get; set; }
+        public bool VippsTestMode { get; set; }
         public string CompanyName { get; set; } = string.Empty;
         public string CompanyLegalName { get; set; } = string.Empty;
         public string CompanyOrgNumber { get; set; } = string.Empty;

--- a/Dtos/Admin/AppSettingsDto.cs
+++ b/Dtos/Admin/AppSettingsDto.cs
@@ -3,5 +3,22 @@ namespace garge_api.Dtos.Admin
     public class AppSettingsDto
     {
         public bool CookieBannerEnabled { get; set; }
+        public bool VatEnabled { get; set; }
+        public string CompanyName { get; set; } = string.Empty;
+        public string CompanyLegalName { get; set; } = string.Empty;
+        public string CompanyOrgNumber { get; set; } = string.Empty;
+        public string CompanyAddress { get; set; } = string.Empty;
+        public string CompanyEmail { get; set; } = string.Empty;
+    }
+
+    public class PublicSettingsDto
+    {
+        public bool CookieBannerEnabled { get; set; }
+        public bool VatEnabled { get; set; }
+        public string CompanyName { get; set; } = string.Empty;
+        public string CompanyLegalName { get; set; } = string.Empty;
+        public string CompanyOrgNumber { get; set; } = string.Empty;
+        public string CompanyAddress { get; set; } = string.Empty;
+        public string CompanyEmail { get; set; } = string.Empty;
     }
 }

--- a/Dtos/Admin/UpdateAppSettingsDto.cs
+++ b/Dtos/Admin/UpdateAppSettingsDto.cs
@@ -1,7 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace garge_api.Dtos.Admin
 {
     public class UpdateAppSettingsDto
     {
         public bool CookieBannerEnabled { get; set; }
+        public bool VatEnabled { get; set; }
+        [MaxLength(100)] public string CompanyName { get; set; } = string.Empty;
+        [MaxLength(200)] public string CompanyLegalName { get; set; } = string.Empty;
+        [MaxLength(20)]  public string CompanyOrgNumber { get; set; } = string.Empty;
+        [MaxLength(500)] public string CompanyAddress { get; set; } = string.Empty;
+        [MaxLength(200)] public string CompanyEmail { get; set; } = string.Empty;
     }
 }

--- a/Dtos/Admin/UpdateAppSettingsDto.cs
+++ b/Dtos/Admin/UpdateAppSettingsDto.cs
@@ -6,6 +6,7 @@ namespace garge_api.Dtos.Admin
     {
         public bool CookieBannerEnabled { get; set; }
         public bool VatEnabled { get; set; }
+        public bool VippsTestMode { get; set; }
         [MaxLength(100)] public string CompanyName { get; set; } = string.Empty;
         [MaxLength(200)] public string CompanyLegalName { get; set; } = string.Empty;
         [MaxLength(20)]  public string CompanyOrgNumber { get; set; } = string.Empty;

--- a/Dtos/Admin/UpdateAppSettingsDto.cs
+++ b/Dtos/Admin/UpdateAppSettingsDto.cs
@@ -4,13 +4,13 @@ namespace garge_api.Dtos.Admin
 {
     public class UpdateAppSettingsDto
     {
-        public bool CookieBannerEnabled { get; set; }
-        public bool VatEnabled { get; set; }
-        public bool VippsTestMode { get; set; }
-        [MaxLength(100)] public string CompanyName { get; set; } = string.Empty;
-        [MaxLength(200)] public string CompanyLegalName { get; set; } = string.Empty;
-        [MaxLength(20)]  public string CompanyOrgNumber { get; set; } = string.Empty;
-        [MaxLength(500)] public string CompanyAddress { get; set; } = string.Empty;
-        [MaxLength(200)] public string CompanyEmail { get; set; } = string.Empty;
+        public bool? CookieBannerEnabled { get; set; }
+        public bool? VatEnabled { get; set; }
+        public bool? VippsTestMode { get; set; }
+        [MaxLength(100)] public string? CompanyName { get; set; }
+        [MaxLength(200)] public string? CompanyLegalName { get; set; }
+        [MaxLength(20)]  public string? CompanyOrgNumber { get; set; }
+        [MaxLength(500)] public string? CompanyAddress { get; set; }
+        [MaxLength(200)] public string? CompanyEmail { get; set; }
     }
 }

--- a/Dtos/Shop/ShopDtos.cs
+++ b/Dtos/Shop/ShopDtos.cs
@@ -95,6 +95,7 @@ namespace garge_api.Dtos.Shop
         public string? ShippingAddress { get; set; }
         public DateTime? ShippedAt { get; set; }
         public bool HasInvoice { get; set; }
+        public bool IsTest { get; set; }
         public List<OrderItemResponseDto> Items { get; set; } = [];
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
@@ -125,6 +126,7 @@ namespace garge_api.Dtos.Shop
         public string? ShippingAddress { get; set; }
         public DateTime? ShippedAt { get; set; }
         public bool HasInvoice { get; set; }
+        public bool IsTest { get; set; }
         public List<OrderItemResponseDto> Items { get; set; } = [];
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }

--- a/Dtos/Shop/ShopDtos.cs
+++ b/Dtos/Shop/ShopDtos.cs
@@ -64,10 +64,8 @@ namespace garge_api.Dtos.Shop
         public required List<OrderItemRequestDto> Items { get; set; }
 
         [Required]
+        [RegularExpression(@"^(?:47)?\d{8}$", ErrorMessage = "Phone number must be 8 Norwegian digits, optionally prefixed with 47.")]
         public required string PhoneNumber { get; set; }
-
-        [Required]
-        public required string RedirectUrl { get; set; }
 
         [Required]
         [MaxLength(500)]
@@ -135,7 +133,15 @@ namespace garge_api.Dtos.Shop
     public class VippsPaymentWebhookDto
     {
         public string Reference { get; set; } = string.Empty;
+        public string PspReference { get; set; } = string.Empty;
         public string Name { get; set; } = string.Empty;
-        public int? Amount { get; set; }
+        public VippsWebhookAmountDto? Amount { get; set; }
+        public string? Msn { get; set; }
+    }
+
+    public class VippsWebhookAmountDto
+    {
+        public int Value { get; set; }
+        public string Currency { get; set; } = string.Empty;
     }
 }

--- a/Dtos/Shop/ShopDtos.cs
+++ b/Dtos/Shop/ShopDtos.cs
@@ -1,0 +1,139 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace garge_api.Dtos.Shop
+{
+    public class ShopItemResponseDto
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string? Description { get; set; }
+        public int PriceInOre { get; set; }
+        public int StockCount { get; set; }
+        public bool IsActive { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+
+    public class CreateShopItemDto
+    {
+        [Required]
+        [MaxLength(100)]
+        public required string Name { get; set; }
+
+        [MaxLength(1000)]
+        public string? Description { get; set; }
+
+        [Required]
+        [Range(1, int.MaxValue)]
+        public int PriceInOre { get; set; }
+
+        public int StockCount { get; set; } = -1;
+    }
+
+    public class UpdateShopItemDto
+    {
+        [Required]
+        [MaxLength(100)]
+        public required string Name { get; set; }
+
+        [MaxLength(1000)]
+        public string? Description { get; set; }
+
+        [Required]
+        [Range(1, int.MaxValue)]
+        public int PriceInOre { get; set; }
+
+        public int StockCount { get; set; } = -1;
+
+        public bool IsActive { get; set; }
+    }
+
+    public class OrderItemRequestDto
+    {
+        [Required]
+        public int ShopItemId { get; set; }
+
+        [Required]
+        [Range(1, 100)]
+        public int Quantity { get; set; }
+    }
+
+    public class CreateOrderDto
+    {
+        [Required]
+        [MinLength(1)]
+        public required List<OrderItemRequestDto> Items { get; set; }
+
+        [Required]
+        public required string PhoneNumber { get; set; }
+
+        [Required]
+        public required string RedirectUrl { get; set; }
+
+        [Required]
+        [MaxLength(500)]
+        public required string ShippingAddress { get; set; }
+    }
+
+    public class OrderItemResponseDto
+    {
+        public int Id { get; set; }
+        public int ShopItemId { get; set; }
+        public string ShopItemName { get; set; } = string.Empty;
+        public int Quantity { get; set; }
+        public int PriceAtPurchaseInOre { get; set; }
+        public int UnitPriceExclVatInOre { get; set; }
+        public int VatPercentage { get; set; }
+    }
+
+    public class OrderResponseDto
+    {
+        public int Id { get; set; }
+        public string UserId { get; set; } = string.Empty;
+        public string? VippsOrderId { get; set; }
+        public string Status { get; set; } = string.Empty;
+        public int TotalInOre { get; set; }
+        public string? ShippingAddress { get; set; }
+        public DateTime? ShippedAt { get; set; }
+        public bool HasInvoice { get; set; }
+        public List<OrderItemResponseDto> Items { get; set; } = [];
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+    }
+
+    public class InvoiceResponseDto
+    {
+        public int Id { get; set; }
+        public int OrderId { get; set; }
+        public DateTime IssuedAt { get; set; }
+    }
+
+    public class CheckoutResponseDto
+    {
+        public string RedirectUrl { get; set; } = string.Empty;
+        public int OrderId { get; set; }
+    }
+
+    public class AdminOrderResponseDto
+    {
+        public int Id { get; set; }
+        public string UserId { get; set; } = string.Empty;
+        public string UserEmail { get; set; } = string.Empty;
+        public string UserName { get; set; } = string.Empty;
+        public string? VippsOrderId { get; set; }
+        public string Status { get; set; } = string.Empty;
+        public int TotalInOre { get; set; }
+        public string? ShippingAddress { get; set; }
+        public DateTime? ShippedAt { get; set; }
+        public bool HasInvoice { get; set; }
+        public List<OrderItemResponseDto> Items { get; set; } = [];
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+    }
+
+    public class VippsPaymentWebhookDto
+    {
+        public string Reference { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public int? Amount { get; set; }
+    }
+}

--- a/Dtos/Subscription/ProductDtos.cs
+++ b/Dtos/Subscription/ProductDtos.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel.DataAnnotations;
+using garge_api.Models.Subscription;
+
+namespace garge_api.Dtos.Subscription
+{
+    public class ProductResponseDto
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string? Description { get; set; }
+        public int PriceInOre { get; set; }
+        public string Interval { get; set; } = string.Empty;
+        public bool IsActive { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+
+    public class CreateProductDto
+    {
+        [Required]
+        [MaxLength(100)]
+        public required string Name { get; set; }
+
+        [MaxLength(500)]
+        public string? Description { get; set; }
+
+        [Required]
+        [Range(1, int.MaxValue)]
+        public int PriceInOre { get; set; }
+
+        [Required]
+        public BillingInterval Interval { get; set; }
+    }
+
+    public class UpdateProductDto
+    {
+        [Required]
+        [MaxLength(100)]
+        public required string Name { get; set; }
+
+        [MaxLength(500)]
+        public string? Description { get; set; }
+
+        [Required]
+        [Range(1, int.MaxValue)]
+        public int PriceInOre { get; set; }
+
+        [Required]
+        public BillingInterval Interval { get; set; }
+
+        public bool IsActive { get; set; }
+    }
+}

--- a/Dtos/Subscription/ProductDtos.cs
+++ b/Dtos/Subscription/ProductDtos.cs
@@ -10,6 +10,7 @@ namespace garge_api.Dtos.Subscription
         public string? Description { get; set; }
         public int PriceInOre { get; set; }
         public string Interval { get; set; } = string.Empty;
+        public string Type { get; set; } = string.Empty;
         public bool IsActive { get; set; }
         public DateTime CreatedAt { get; set; }
     }
@@ -29,6 +30,9 @@ namespace garge_api.Dtos.Subscription
 
         [Required]
         public BillingInterval Interval { get; set; }
+
+        [Required]
+        public ProductType Type { get; set; } = ProductType.Primary;
     }
 
     public class UpdateProductDto
@@ -46,6 +50,9 @@ namespace garge_api.Dtos.Subscription
 
         [Required]
         public BillingInterval Interval { get; set; }
+
+        [Required]
+        public ProductType Type { get; set; }
 
         public bool IsActive { get; set; }
     }

--- a/Dtos/Subscription/SubscriptionDtos.cs
+++ b/Dtos/Subscription/SubscriptionDtos.cs
@@ -1,0 +1,46 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace garge_api.Dtos.Subscription
+{
+    public class SubscriptionResponseDto
+    {
+        public int Id { get; set; }
+        public string UserId { get; set; } = string.Empty;
+        public int ProductId { get; set; }
+        public string ProductName { get; set; } = string.Empty;
+        public int PriceInOre { get; set; }
+        public string Interval { get; set; } = string.Empty;
+        public string VippsAgreementId { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
+        public DateTime? StartDate { get; set; }
+        public DateTime? NextChargeDate { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+    }
+
+    public class InitiateSubscriptionDto
+    {
+        [Required]
+        public int ProductId { get; set; }
+
+        [Required]
+        public required string PhoneNumber { get; set; }
+
+        [Required]
+        public required string RedirectUrl { get; set; }
+    }
+
+    public class InitiateSubscriptionResponseDto
+    {
+        public int SubscriptionId { get; set; }
+        public string VippsConfirmationUrl { get; set; } = string.Empty;
+        public string VippsAgreementId { get; set; } = string.Empty;
+    }
+
+    public class VippsAgreementWebhookDto
+    {
+        public string AgreementId { get; set; } = string.Empty;
+        public string EventType { get; set; } = string.Empty;
+        public DateTime? Occurred { get; set; }
+    }
+}

--- a/Dtos/Subscription/SubscriptionDtos.cs
+++ b/Dtos/Subscription/SubscriptionDtos.cs
@@ -12,6 +12,7 @@ namespace garge_api.Dtos.Subscription
         public string Interval { get; set; } = string.Empty;
         public string VippsAgreementId { get; set; } = string.Empty;
         public string Status { get; set; } = string.Empty;
+        public bool IsTest { get; set; }
         public DateTime? StartDate { get; set; }
         public DateTime? NextChargeDate { get; set; }
         public DateTime CreatedAt { get; set; }

--- a/Dtos/Subscription/SubscriptionDtos.cs
+++ b/Dtos/Subscription/SubscriptionDtos.cs
@@ -8,6 +8,7 @@ namespace garge_api.Dtos.Subscription
         public string UserId { get; set; } = string.Empty;
         public int ProductId { get; set; }
         public string ProductName { get; set; } = string.Empty;
+        public string ProductType { get; set; } = string.Empty;
         public int PriceInOre { get; set; }
         public string Interval { get; set; } = string.Empty;
         public string VippsAgreementId { get; set; } = string.Empty;
@@ -25,10 +26,11 @@ namespace garge_api.Dtos.Subscription
         public int ProductId { get; set; }
 
         [Required]
+        [RegularExpression(@"^(?:47)?\d{8}$", ErrorMessage = "Phone number must be 8 Norwegian digits, optionally prefixed with 47.")]
         public required string PhoneNumber { get; set; }
 
         [Required]
-        public required string RedirectUrl { get; set; }
+        public bool ConsentToWaiveWithdrawal { get; set; }
     }
 
     public class InitiateSubscriptionResponseDto
@@ -41,7 +43,9 @@ namespace garge_api.Dtos.Subscription
     public class VippsAgreementWebhookDto
     {
         public string AgreementId { get; set; } = string.Empty;
+        public string EventId { get; set; } = string.Empty;
         public string EventType { get; set; } = string.Empty;
         public DateTime? Occurred { get; set; }
+        public string? Msn { get; set; }
     }
 }

--- a/Helpers/PhoneNumber.cs
+++ b/Helpers/PhoneNumber.cs
@@ -1,0 +1,24 @@
+using System.Text.RegularExpressions;
+
+namespace garge_api.Helpers
+{
+    public static class PhoneNumber
+    {
+        private static readonly Regex Cleaner = new(@"\D", RegexOptions.Compiled);
+
+        public static bool TryNormalizeNo(string raw, out string msisdn)
+        {
+            msisdn = string.Empty;
+            if (string.IsNullOrWhiteSpace(raw)) return false;
+
+            var digits = Cleaner.Replace(raw, string.Empty);
+            if (digits.Length == 8)
+                digits = "47" + digits;
+            if (digits.Length != 10 || !digits.StartsWith("47"))
+                return false;
+
+            msisdn = digits;
+            return true;
+        }
+    }
+}

--- a/Migrations/20260503154745_AddAppSettings.cs
+++ b/Migrations/20260503154745_AddAppSettings.cs
@@ -10,13 +10,29 @@ namespace garge_api.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.CreateTable(
+                name: "AppSettings",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false),
+                    CookieBannerEnabled = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AppSettings", x => x.Id);
+                    table.CheckConstraint("CK_AppSettings_SingleRow", "\"Id\" = 1");
+                });
 
+            migrationBuilder.InsertData(
+                table: "AppSettings",
+                columns: new[] { "Id", "CookieBannerEnabled" },
+                values: new object[] { 1, true });
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-
+            migrationBuilder.DropTable(name: "AppSettings");
         }
     }
 }

--- a/Migrations/20260504155920_AddSubscriptionsAndShop.Designer.cs
+++ b/Migrations/20260504155920_AddSubscriptionsAndShop.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260504155920_AddSubscriptionsAndShop")]
+    partial class AddSubscriptionsAndShop
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -287,48 +290,8 @@ namespace garge_api.Migrations
                     b.Property<int>("Id")
                         .HasColumnType("integer");
 
-                    b.Property<string>("CompanyAddress")
-                        .IsRequired()
-                        .HasMaxLength(500)
-                        .HasColumnType("character varying(500)");
-
-                    b.Property<string>("CompanyEmail")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
-
-                    b.Property<string>("CompanyLegalName")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
-
-                    b.Property<string>("CompanyName")
-                        .IsRequired()
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<string>("CompanyOrgNumber")
-                        .IsRequired()
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
                     b.Property<bool>("CookieBannerEnabled")
                         .HasColumnType("boolean");
-
-                    b.Property<bool>("VatEnabled")
-                        .HasColumnType("boolean");
-
-                    b.Property<string>("VippsShopWebhookId")
-                        .HasColumnType("text");
-
-                    b.Property<string>("VippsShopWebhookSecret")
-                        .HasColumnType("text");
-
-                    b.Property<string>("VippsSubscriptionWebhookId")
-                        .HasColumnType("text");
-
-                    b.Property<string>("VippsSubscriptionWebhookSecret")
-                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -341,13 +304,7 @@ namespace garge_api.Migrations
                         new
                         {
                             Id = 1,
-                            CompanyAddress = "Mårvegen 21a, 4347 Lye",
-                            CompanyEmail = "sondresjoelyst@gmail.com",
-                            CompanyLegalName = "Sjølyst Innovations",
-                            CompanyName = "Garge",
-                            CompanyOrgNumber = "934 531 035",
-                            CookieBannerEnabled = true,
-                            VatEnabled = false
+                            CookieBannerEnabled = true
                         });
                 });
 
@@ -975,32 +932,6 @@ namespace garge_api.Migrations
                     b.ToTable("UserSensorCustomNames");
                 });
 
-            modelBuilder.Entity("garge_api.Models.Shop.Invoice", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<DateTime>("IssuedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<int>("OrderId")
-                        .HasColumnType("integer");
-
-                    b.Property<byte[]>("PdfData")
-                        .IsRequired()
-                        .HasColumnType("bytea");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("OrderId")
-                        .IsUnique();
-
-                    b.ToTable("Invoices");
-                });
-
             modelBuilder.Entity("garge_api.Models.Shop.Order", b =>
                 {
                     b.Property<int>("Id")
@@ -1011,13 +942,6 @@ namespace garge_api.Migrations
 
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("timestamp with time zone");
-
-                    b.Property<DateTime?>("ShippedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("ShippingAddress")
-                        .HasMaxLength(500)
-                        .HasColumnType("character varying(500)");
 
                     b.Property<int>("Status")
                         .HasColumnType("integer");
@@ -1065,12 +989,6 @@ namespace garge_api.Migrations
                         .HasColumnType("integer");
 
                     b.Property<int>("ShopItemId")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("UnitPriceExclVatInOre")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("VatPercentage")
                         .HasColumnType("integer");
 
                     b.HasKey("Id");
@@ -1161,13 +1079,6 @@ namespace garge_api.Migrations
                         .HasColumnType("integer");
 
                     NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<DateTime?>("ConsentAcceptedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("ConsentIp")
-                        .HasMaxLength(45)
-                        .HasColumnType("character varying(45)");
 
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("timestamp with time zone");
@@ -1549,17 +1460,6 @@ namespace garge_api.Migrations
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("garge_api.Models.Shop.Invoice", b =>
-                {
-                    b.HasOne("garge_api.Models.Shop.Order", "Order")
-                        .WithOne("Invoice")
-                        .HasForeignKey("garge_api.Models.Shop.Invoice", "OrderId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Order");
-                });
-
             modelBuilder.Entity("garge_api.Models.Shop.Order", b =>
                 {
                     b.HasOne("User", "User")
@@ -1667,8 +1567,6 @@ namespace garge_api.Migrations
 
             modelBuilder.Entity("garge_api.Models.Shop.Order", b =>
                 {
-                    b.Navigation("Invoice");
-
                     b.Navigation("OrderItems");
                 });
 #pragma warning restore 612, 618

--- a/Migrations/20260504155920_AddSubscriptionsAndShop.cs
+++ b/Migrations/20260504155920_AddSubscriptionsAndShop.cs
@@ -1,0 +1,203 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSubscriptionsAndShop : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Orders",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<string>(type: "text", nullable: false),
+                    VippsOrderId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    TotalInOre = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Orders", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Orders_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Products",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Description = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    PriceInOre = table.Column<int>(type: "integer", nullable: false),
+                    Interval = table.Column<int>(type: "integer", nullable: false),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Products", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ShopItems",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Description = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    PriceInOre = table.Column<int>(type: "integer", nullable: false),
+                    StockCount = table.Column<int>(type: "integer", nullable: false),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ShopItems", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Subscriptions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<string>(type: "text", nullable: false),
+                    ProductId = table.Column<int>(type: "integer", nullable: false),
+                    VippsAgreementId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    StartDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    NextChargeDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Subscriptions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Subscriptions_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Subscriptions_Products_ProductId",
+                        column: x => x.ProductId,
+                        principalTable: "Products",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OrderItems",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    OrderId = table.Column<int>(type: "integer", nullable: false),
+                    ShopItemId = table.Column<int>(type: "integer", nullable: false),
+                    Quantity = table.Column<int>(type: "integer", nullable: false),
+                    PriceAtPurchaseInOre = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OrderItems", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OrderItems_Orders_OrderId",
+                        column: x => x.OrderId,
+                        principalTable: "Orders",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_OrderItems_ShopItems_ShopItemId",
+                        column: x => x.ShopItemId,
+                        principalTable: "ShopItems",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrderItems_OrderId",
+                table: "OrderItems",
+                column: "OrderId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrderItems_ShopItemId",
+                table: "OrderItems",
+                column: "ShopItemId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Orders_UserId",
+                table: "Orders",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Orders_VippsOrderId",
+                table: "Orders",
+                column: "VippsOrderId",
+                unique: true,
+                filter: "\"VippsOrderId\" IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Products_IsActive",
+                table: "Products",
+                column: "IsActive");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShopItems_IsActive",
+                table: "ShopItems",
+                column: "IsActive");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Subscriptions_ProductId",
+                table: "Subscriptions",
+                column: "ProductId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Subscriptions_UserId_Status",
+                table: "Subscriptions",
+                columns: new[] { "UserId", "Status" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Subscriptions_VippsAgreementId",
+                table: "Subscriptions",
+                column: "VippsAgreementId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OrderItems");
+
+            migrationBuilder.DropTable(
+                name: "Subscriptions");
+
+            migrationBuilder.DropTable(
+                name: "Orders");
+
+            migrationBuilder.DropTable(
+                name: "ShopItems");
+
+            migrationBuilder.DropTable(
+                name: "Products");
+        }
+    }
+}

--- a/Migrations/20260504180843_AddSubscriptionConsent.Designer.cs
+++ b/Migrations/20260504180843_AddSubscriptionConsent.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260504180843_AddSubscriptionConsent")]
+    partial class AddSubscriptionConsent
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -287,48 +290,11 @@ namespace garge_api.Migrations
                     b.Property<int>("Id")
                         .HasColumnType("integer");
 
-                    b.Property<string>("CompanyAddress")
-                        .IsRequired()
-                        .HasMaxLength(500)
-                        .HasColumnType("character varying(500)");
-
-                    b.Property<string>("CompanyEmail")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
-
-                    b.Property<string>("CompanyLegalName")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
-
-                    b.Property<string>("CompanyName")
-                        .IsRequired()
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<string>("CompanyOrgNumber")
-                        .IsRequired()
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
                     b.Property<bool>("CookieBannerEnabled")
                         .HasColumnType("boolean");
 
                     b.Property<bool>("VatEnabled")
                         .HasColumnType("boolean");
-
-                    b.Property<string>("VippsShopWebhookId")
-                        .HasColumnType("text");
-
-                    b.Property<string>("VippsShopWebhookSecret")
-                        .HasColumnType("text");
-
-                    b.Property<string>("VippsSubscriptionWebhookId")
-                        .HasColumnType("text");
-
-                    b.Property<string>("VippsSubscriptionWebhookSecret")
-                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -341,11 +307,6 @@ namespace garge_api.Migrations
                         new
                         {
                             Id = 1,
-                            CompanyAddress = "Mårvegen 21a, 4347 Lye",
-                            CompanyEmail = "sondresjoelyst@gmail.com",
-                            CompanyLegalName = "Sjølyst Innovations",
-                            CompanyName = "Garge",
-                            CompanyOrgNumber = "934 531 035",
                             CookieBannerEnabled = true,
                             VatEnabled = false
                         });
@@ -975,32 +936,6 @@ namespace garge_api.Migrations
                     b.ToTable("UserSensorCustomNames");
                 });
 
-            modelBuilder.Entity("garge_api.Models.Shop.Invoice", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<DateTime>("IssuedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<int>("OrderId")
-                        .HasColumnType("integer");
-
-                    b.Property<byte[]>("PdfData")
-                        .IsRequired()
-                        .HasColumnType("bytea");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("OrderId")
-                        .IsUnique();
-
-                    b.ToTable("Invoices");
-                });
-
             modelBuilder.Entity("garge_api.Models.Shop.Order", b =>
                 {
                     b.Property<int>("Id")
@@ -1011,13 +946,6 @@ namespace garge_api.Migrations
 
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("timestamp with time zone");
-
-                    b.Property<DateTime?>("ShippedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("ShippingAddress")
-                        .HasMaxLength(500)
-                        .HasColumnType("character varying(500)");
 
                     b.Property<int>("Status")
                         .HasColumnType("integer");
@@ -1065,12 +993,6 @@ namespace garge_api.Migrations
                         .HasColumnType("integer");
 
                     b.Property<int>("ShopItemId")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("UnitPriceExclVatInOre")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("VatPercentage")
                         .HasColumnType("integer");
 
                     b.HasKey("Id");
@@ -1549,17 +1471,6 @@ namespace garge_api.Migrations
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("garge_api.Models.Shop.Invoice", b =>
-                {
-                    b.HasOne("garge_api.Models.Shop.Order", "Order")
-                        .WithOne("Invoice")
-                        .HasForeignKey("garge_api.Models.Shop.Invoice", "OrderId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Order");
-                });
-
             modelBuilder.Entity("garge_api.Models.Shop.Order", b =>
                 {
                     b.HasOne("User", "User")
@@ -1667,8 +1578,6 @@ namespace garge_api.Migrations
 
             modelBuilder.Entity("garge_api.Models.Shop.Order", b =>
                 {
-                    b.Navigation("Invoice");
-
                     b.Navigation("OrderItems");
                 });
 #pragma warning restore 612, 618

--- a/Migrations/20260504180843_AddSubscriptionConsent.cs
+++ b/Migrations/20260504180843_AddSubscriptionConsent.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSubscriptionConsent : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Guard: AddAppSettings migration had an empty Up() in dev — create the table if it wasn't created.
+            migrationBuilder.Sql(@"
+                CREATE TABLE IF NOT EXISTS ""AppSettings"" (
+                    ""Id"" integer NOT NULL DEFAULT 1,
+                    ""CookieBannerEnabled"" boolean NOT NULL DEFAULT true,
+                    CONSTRAINT ""PK_AppSettings"" PRIMARY KEY (""Id""),
+                    CONSTRAINT ""CK_AppSettings_SingleRow"" CHECK (""Id"" = 1)
+                );
+                INSERT INTO ""AppSettings"" (""Id"", ""CookieBannerEnabled"") VALUES (1, true) ON CONFLICT DO NOTHING;
+            ");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ConsentAcceptedAt",
+                table: "Subscriptions",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConsentIp",
+                table: "Subscriptions",
+                type: "character varying(45)",
+                maxLength: 45,
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "VatEnabled",
+                table: "AppSettings",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.UpdateData(
+                table: "AppSettings",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "VatEnabled",
+                value: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ConsentAcceptedAt",
+                table: "Subscriptions");
+
+            migrationBuilder.DropColumn(
+                name: "ConsentIp",
+                table: "Subscriptions");
+
+            migrationBuilder.DropColumn(
+                name: "VatEnabled",
+                table: "AppSettings");
+        }
+    }
+}

--- a/Migrations/20260504181813_AddVippsWebhookSettings.Designer.cs
+++ b/Migrations/20260504181813_AddVippsWebhookSettings.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260504181813_AddVippsWebhookSettings")]
+    partial class AddVippsWebhookSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -287,31 +290,6 @@ namespace garge_api.Migrations
                     b.Property<int>("Id")
                         .HasColumnType("integer");
 
-                    b.Property<string>("CompanyAddress")
-                        .IsRequired()
-                        .HasMaxLength(500)
-                        .HasColumnType("character varying(500)");
-
-                    b.Property<string>("CompanyEmail")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
-
-                    b.Property<string>("CompanyLegalName")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
-
-                    b.Property<string>("CompanyName")
-                        .IsRequired()
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<string>("CompanyOrgNumber")
-                        .IsRequired()
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
                     b.Property<bool>("CookieBannerEnabled")
                         .HasColumnType("boolean");
 
@@ -341,11 +319,6 @@ namespace garge_api.Migrations
                         new
                         {
                             Id = 1,
-                            CompanyAddress = "Mårvegen 21a, 4347 Lye",
-                            CompanyEmail = "sondresjoelyst@gmail.com",
-                            CompanyLegalName = "Sjølyst Innovations",
-                            CompanyName = "Garge",
-                            CompanyOrgNumber = "934 531 035",
                             CookieBannerEnabled = true,
                             VatEnabled = false
                         });
@@ -975,32 +948,6 @@ namespace garge_api.Migrations
                     b.ToTable("UserSensorCustomNames");
                 });
 
-            modelBuilder.Entity("garge_api.Models.Shop.Invoice", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<DateTime>("IssuedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<int>("OrderId")
-                        .HasColumnType("integer");
-
-                    b.Property<byte[]>("PdfData")
-                        .IsRequired()
-                        .HasColumnType("bytea");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("OrderId")
-                        .IsUnique();
-
-                    b.ToTable("Invoices");
-                });
-
             modelBuilder.Entity("garge_api.Models.Shop.Order", b =>
                 {
                     b.Property<int>("Id")
@@ -1011,13 +958,6 @@ namespace garge_api.Migrations
 
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("timestamp with time zone");
-
-                    b.Property<DateTime?>("ShippedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("ShippingAddress")
-                        .HasMaxLength(500)
-                        .HasColumnType("character varying(500)");
 
                     b.Property<int>("Status")
                         .HasColumnType("integer");
@@ -1065,12 +1005,6 @@ namespace garge_api.Migrations
                         .HasColumnType("integer");
 
                     b.Property<int>("ShopItemId")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("UnitPriceExclVatInOre")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("VatPercentage")
                         .HasColumnType("integer");
 
                     b.HasKey("Id");
@@ -1549,17 +1483,6 @@ namespace garge_api.Migrations
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("garge_api.Models.Shop.Invoice", b =>
-                {
-                    b.HasOne("garge_api.Models.Shop.Order", "Order")
-                        .WithOne("Invoice")
-                        .HasForeignKey("garge_api.Models.Shop.Invoice", "OrderId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Order");
-                });
-
             modelBuilder.Entity("garge_api.Models.Shop.Order", b =>
                 {
                     b.HasOne("User", "User")
@@ -1667,8 +1590,6 @@ namespace garge_api.Migrations
 
             modelBuilder.Entity("garge_api.Models.Shop.Order", b =>
                 {
-                    b.Navigation("Invoice");
-
                     b.Navigation("OrderItems");
                 });
 #pragma warning restore 612, 618

--- a/Migrations/20260504181813_AddVippsWebhookSettings.cs
+++ b/Migrations/20260504181813_AddVippsWebhookSettings.cs
@@ -1,0 +1,65 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddVippsWebhookSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "VippsShopWebhookId",
+                table: "AppSettings",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "VippsShopWebhookSecret",
+                table: "AppSettings",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "VippsSubscriptionWebhookId",
+                table: "AppSettings",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "VippsSubscriptionWebhookSecret",
+                table: "AppSettings",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.UpdateData(
+                table: "AppSettings",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "VippsShopWebhookId", "VippsShopWebhookSecret", "VippsSubscriptionWebhookId", "VippsSubscriptionWebhookSecret" },
+                values: new object[] { null, null, null, null });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "VippsShopWebhookId",
+                table: "AppSettings");
+
+            migrationBuilder.DropColumn(
+                name: "VippsShopWebhookSecret",
+                table: "AppSettings");
+
+            migrationBuilder.DropColumn(
+                name: "VippsSubscriptionWebhookId",
+                table: "AppSettings");
+
+            migrationBuilder.DropColumn(
+                name: "VippsSubscriptionWebhookSecret",
+                table: "AppSettings");
+        }
+    }
+}

--- a/Migrations/20260504191540_AddInvoicesAndCompanySettings.Designer.cs
+++ b/Migrations/20260504191540_AddInvoicesAndCompanySettings.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260504191540_AddInvoicesAndCompanySettings")]
+    partial class AddInvoicesAndCompanySettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260504191540_AddInvoicesAndCompanySettings.cs
+++ b/Migrations/20260504191540_AddInvoicesAndCompanySettings.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInvoicesAndCompanySettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ShippedAt",
+                table: "Orders",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ShippingAddress",
+                table: "Orders",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "UnitPriceExclVatInOre",
+                table: "OrderItems",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "VatPercentage",
+                table: "OrderItems",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CompanyAddress",
+                table: "AppSettings",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "CompanyEmail",
+                table: "AppSettings",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "CompanyLegalName",
+                table: "AppSettings",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "CompanyName",
+                table: "AppSettings",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "CompanyOrgNumber",
+                table: "AppSettings",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateTable(
+                name: "Invoices",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    OrderId = table.Column<int>(type: "integer", nullable: false),
+                    IssuedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    PdfData = table.Column<byte[]>(type: "bytea", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Invoices", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Invoices_Orders_OrderId",
+                        column: x => x.OrderId,
+                        principalTable: "Orders",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.UpdateData(
+                table: "AppSettings",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CompanyAddress", "CompanyEmail", "CompanyLegalName", "CompanyName", "CompanyOrgNumber" },
+                values: new object[] { "Mårvegen 21a, 4347 Lye", "sondresjoelyst@gmail.com", "Sjølyst Innovations", "Garge", "934 531 035" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Invoices_OrderId",
+                table: "Invoices",
+                column: "OrderId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Invoices");
+
+            migrationBuilder.DropColumn(
+                name: "ShippedAt",
+                table: "Orders");
+
+            migrationBuilder.DropColumn(
+                name: "ShippingAddress",
+                table: "Orders");
+
+            migrationBuilder.DropColumn(
+                name: "UnitPriceExclVatInOre",
+                table: "OrderItems");
+
+            migrationBuilder.DropColumn(
+                name: "VatPercentage",
+                table: "OrderItems");
+
+            migrationBuilder.DropColumn(
+                name: "CompanyAddress",
+                table: "AppSettings");
+
+            migrationBuilder.DropColumn(
+                name: "CompanyEmail",
+                table: "AppSettings");
+
+            migrationBuilder.DropColumn(
+                name: "CompanyLegalName",
+                table: "AppSettings");
+
+            migrationBuilder.DropColumn(
+                name: "CompanyName",
+                table: "AppSettings");
+
+            migrationBuilder.DropColumn(
+                name: "CompanyOrgNumber",
+                table: "AppSettings");
+        }
+    }
+}

--- a/Migrations/20260505133116_AddVippsTestMode.Designer.cs
+++ b/Migrations/20260505133116_AddVippsTestMode.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260505133116_AddVippsTestMode")]
+    partial class AddVippsTestMode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260505133116_AddVippsTestMode.cs
+++ b/Migrations/20260505133116_AddVippsTestMode.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddVippsTestMode : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsTest",
+                table: "Subscriptions",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsTest",
+                table: "Orders",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "VippsTestMode",
+                table: "AppSettings",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.UpdateData(
+                table: "AppSettings",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "VippsTestMode",
+                value: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsTest",
+                table: "Subscriptions");
+
+            migrationBuilder.DropColumn(
+                name: "IsTest",
+                table: "Orders");
+
+            migrationBuilder.DropColumn(
+                name: "VippsTestMode",
+                table: "AppSettings");
+        }
+    }
+}

--- a/Migrations/20260505152231_AddProductType.Designer.cs
+++ b/Migrations/20260505152231_AddProductType.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260505152231_AddProductType")]
+    partial class AddProductType
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -21,25 +24,6 @@ namespace garge_api.Migrations
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
-
-            modelBuilder.Entity("Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.DataProtectionKey", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<string>("FriendlyName")
-                        .HasColumnType("text");
-
-                    b.Property<string>("Xml")
-                        .HasColumnType("text");
-
-                    b.HasKey("Id");
-
-                    b.ToTable("DataProtectionKeys");
-                });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole", b =>
                 {
@@ -969,9 +953,6 @@ namespace garge_api.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<bool>("IsOwner")
-                        .HasColumnType("boolean");
-
                     b.HasKey("UserId", "SensorId");
 
                     b.HasIndex("SensorId");
@@ -1231,10 +1212,6 @@ namespace garge_api.Migrations
                         .HasMaxLength(200)
                         .HasColumnType("character varying(200)");
 
-                    b.Property<string>("VippsConfirmationUrl")
-                        .HasMaxLength(500)
-                        .HasColumnType("character varying(500)");
-
                     b.HasKey("Id");
 
                     b.HasIndex("ProductId");
@@ -1345,29 +1322,6 @@ namespace garge_api.Migrations
                     b.HasIndex("SwitchId");
 
                     b.ToTable("UserSwitchCustomNames");
-                });
-
-            modelBuilder.Entity("garge_api.Models.Webhook.ProcessedWebhookEvent", b =>
-                {
-                    b.Property<string>("Id")
-                        .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
-
-                    b.Property<DateTime>("ProcessedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Source")
-                        .IsRequired()
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("ProcessedAt");
-
-                    b.HasIndex("Source", "Id");
-
-                    b.ToTable("ProcessedWebhookEvents");
                 });
 
             modelBuilder.Entity("garge_api.Models.Webhook.WebhookSubscription", b =>

--- a/Migrations/20260505152231_AddProductType.cs
+++ b/Migrations/20260505152231_AddProductType.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProductType : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Type",
+                table: "Products",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Type",
+                table: "Products");
+        }
+    }
+}

--- a/Migrations/20260505154916_AddUserSensorIsOwner.Designer.cs
+++ b/Migrations/20260505154916_AddUserSensorIsOwner.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260505154916_AddUserSensorIsOwner")]
+    partial class AddUserSensorIsOwner
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -21,25 +24,6 @@ namespace garge_api.Migrations
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
-
-            modelBuilder.Entity("Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.DataProtectionKey", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<string>("FriendlyName")
-                        .HasColumnType("text");
-
-                    b.Property<string>("Xml")
-                        .HasColumnType("text");
-
-                    b.HasKey("Id");
-
-                    b.ToTable("DataProtectionKeys");
-                });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole", b =>
                 {
@@ -1231,10 +1215,6 @@ namespace garge_api.Migrations
                         .HasMaxLength(200)
                         .HasColumnType("character varying(200)");
 
-                    b.Property<string>("VippsConfirmationUrl")
-                        .HasMaxLength(500)
-                        .HasColumnType("character varying(500)");
-
                     b.HasKey("Id");
 
                     b.HasIndex("ProductId");
@@ -1345,29 +1325,6 @@ namespace garge_api.Migrations
                     b.HasIndex("SwitchId");
 
                     b.ToTable("UserSwitchCustomNames");
-                });
-
-            modelBuilder.Entity("garge_api.Models.Webhook.ProcessedWebhookEvent", b =>
-                {
-                    b.Property<string>("Id")
-                        .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
-
-                    b.Property<DateTime>("ProcessedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Source")
-                        .IsRequired()
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("ProcessedAt");
-
-                    b.HasIndex("Source", "Id");
-
-                    b.ToTable("ProcessedWebhookEvents");
                 });
 
             modelBuilder.Entity("garge_api.Models.Webhook.WebhookSubscription", b =>

--- a/Migrations/20260505154916_AddUserSensorIsOwner.cs
+++ b/Migrations/20260505154916_AddUserSensorIsOwner.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserSensorIsOwner : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsOwner",
+                table: "UserSensors",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsOwner",
+                table: "UserSensors");
+        }
+    }
+}

--- a/Migrations/20260506150516_AddProcessedWebhookEventsAndDataProtection.Designer.cs
+++ b/Migrations/20260506150516_AddProcessedWebhookEventsAndDataProtection.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260506150516_AddProcessedWebhookEventsAndDataProtection")]
+    partial class AddProcessedWebhookEventsAndDataProtection
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1230,10 +1233,6 @@ namespace garge_api.Migrations
                         .IsRequired()
                         .HasMaxLength(200)
                         .HasColumnType("character varying(200)");
-
-                    b.Property<string>("VippsConfirmationUrl")
-                        .HasMaxLength(500)
-                        .HasColumnType("character varying(500)");
 
                     b.HasKey("Id");
 

--- a/Migrations/20260506150516_AddProcessedWebhookEventsAndDataProtection.cs
+++ b/Migrations/20260506150516_AddProcessedWebhookEventsAndDataProtection.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProcessedWebhookEventsAndDataProtection : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "DataProtectionKeys",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    FriendlyName = table.Column<string>(type: "text", nullable: true),
+                    Xml = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DataProtectionKeys", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ProcessedWebhookEvents",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Source = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    ProcessedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProcessedWebhookEvents", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProcessedWebhookEvents_ProcessedAt",
+                table: "ProcessedWebhookEvents",
+                column: "ProcessedAt");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProcessedWebhookEvents_Source_Id",
+                table: "ProcessedWebhookEvents",
+                columns: new[] { "Source", "Id" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "DataProtectionKeys");
+
+            migrationBuilder.DropTable(
+                name: "ProcessedWebhookEvents");
+        }
+    }
+}

--- a/Migrations/20260506170855_AddVippsConfirmationUrl.Designer.cs
+++ b/Migrations/20260506170855_AddVippsConfirmationUrl.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260506170855_AddVippsConfirmationUrl")]
+    partial class AddVippsConfirmationUrl
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260506170855_AddVippsConfirmationUrl.cs
+++ b/Migrations/20260506170855_AddVippsConfirmationUrl.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddVippsConfirmationUrl : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "VippsConfirmationUrl",
+                table: "Subscriptions",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "VippsConfirmationUrl",
+                table: "Subscriptions");
+        }
+    }
+}

--- a/Models/Admin/AppSettings.cs
+++ b/Models/Admin/AppSettings.cs
@@ -1,8 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace garge_api.Models.Admin
 {
     public class AppSettings
     {
         public int Id { get; set; } = 1;
         public bool CookieBannerEnabled { get; set; } = true;
+        public bool VatEnabled { get; set; } = false;
+        public string? VippsShopWebhookId { get; set; }
+        public string? VippsShopWebhookSecret { get; set; }
+        public string? VippsSubscriptionWebhookId { get; set; }
+        public string? VippsSubscriptionWebhookSecret { get; set; }
+
+        [MaxLength(100)]
+        public string CompanyName { get; set; } = "Garge";
+        [MaxLength(200)]
+        public string CompanyLegalName { get; set; } = "Sjølyst Innovations";
+        [MaxLength(20)]
+        public string CompanyOrgNumber { get; set; } = "934 531 035";
+        [MaxLength(500)]
+        public string CompanyAddress { get; set; } = "Mårvegen 21a, 4347 Lye";
+        [MaxLength(200)]
+        public string CompanyEmail { get; set; } = "sondresjoelyst@gmail.com";
     }
 }

--- a/Models/Admin/AppSettings.cs
+++ b/Models/Admin/AppSettings.cs
@@ -22,5 +22,7 @@ namespace garge_api.Models.Admin
         public string CompanyAddress { get; set; } = "Mårvegen 21a, 4347 Lye";
         [MaxLength(200)]
         public string CompanyEmail { get; set; } = "sondresjoelyst@gmail.com";
+
+        public bool VippsTestMode { get; set; } = false;
     }
 }

--- a/Models/Admin/AppSettings.cs
+++ b/Models/Admin/AppSettings.cs
@@ -23,6 +23,6 @@ namespace garge_api.Models.Admin
         [MaxLength(200)]
         public string CompanyEmail { get; set; } = "sondresjoelyst@gmail.com";
 
-        public bool VippsTestMode { get; set; } = false;
+        public bool VippsTestMode { get; set; }
     }
 }

--- a/Models/ApplicationDbContext.cs
+++ b/Models/ApplicationDbContext.cs
@@ -6,6 +6,8 @@ using garge_api.Models.Group;
 using garge_api.Models.Mqtt;
 using garge_api.Models.Push;
 using garge_api.Models.Sensor;
+using garge_api.Models.Shop;
+using garge_api.Models.Subscription;
 using garge_api.Models.Switch;
 using garge_api.Models.Webhook;
 using Microsoft.AspNetCore.Identity;
@@ -42,6 +44,12 @@ namespace garge_api.Models
         public DbSet<PushSubscription> PushSubscriptions { get; set; }
         public DbSet<SensorOfflineNotification> SensorOfflineNotifications { get; set; }
         public DbSet<AppSettings> AppSettings { get; set; }
+        public DbSet<Product> Products { get; set; }
+        public DbSet<Subscription.Subscription> Subscriptions { get; set; }
+        public DbSet<ShopItem> ShopItems { get; set; }
+        public DbSet<Order> Orders { get; set; }
+        public DbSet<OrderItem> OrderItems { get; set; }
+        public DbSet<Invoice> Invoices { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -223,7 +231,68 @@ namespace garge_api.Models
                 .ToTable(t => t.HasCheckConstraint("CK_AppSettings_SingleRow", "\"Id\" = 1"));
 
             modelBuilder.Entity<AppSettings>()
-                .HasData(new AppSettings { Id = 1, CookieBannerEnabled = true });
+                .HasData(new AppSettings());
+
+            modelBuilder.Entity<Product>()
+                .HasIndex(p => p.IsActive);
+
+            modelBuilder.Entity<Subscription.Subscription>()
+                .HasOne(s => s.User)
+                .WithMany()
+                .HasForeignKey(s => s.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<Subscription.Subscription>()
+                .HasOne(s => s.Product)
+                .WithMany()
+                .HasForeignKey(s => s.ProductId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<Subscription.Subscription>()
+                .HasIndex(s => s.VippsAgreementId)
+                .IsUnique();
+
+            modelBuilder.Entity<Subscription.Subscription>()
+                .HasIndex(s => new { s.UserId, s.Status });
+
+            modelBuilder.Entity<ShopItem>()
+                .HasIndex(si => si.IsActive);
+
+            modelBuilder.Entity<Order>()
+                .HasOne(o => o.User)
+                .WithMany()
+                .HasForeignKey(o => o.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<Order>()
+                .HasIndex(o => o.VippsOrderId)
+                .IsUnique()
+                .HasFilter("\"VippsOrderId\" IS NOT NULL");
+
+            modelBuilder.Entity<Order>()
+                .HasIndex(o => o.UserId);
+
+            modelBuilder.Entity<OrderItem>()
+                .HasOne(oi => oi.Order)
+                .WithMany(o => o.OrderItems)
+                .HasForeignKey(oi => oi.OrderId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<OrderItem>()
+                .HasOne(oi => oi.ShopItem)
+                .WithMany()
+                .HasForeignKey(oi => oi.ShopItemId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<Invoice>()
+                .HasOne(i => i.Order)
+                .WithOne(o => o.Invoice)
+                .HasForeignKey<Invoice>(i => i.OrderId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<Invoice>()
+                .HasIndex(i => i.OrderId)
+                .IsUnique();
         }
         public void EnsureTriggers()
         {

--- a/Models/ApplicationDbContext.cs
+++ b/Models/ApplicationDbContext.cs
@@ -10,14 +10,17 @@ using garge_api.Models.Shop;
 using garge_api.Models.Subscription;
 using garge_api.Models.Switch;
 using garge_api.Models.Webhook;
+using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace garge_api.Models
 {
-    public partial class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : IdentityDbContext<User, IdentityRole, string>(options)
+    public partial class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+        : IdentityDbContext<User, IdentityRole, string>(options), IDataProtectionKeyContext
     {
+        public DbSet<DataProtectionKey> DataProtectionKeys { get; set; }
         public DbSet<UserProfile> UserProfiles { get; set; }
         public DbSet<RolePermission> RolePermissions { get; set; }
         public DbSet<Sensor.Sensor> Sensors { get; set; }
@@ -50,6 +53,7 @@ namespace garge_api.Models
         public DbSet<Order> Orders { get; set; }
         public DbSet<OrderItem> OrderItems { get; set; }
         public DbSet<Invoice> Invoices { get; set; }
+        public DbSet<ProcessedWebhookEvent> ProcessedWebhookEvents { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -293,6 +297,12 @@ namespace garge_api.Models
             modelBuilder.Entity<Invoice>()
                 .HasIndex(i => i.OrderId)
                 .IsUnique();
+
+            modelBuilder.Entity<ProcessedWebhookEvent>()
+                .HasIndex(p => new { p.Source, p.Id });
+
+            modelBuilder.Entity<ProcessedWebhookEvent>()
+                .HasIndex(p => p.ProcessedAt);
         }
         public void EnsureTriggers()
         {

--- a/Models/Sensor/UserSensor.cs
+++ b/Models/Sensor/UserSensor.cs
@@ -11,6 +11,8 @@ namespace garge_api.Models.Sensor
         [Required]
         public int SensorId { get; set; }
 
+        public bool IsOwner { get; set; } = true;
+
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
         [ForeignKey(nameof(UserId))]

--- a/Models/Shop/Invoice.cs
+++ b/Models/Shop/Invoice.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace garge_api.Models.Shop
+{
+    public class Invoice
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+
+        [Required]
+        public int OrderId { get; set; }
+
+        [ForeignKey(nameof(OrderId))]
+        public Order? Order { get; set; }
+
+        public DateTime IssuedAt { get; set; } = DateTime.UtcNow;
+
+        [Required]
+        public required byte[] PdfData { get; set; }
+    }
+}

--- a/Models/Shop/Order.cs
+++ b/Models/Shop/Order.cs
@@ -39,6 +39,8 @@ namespace garge_api.Models.Shop
 
         public DateTime? ShippedAt { get; set; }
 
+        public bool IsTest { get; set; } = false;
+
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
         public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;

--- a/Models/Shop/Order.cs
+++ b/Models/Shop/Order.cs
@@ -39,7 +39,7 @@ namespace garge_api.Models.Shop
 
         public DateTime? ShippedAt { get; set; }
 
-        public bool IsTest { get; set; } = false;
+        public bool IsTest { get; set; }
 
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 

--- a/Models/Shop/Order.cs
+++ b/Models/Shop/Order.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace garge_api.Models.Shop
+{
+    public enum OrderStatus
+    {
+        Pending = 0,
+        Paid = 1,
+        Failed = 2,
+        Refunded = 3,
+        Reserved = 4,
+        Cancelled = 5
+    }
+
+    public class Order
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+
+        [Required]
+        public required string UserId { get; set; }
+
+        [ForeignKey(nameof(UserId))]
+        public User? User { get; set; }
+
+        [MaxLength(200)]
+        public string? VippsOrderId { get; set; }
+
+        [Required]
+        public OrderStatus Status { get; set; } = OrderStatus.Pending;
+
+        [Required]
+        public int TotalInOre { get; set; }
+
+        [MaxLength(500)]
+        public string? ShippingAddress { get; set; }
+
+        public DateTime? ShippedAt { get; set; }
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+        public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+        public List<OrderItem> OrderItems { get; set; } = [];
+
+        public Invoice? Invoice { get; set; }
+    }
+}

--- a/Models/Shop/OrderItem.cs
+++ b/Models/Shop/OrderItem.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace garge_api.Models.Shop
+{
+    public class OrderItem
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+
+        [Required]
+        public int OrderId { get; set; }
+
+        [ForeignKey(nameof(OrderId))]
+        public Order? Order { get; set; }
+
+        [Required]
+        public int ShopItemId { get; set; }
+
+        [ForeignKey(nameof(ShopItemId))]
+        public ShopItem? ShopItem { get; set; }
+
+        [Required]
+        public int Quantity { get; set; }
+
+        [Required]
+        public int PriceAtPurchaseInOre { get; set; }
+
+        [Required]
+        public int UnitPriceExclVatInOre { get; set; }
+
+        [Required]
+        public int VatPercentage { get; set; }
+    }
+}

--- a/Models/Shop/ShopItem.cs
+++ b/Models/Shop/ShopItem.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace garge_api.Models.Shop
+{
+    public class ShopItem
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+
+        [Required]
+        [MaxLength(100)]
+        public required string Name { get; set; }
+
+        [MaxLength(1000)]
+        public string? Description { get; set; }
+
+        [Required]
+        public int PriceInOre { get; set; }
+
+        public int StockCount { get; set; } = -1;
+
+        public bool IsActive { get; set; } = true;
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/Models/Subscription/Product.cs
+++ b/Models/Subscription/Product.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace garge_api.Models.Subscription
+{
+    public enum BillingInterval
+    {
+        Monthly = 0,
+        Yearly = 1
+    }
+
+    public class Product
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+
+        [Required]
+        [MaxLength(100)]
+        public required string Name { get; set; }
+
+        [MaxLength(500)]
+        public string? Description { get; set; }
+
+        [Required]
+        public int PriceInOre { get; set; }
+
+        [Required]
+        public BillingInterval Interval { get; set; }
+
+        public bool IsActive { get; set; } = true;
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/Models/Subscription/Product.cs
+++ b/Models/Subscription/Product.cs
@@ -9,6 +9,12 @@ namespace garge_api.Models.Subscription
         Yearly = 1
     }
 
+    public enum ProductType
+    {
+        Primary = 0,
+        AddOn = 1
+    }
+
     public class Product
     {
         [Key]
@@ -27,6 +33,9 @@ namespace garge_api.Models.Subscription
 
         [Required]
         public BillingInterval Interval { get; set; }
+
+        [Required]
+        public ProductType Type { get; set; } = ProductType.Primary;
 
         public bool IsActive { get; set; } = true;
 

--- a/Models/Subscription/Subscription.cs
+++ b/Models/Subscription/Subscription.cs
@@ -33,6 +33,9 @@ namespace garge_api.Models.Subscription
         [MaxLength(200)]
         public required string VippsAgreementId { get; set; }
 
+        [MaxLength(500)]
+        public string? VippsConfirmationUrl { get; set; }
+
         [Required]
         public SubscriptionStatus Status { get; set; } = SubscriptionStatus.Pending;
 

--- a/Models/Subscription/Subscription.cs
+++ b/Models/Subscription/Subscription.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace garge_api.Models.Subscription
+{
+    public enum SubscriptionStatus
+    {
+        Pending = 0,
+        Active = 1,
+        Stopped = 2,
+        Expired = 3
+    }
+
+    public class Subscription
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+
+        [Required]
+        public required string UserId { get; set; }
+
+        [ForeignKey(nameof(UserId))]
+        public User? User { get; set; }
+
+        [Required]
+        public int ProductId { get; set; }
+
+        [ForeignKey(nameof(ProductId))]
+        public Product? Product { get; set; }
+
+        [Required]
+        [MaxLength(200)]
+        public required string VippsAgreementId { get; set; }
+
+        [Required]
+        public SubscriptionStatus Status { get; set; } = SubscriptionStatus.Pending;
+
+        public DateTime? StartDate { get; set; }
+
+        public DateTime? NextChargeDate { get; set; }
+
+        public DateTime? ConsentAcceptedAt { get; set; }
+
+        [MaxLength(45)]
+        public string? ConsentIp { get; set; }
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+        public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/Models/Subscription/Subscription.cs
+++ b/Models/Subscription/Subscription.cs
@@ -45,7 +45,7 @@ namespace garge_api.Models.Subscription
         [MaxLength(45)]
         public string? ConsentIp { get; set; }
 
-        public bool IsTest { get; set; } = false;
+        public bool IsTest { get; set; }
 
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 

--- a/Models/Subscription/Subscription.cs
+++ b/Models/Subscription/Subscription.cs
@@ -45,6 +45,8 @@ namespace garge_api.Models.Subscription
         [MaxLength(45)]
         public string? ConsentIp { get; set; }
 
+        public bool IsTest { get; set; } = false;
+
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
         public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;

--- a/Models/Webhook/ProcessedWebhookEvent.cs
+++ b/Models/Webhook/ProcessedWebhookEvent.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace garge_api.Models.Webhook
+{
+    public class ProcessedWebhookEvent
+    {
+        [Key]
+        [MaxLength(200)]
+        public required string Id { get; set; }
+
+        [Required]
+        [MaxLength(50)]
+        public required string Source { get; set; }
+
+        public DateTime ProcessedAt { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/Profiles/MappingProfile.cs
+++ b/Profiles/MappingProfile.cs
@@ -27,7 +27,8 @@ public class MappingProfile : Profile
         CreateMap<User, UserDto>();
         CreateMap<AppSettings, AppSettingsDto>();
         CreateMap<AppSettings, PublicSettingsDto>();
-        CreateMap<UpdateAppSettingsDto, AppSettings>();
+        CreateMap<UpdateAppSettingsDto, AppSettings>()
+            .ForAllMembers(opt => opt.Condition((_, _, srcMember) => srcMember != null));
 
         // Electricity mappings
         CreateMap<PriceResponse, PriceResponseDto>();
@@ -64,7 +65,8 @@ public class MappingProfile : Profile
 
         // Subscription plan mappings
         CreateMap<Product, ProductResponseDto>()
-            .ForMember(d => d.Interval, o => o.MapFrom(s => s.Interval.ToString()));
+            .ForMember(d => d.Interval, o => o.MapFrom(s => s.Interval.ToString()))
+            .ForMember(d => d.Type, o => o.MapFrom(s => s.Type.ToString()));
         CreateMap<CreateProductDto, Product>();
         CreateMap<UpdateProductDto, Product>();
 
@@ -72,6 +74,7 @@ public class MappingProfile : Profile
             .ForMember(d => d.Status, o => o.MapFrom(s => s.Status.ToString()))
             .ForMember(d => d.Interval, o => o.MapFrom(s => s.Product != null ? s.Product.Interval.ToString() : string.Empty))
             .ForMember(d => d.ProductName, o => o.MapFrom(s => s.Product != null ? s.Product.Name : string.Empty))
+            .ForMember(d => d.ProductType, o => o.MapFrom(s => s.Product != null ? s.Product.Type.ToString() : string.Empty))
             .ForMember(d => d.PriceInOre, o => o.MapFrom(s => s.Product != null ? s.Product.PriceInOre : 0));
 
         // Shop mappings

--- a/Profiles/MappingProfile.cs
+++ b/Profiles/MappingProfile.cs
@@ -3,12 +3,16 @@ using garge_api.Dtos.Admin;
 using garge_api.Dtos.Auth;
 using garge_api.Dtos.Electricity;
 using garge_api.Dtos.Sensor;
+using garge_api.Dtos.Shop;
+using garge_api.Dtos.Subscription;
 using garge_api.Dtos.Switch;
 using garge_api.Dtos.User;
 using garge_api.Dtos.Webhook;
 using garge_api.Models.Admin;
 using garge_api.Models.Electricity;
 using garge_api.Models.Sensor;
+using garge_api.Models.Shop;
+using garge_api.Models.Subscription;
 using garge_api.Models.Switch;
 using garge_api.Models.Webhook;
 using Microsoft.AspNetCore.Identity;
@@ -22,6 +26,7 @@ public class MappingProfile : Profile
         CreateMap<RolePermission, RolePermissionDto>().ReverseMap();
         CreateMap<User, UserDto>();
         CreateMap<AppSettings, AppSettingsDto>();
+        CreateMap<AppSettings, PublicSettingsDto>();
         CreateMap<UpdateAppSettingsDto, AppSettings>();
 
         // Electricity mappings
@@ -57,5 +62,38 @@ public class MappingProfile : Profile
         CreateMap<WebhookSubscription, WebhookSubscriptionDto>().ReverseMap();
         CreateMap<CreateWebhookSubscriptionDto, WebhookSubscription>();
 
+        // Subscription plan mappings
+        CreateMap<Product, ProductResponseDto>()
+            .ForMember(d => d.Interval, o => o.MapFrom(s => s.Interval.ToString()));
+        CreateMap<CreateProductDto, Product>();
+        CreateMap<UpdateProductDto, Product>();
+
+        CreateMap<garge_api.Models.Subscription.Subscription, SubscriptionResponseDto>()
+            .ForMember(d => d.Status, o => o.MapFrom(s => s.Status.ToString()))
+            .ForMember(d => d.Interval, o => o.MapFrom(s => s.Product != null ? s.Product.Interval.ToString() : string.Empty))
+            .ForMember(d => d.ProductName, o => o.MapFrom(s => s.Product != null ? s.Product.Name : string.Empty))
+            .ForMember(d => d.PriceInOre, o => o.MapFrom(s => s.Product != null ? s.Product.PriceInOre : 0));
+
+        // Shop mappings
+        CreateMap<ShopItem, ShopItemResponseDto>();
+        CreateMap<CreateShopItemDto, ShopItem>();
+        CreateMap<UpdateShopItemDto, ShopItem>();
+
+        CreateMap<Order, OrderResponseDto>()
+            .ForMember(d => d.Status, o => o.MapFrom(s => s.Status.ToString()))
+            .ForMember(d => d.Items, o => o.MapFrom(s => s.OrderItems))
+            .ForMember(d => d.HasInvoice, o => o.MapFrom(s => s.Invoice != null));
+
+        CreateMap<OrderItem, OrderItemResponseDto>()
+            .ForMember(d => d.ShopItemName, o => o.MapFrom(s => s.ShopItem != null ? s.ShopItem.Name : string.Empty));
+
+        CreateMap<Invoice, InvoiceResponseDto>();
+
+        CreateMap<Order, AdminOrderResponseDto>()
+            .ForMember(d => d.Status, o => o.MapFrom(s => s.Status.ToString()))
+            .ForMember(d => d.Items, o => o.MapFrom(s => s.OrderItems))
+            .ForMember(d => d.HasInvoice, o => o.MapFrom(s => s.Invoice != null))
+            .ForMember(d => d.UserEmail, o => o.MapFrom(s => s.User != null ? s.User.Email ?? string.Empty : string.Empty))
+            .ForMember(d => d.UserName, o => o.MapFrom(s => s.User != null ? $"{s.User.FirstName} {s.User.LastName}" : string.Empty));
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -17,6 +17,9 @@ using System.IO.Compression;
 using garge_api.Authorization;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.Caching.Memory;
+using System.Security.Claims;
 
 namespace garge_api
 {
@@ -94,6 +97,31 @@ namespace garge_api
                     ValidIssuer = jwtIssuer,
                     ValidAudience = jwtIssuer,
                     IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey))
+                };
+                options.Events = new Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerEvents
+                {
+                    OnTokenValidated = async ctx =>
+                    {
+                        var userId = ctx.Principal?.FindFirstValue(System.Security.Claims.ClaimTypes.NameIdentifier);
+                        if (string.IsNullOrEmpty(userId))
+                        {
+                            ctx.Fail("Missing user id claim.");
+                            return;
+                        }
+
+                        var cache = ctx.HttpContext.RequestServices.GetRequiredService<Microsoft.Extensions.Caching.Memory.IMemoryCache>();
+                        var cacheKey = $"user_exists:{userId}";
+                        if (cache.TryGetValue(cacheKey, out bool exists))
+                        {
+                            if (!exists) ctx.Fail("User no longer exists.");
+                            return;
+                        }
+
+                        var db = ctx.HttpContext.RequestServices.GetRequiredService<ApplicationDbContext>();
+                        exists = await db.Users.AsNoTracking().AnyAsync(u => u.Id == userId);
+                        cache.Set(cacheKey, exists, TimeSpan.FromSeconds(60));
+                        if (!exists) ctx.Fail("User no longer exists.");
+                    }
                 };
             });
 
@@ -212,6 +240,15 @@ namespace garge_api
                 }
             }
 
+            var fwd = new ForwardedHeadersOptions
+            {
+                ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto,
+                ForwardLimit = 2
+            };
+            fwd.KnownNetworks.Clear();
+            fwd.KnownProxies.Clear();
+            app.UseForwardedHeaders(fwd);
+
             app.UseResponseCompression();
             app.UseSwagger();
             app.UseSwaggerUI(c =>
@@ -219,7 +256,6 @@ namespace garge_api
                 c.SwaggerEndpoint("/swagger/v1/swagger.json", "Garge API V1");
             });
 
-            app.UseStaticFiles();
             app.UseRouting();
             app.UseMiddleware<RequestLoggingMiddleware>();
             app.UseCors("AllowAllOrigins");

--- a/Program.cs
+++ b/Program.cs
@@ -14,6 +14,8 @@ using garge_api.Models.Admin;
 using Serilog;
 using Microsoft.AspNetCore.ResponseCompression;
 using System.IO.Compression;
+using garge_api.Authorization;
+using Microsoft.AspNetCore.Authorization;
 
 namespace garge_api
 {
@@ -97,7 +99,15 @@ namespace garge_api
             builder.Services.AddAuthorization(options =>
             {
                 options.AddPolicy("Admin", policy => policy.RequireRole("Admin"));
+                options.AddPolicy("ActiveSubscription", policy =>
+                    policy.AddRequirements(new ActiveSubscriptionRequirement()));
             });
+            builder.Services.AddSingleton<IAuthorizationHandler, ActiveSubscriptionHandler>();
+            builder.Services.Configure<AppOptions>(builder.Configuration.GetSection("App"));
+            builder.Services.Configure<VippsOptions>(builder.Configuration.GetSection("Vipps"));
+            builder.Services.AddScoped<IInvoiceService, InvoiceService>();
+            builder.Services.AddHttpClient<IVippsService, VippsService>();
+            builder.Services.AddHostedService<VippsWebhookRegistrationService>();
 
             var allowedOrigins = builder.Configuration
                 .GetSection("Cors:AllowedOrigins")

--- a/Program.cs
+++ b/Program.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.ResponseCompression;
 using System.IO.Compression;
 using garge_api.Authorization;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.DataProtection;
 
 namespace garge_api
 {
@@ -105,9 +106,15 @@ namespace garge_api
             builder.Services.AddSingleton<IAuthorizationHandler, ActiveSubscriptionHandler>();
             builder.Services.Configure<AppOptions>(builder.Configuration.GetSection("App"));
             builder.Services.Configure<VippsOptions>(builder.Configuration.GetSection("Vipps"));
+            builder.Services.AddDataProtection()
+                .PersistKeysToDbContext<ApplicationDbContext>()
+                .SetApplicationName("garge-api");
+            builder.Services.AddSingleton<IWebhookSecretProtector, WebhookSecretProtector>();
+            builder.Services.AddSingleton<IAppSettingsCache, AppSettingsCache>();
             builder.Services.AddScoped<IInvoiceService, InvoiceService>();
             builder.Services.AddHttpClient<IVippsService, VippsService>();
             builder.Services.AddHostedService<VippsWebhookRegistrationService>();
+            builder.Services.AddHostedService<ProcessedWebhookEventCleanupService>();
 
             var allowedOrigins = builder.Configuration
                 .GetSection("Cors:AllowedOrigins")

--- a/Services/AppOptions.cs
+++ b/Services/AppOptions.cs
@@ -1,0 +1,8 @@
+namespace garge_api.Services
+{
+    public class AppOptions
+    {
+        public required string FrontendBaseUrl { get; set; }
+        public required string ApiBaseUrl { get; set; }
+    }
+}

--- a/Services/AppSettingsCache.cs
+++ b/Services/AppSettingsCache.cs
@@ -1,0 +1,38 @@
+using garge_api.Models;
+using garge_api.Models.Admin;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace garge_api.Services
+{
+    public class AppSettingsCache : IAppSettingsCache
+    {
+        private const string CacheKey = "app_settings";
+        private static readonly TimeSpan Ttl = TimeSpan.FromSeconds(30);
+
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly IMemoryCache _cache;
+
+        public AppSettingsCache(IServiceScopeFactory scopeFactory, IMemoryCache cache)
+        {
+            _scopeFactory = scopeFactory;
+            _cache = cache;
+        }
+
+        public async Task<AppSettings> GetAsync()
+        {
+            if (_cache.TryGetValue(CacheKey, out AppSettings? cached) && cached != null)
+                return cached;
+
+            using var scope = _scopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var settings = await db.AppSettings.AsNoTracking().FirstOrDefaultAsync(s => s.Id == 1)
+                           ?? new AppSettings { Id = 1 };
+
+            _cache.Set(CacheKey, settings, Ttl);
+            return settings;
+        }
+
+        public void Invalidate() => _cache.Remove(CacheKey);
+    }
+}

--- a/Services/IAppSettingsCache.cs
+++ b/Services/IAppSettingsCache.cs
@@ -1,0 +1,10 @@
+using garge_api.Models.Admin;
+
+namespace garge_api.Services
+{
+    public interface IAppSettingsCache
+    {
+        Task<AppSettings> GetAsync();
+        void Invalidate();
+    }
+}

--- a/Services/IInvoiceService.cs
+++ b/Services/IInvoiceService.cs
@@ -1,0 +1,7 @@
+namespace garge_api.Services
+{
+    public interface IInvoiceService
+    {
+        Task<int> GenerateAndStoreAsync(int orderId);
+    }
+}

--- a/Services/IVippsService.cs
+++ b/Services/IVippsService.cs
@@ -3,6 +3,17 @@ using garge_api.Models.Subscription;
 
 namespace garge_api.Services
 {
+    public enum WebhookVerifyResult
+    {
+        Valid,
+        MissingSecret,
+        MissingHeader,
+        BadDate,
+        Stale,
+        BadContentHash,
+        BadSignature
+    }
+
     public class VippsCreateAgreementResponse
     {
         public string AgreementId { get; set; } = string.Empty;
@@ -37,7 +48,8 @@ namespace garge_api.Services
         public int UnitPriceInOre { get; set; }
         public int UnitPriceExclVatInOre { get; set; }
         public int Quantity { get; set; }
-        public int TaxPercentage { get; set; }
+        /// <summary>VAT in basis points (Vipps spec: 0..10000, where 2500 = 25%).</summary>
+        public int TaxPercentageBasisPoints { get; set; }
     }
 
     public interface IVippsService
@@ -45,17 +57,19 @@ namespace garge_api.Services
         Task<string> GetAccessTokenAsync();
 
         Task<VippsCreateAgreementResponse> CreateAgreementAsync(
-            Product product, string userId, string redirectUrl, string phoneNumber, int effectivePriceInOre);
+            Product product, string userId, string redirectUrl, string phoneNumber,
+            int effectivePriceInOre, string idempotencyKey);
         Task<VippsAgreementResponse> GetAgreementAsync(string agreementId);
-        Task CancelAgreementAsync(string agreementId);
+        Task CancelAgreementAsync(string agreementId, string idempotencyKey);
 
         Task<VippsCreatePaymentResponse> CreatePaymentAsync(
-            Order order, List<VippsOrderLine> receiptLines, string redirectUrl, string phoneNumber);
+            Order order, List<VippsOrderLine> receiptLines, string redirectUrl,
+            string phoneNumber, string idempotencyKey);
         Task<VippsPaymentResponse> GetPaymentAsync(string reference);
-        Task CapturePaymentAsync(string reference, int amountInOre);
-        Task CancelPaymentAsync(string reference);
+        Task CapturePaymentAsync(string reference, int amountInOre, string idempotencyKey);
+        Task CancelPaymentAsync(string reference, string idempotencyKey);
 
         Task<(string WebhookId, string Secret)> RegisterWebhookAsync(string url, string[] events);
-        bool VerifyWebhookSignature(string rawBody, string signatureHeader, string secret);
+        WebhookVerifyResult VerifyWebhookSignature(HttpRequest request, string rawBody, string secret);
     }
 }

--- a/Services/IVippsService.cs
+++ b/Services/IVippsService.cs
@@ -1,0 +1,61 @@
+using garge_api.Models.Shop;
+using garge_api.Models.Subscription;
+
+namespace garge_api.Services
+{
+    public class VippsCreateAgreementResponse
+    {
+        public string AgreementId { get; set; } = string.Empty;
+        public string VippsConfirmationUrl { get; set; } = string.Empty;
+    }
+
+    public class VippsAgreementResponse
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
+        public string ProductName { get; set; } = string.Empty;
+        public DateTime? Start { get; set; }
+        public DateTime? Stop { get; set; }
+    }
+
+    public class VippsCreatePaymentResponse
+    {
+        public string RedirectUrl { get; set; } = string.Empty;
+        public string Reference { get; set; } = string.Empty;
+    }
+
+    public class VippsPaymentResponse
+    {
+        public string Reference { get; set; } = string.Empty;
+        public string State { get; set; } = string.Empty;
+    }
+
+    public class VippsOrderLine
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Id { get; set; } = string.Empty;
+        public int UnitPriceInOre { get; set; }
+        public int UnitPriceExclVatInOre { get; set; }
+        public int Quantity { get; set; }
+        public int TaxPercentage { get; set; }
+    }
+
+    public interface IVippsService
+    {
+        Task<string> GetAccessTokenAsync();
+
+        Task<VippsCreateAgreementResponse> CreateAgreementAsync(
+            Product product, string userId, string redirectUrl, string phoneNumber, int effectivePriceInOre);
+        Task<VippsAgreementResponse> GetAgreementAsync(string agreementId);
+        Task CancelAgreementAsync(string agreementId);
+
+        Task<VippsCreatePaymentResponse> CreatePaymentAsync(
+            Order order, List<VippsOrderLine> receiptLines, string redirectUrl, string phoneNumber);
+        Task<VippsPaymentResponse> GetPaymentAsync(string reference);
+        Task CapturePaymentAsync(string reference, int amountInOre);
+        Task CancelPaymentAsync(string reference);
+
+        Task<(string WebhookId, string Secret)> RegisterWebhookAsync(string url, string[] events);
+        bool VerifyWebhookSignature(string rawBody, string signatureHeader, string secret);
+    }
+}

--- a/Services/InvoiceService.cs
+++ b/Services/InvoiceService.cs
@@ -1,0 +1,296 @@
+using garge_api.Models;
+using garge_api.Models.Admin;
+using garge_api.Models.Shop;
+using Microsoft.EntityFrameworkCore;
+using PuppeteerSharp;
+using PuppeteerSharp.Media;
+using System.Globalization;
+using System.Text;
+using System.Web;
+
+namespace garge_api.Services
+{
+    public class InvoiceService : IInvoiceService
+    {
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly IEmailService _emailService;
+        private readonly ILogger<InvoiceService> _logger;
+
+        public InvoiceService(
+            IServiceScopeFactory scopeFactory,
+            IEmailService emailService,
+            ILogger<InvoiceService> logger)
+        {
+            _scopeFactory = scopeFactory;
+            _emailService = emailService;
+            _logger = logger;
+        }
+
+        public async Task<int> GenerateAndStoreAsync(int orderId)
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+            var order = await db.Orders
+                .Include(o => o.User)
+                .Include(o => o.OrderItems).ThenInclude(i => i.ShopItem)
+                .FirstOrDefaultAsync(o => o.Id == orderId)
+                ?? throw new InvalidOperationException($"Order {orderId} not found");
+
+            var settings = await db.AppSettings.FindAsync(1) ?? new AppSettings();
+
+            // Save first to get the sequential invoice ID, then fill PDF
+            var invoice = new Invoice { OrderId = orderId, IssuedAt = DateTime.UtcNow, PdfData = [] };
+            db.Invoices.Add(invoice);
+            await db.SaveChangesAsync();
+
+            var html = BuildInvoiceHtml(order, settings, invoice.Id, invoice.IssuedAt);
+            invoice.PdfData = await RenderPdfAsync(html);
+            await db.SaveChangesAsync();
+
+            try
+            {
+                var buyerEmail = order.User?.Email;
+                if (!string.IsNullOrEmpty(buyerEmail))
+                    await _emailService.SendEmailAsync(
+                        buyerEmail,
+                        $"Invoice #{invoice.Id:D4} — {settings.CompanyName}",
+                        html);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to email invoice {InvoiceId} for order {OrderId}", invoice.Id, orderId);
+            }
+
+            _logger.LogInformation("Invoice {InvoiceId} generated for order {OrderId}", invoice.Id, orderId);
+            return invoice.Id;
+        }
+
+        private static async Task<byte[]> RenderPdfAsync(string html)
+        {
+            var browserFetcher = new BrowserFetcher();
+            await browserFetcher.DownloadAsync();
+
+            await using var browser = await Puppeteer.LaunchAsync(new LaunchOptions
+            {
+                Headless = true,
+                Args = ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage"]
+            });
+            await using var page = await browser.NewPageAsync();
+            await page.SetContentAsync(html, new NavigationOptions
+            {
+                WaitUntil = [WaitUntilNavigation.Networkidle0]
+            });
+
+            return await page.PdfDataAsync(new PdfOptions
+            {
+                Format = PaperFormat.A4,
+                PrintBackground = true,
+                MarginOptions = new MarginOptions { Top = "0", Bottom = "15mm", Left = "0", Right = "0" }
+            });
+        }
+
+        private static string BuildInvoiceHtml(Order order, AppSettings s, int invoiceId, DateTime issuedAt)
+        {
+            static string Nok(int ore) => (ore / 100.0).ToString("N2", CultureInfo.InvariantCulture);
+            static string H(string? v) => HttpUtility.HtmlEncode(v ?? string.Empty);
+
+            var orgLine = s.VatEnabled ? $"{s.CompanyOrgNumber} MVA" : s.CompanyOrgNumber;
+
+            var vatHeaders = s.VatEnabled
+                ? """<th class="r">VAT %</th><th class="r">VAT</th>"""
+                : string.Empty;
+
+            var linesSb = new StringBuilder();
+            int totalExcl = 0, totalVat = 0;
+
+            foreach (var item in order.OrderItems)
+            {
+                int lineIncl = item.PriceAtPurchaseInOre * item.Quantity;
+                int lineExcl = item.UnitPriceExclVatInOre * item.Quantity;
+                int lineVat  = lineIncl - lineExcl;
+                totalExcl   += lineExcl;
+                totalVat    += lineVat;
+
+                var vatCols = s.VatEnabled
+                    ? $"""<td class="r">{item.VatPercentage}%</td><td class="r">NOK {Nok(lineVat)}</td>"""
+                    : string.Empty;
+
+                linesSb.Append($"""
+                    <tr>
+                      <td>{H(item.ShopItem?.Name)}</td>
+                      <td class="c">{item.Quantity}</td>
+                      <td class="r">NOK {Nok(item.UnitPriceExclVatInOre)}</td>
+                      {vatCols}
+                      <td class="r">NOK {Nok(lineIncl)}</td>
+                    </tr>
+                    """);
+            }
+
+            var subRows = s.VatEnabled
+                ? $"""
+                    <tr class="sub"><td class="r">Subtotal excl. VAT</td><td class="r">NOK {Nok(totalExcl)}</td></tr>
+                    <tr class="sub"><td class="r">VAT</td><td class="r">NOK {Nok(totalVat)}</td></tr>
+                  """
+                : string.Empty;
+
+            var vatFootnote = s.VatEnabled
+                ? string.Empty
+                : "<p>Not VAT registered — below the NOK 50,000 registration threshold.</p>";
+
+            var deliveryNote = order.ShippedAt.HasValue
+                ? $"Shipped on {order.ShippedAt.Value:yyyy-MM-dd}."
+                : "Estimated delivery: 3–5 business days from shipment.";
+
+            var buyerName = order.User != null ? $"{order.User.FirstName} {order.User.LastName}" : "—";
+
+            return $$"""
+                <!DOCTYPE html>
+                <html>
+                <head>
+                <meta charset="utf-8">
+                <style>
+                  * { box-sizing: border-box; margin: 0; padding: 0; }
+                  body { font-family: Arial, Helvetica, sans-serif; font-size: 12px; color: #1a1a1a; background: #fff; }
+
+                  .header-band {
+                    background: #0284c7;
+                    color: #fff;
+                    padding: 28px 32px 20px;
+                    display: flex;
+                    justify-content: space-between;
+                    align-items: flex-start;
+                  }
+                  .brand { font-size: 22px; font-weight: 700; letter-spacing: .04em; margin-bottom: 4px; }
+                  .brand-sub { font-size: 11px; opacity: .85; }
+                  .inv-meta { text-align: right; }
+                  .inv-number { font-size: 28px; font-weight: 700; line-height: 1; margin-bottom: 4px; }
+                  .inv-date { font-size: 11px; opacity: .85; margin-bottom: 6px; }
+                  .badge {
+                    display: inline-block;
+                    background: rgba(255,255,255,0.25);
+                    border: 1px solid rgba(255,255,255,0.5);
+                    color: #fff;
+                    padding: 2px 10px;
+                    border-radius: 20px;
+                    font-size: 10px;
+                    font-weight: 700;
+                    letter-spacing: .08em;
+                    text-transform: uppercase;
+                  }
+                  .body { padding: 24px 32px; }
+                  .parties { display: flex; gap: 40px; margin-bottom: 24px; }
+                  .party { flex: 1; }
+                  .party-label {
+                    font-size: 9px; font-weight: 700; text-transform: uppercase;
+                    letter-spacing: .1em; color: #0284c7; margin-bottom: 6px;
+                  }
+                  .party p { line-height: 1.6; color: #333; }
+                  table { width: 100%; border-collapse: collapse; }
+                  th {
+                    font-size: 10px; font-weight: 700; text-transform: uppercase;
+                    letter-spacing: .06em; color: #0284c7;
+                    border-bottom: 2px solid #0284c7;
+                    padding: 7px 8px; text-align: left;
+                  }
+                  td { padding: 7px 8px; border-bottom: 1px solid #e5e7eb; }
+                  tr:last-child td { border-bottom: none; }
+                  tbody tr:nth-child(even) { background: #f8fafc; }
+                  .r { text-align: right; }
+                  .c { text-align: center; }
+                  .totals-section { margin-top: 8px; border-top: 2px solid #e5e7eb; padding-top: 8px; }
+                  .totals-section table { width: 40%; margin-left: auto; }
+                  .sub td { padding: 3px 8px; color: #555; }
+                  .grand td {
+                    padding: 7px 8px; font-weight: 700; font-size: 14px;
+                    border-top: 2px solid #0284c7; color: #0284c7;
+                  }
+                  .footer {
+                    margin: 24px 32px 0;
+                    padding-top: 12px;
+                    border-top: 1px solid #e5e7eb;
+                    font-size: 10px; color: #888; line-height: 1.6;
+                  }
+                  .footer p + p { margin-top: 2px; }
+                </style>
+                </head>
+                <body>
+
+                <div class="header-band">
+                  <div>
+                    <div class="brand">{{H(s.CompanyName)}}</div>
+                    <div class="brand-sub">
+                      {{H(s.CompanyLegalName)}}<br>
+                      Org. no. {{H(orgLine)}}<br>
+                      {{H(s.CompanyAddress)}}<br>
+                      {{H(s.CompanyEmail)}}
+                    </div>
+                  </div>
+                  <div class="inv-meta">
+                    <div class="inv-number">#{{invoiceId:D4}}</div>
+                    <div class="inv-date">INVOICE &nbsp;·&nbsp; {{issuedAt:yyyy-MM-dd}}</div>
+                    <span class="badge">Paid</span>
+                    <div style="margin-top:6px;font-size:10px;opacity:.75;">Vipps order #{{order.Id}}</div>
+                  </div>
+                </div>
+
+                <div class="body">
+                  <div class="parties">
+                    <div class="party">
+                      <div class="party-label">From</div>
+                      <p>
+                        <strong>{{H(s.CompanyLegalName)}}</strong><br>
+                        {{H(s.CompanyAddress)}}<br>
+                        {{H(s.CompanyEmail)}}
+                      </p>
+                    </div>
+                    <div class="party">
+                      <div class="party-label">Bill to</div>
+                      <p>
+                        <strong>{{H(buyerName)}}</strong><br>
+                        {{H(order.User?.Email)}}<br>
+                        {{H(order.ShippingAddress)}}
+                      </p>
+                    </div>
+                  </div>
+
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Description</th>
+                        <th class="c">Qty</th>
+                        <th class="r">Unit price</th>
+                        {{vatHeaders}}
+                        <th class="r">Amount</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {{linesSb}}
+                    </tbody>
+                  </table>
+
+                  <div class="totals-section">
+                    <table>
+                      <tbody>{{subRows}}</tbody>
+                      <tbody>
+                        <tr class="grand">
+                          <td>Total</td>
+                          <td class="r">NOK {{Nok(order.TotalInOre)}}</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+
+                <div class="footer">
+                  <p>Payment received via Vipps.</p>
+                  <p>Delivery address: {{H(order.ShippingAddress)}} — {{deliveryNote}}</p>
+                  {{vatFootnote}}
+                </div>
+
+                </body>
+                </html>
+                """;
+        }
+    }
+}

--- a/Services/Pricing.cs
+++ b/Services/Pricing.cs
@@ -1,0 +1,13 @@
+namespace garge_api.Services
+{
+    public static class Pricing
+    {
+        public const int VatPercent = 25;
+        public const int VatBasisPoints = 2500;
+
+        public static int EffectiveInOre(int priceInOre, bool vatEnabled) =>
+            vatEnabled
+                ? (int)Math.Round(priceInOre * (1 + VatPercent / 100.0), MidpointRounding.AwayFromZero)
+                : priceInOre;
+    }
+}

--- a/Services/ProcessedWebhookEventCleanupService.cs
+++ b/Services/ProcessedWebhookEventCleanupService.cs
@@ -1,0 +1,47 @@
+using garge_api.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace garge_api.Services
+{
+    public class ProcessedWebhookEventCleanupService : BackgroundService
+    {
+        private static readonly TimeSpan Interval = TimeSpan.FromHours(6);
+        private static readonly TimeSpan Retention = TimeSpan.FromDays(30);
+
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly ILogger<ProcessedWebhookEventCleanupService> _logger;
+
+        public ProcessedWebhookEventCleanupService(
+            IServiceScopeFactory scopeFactory,
+            ILogger<ProcessedWebhookEventCleanupService> logger)
+        {
+            _scopeFactory = scopeFactory;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    using var scope = _scopeFactory.CreateScope();
+                    var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                    var cutoff = DateTime.UtcNow - Retention;
+                    var deleted = await db.ProcessedWebhookEvents
+                        .Where(e => e.ProcessedAt < cutoff)
+                        .ExecuteDeleteAsync(stoppingToken);
+                    if (deleted > 0)
+                        _logger.LogInformation("Pruned {Count} processed webhook events older than {Cutoff}", deleted, cutoff);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "ProcessedWebhookEvent cleanup failed");
+                }
+
+                try { await Task.Delay(Interval, stoppingToken); }
+                catch (TaskCanceledException) { break; }
+            }
+        }
+    }
+}

--- a/Services/VippsOptions.cs
+++ b/Services/VippsOptions.cs
@@ -7,5 +7,11 @@ namespace garge_api.Services
         public required string MerchantSerialNumber { get; set; }
         public required string SubscriptionKey { get; set; }
         public required string BaseUrl { get; set; }
+
+        public string TestBaseUrl { get; set; } = "https://apitest.vipps.no";
+        public string TestClientId { get; set; } = string.Empty;
+        public string TestClientSecret { get; set; } = string.Empty;
+        public string TestMerchantSerialNumber { get; set; } = string.Empty;
+        public string TestSubscriptionKey { get; set; } = string.Empty;
     }
 }

--- a/Services/VippsOptions.cs
+++ b/Services/VippsOptions.cs
@@ -1,0 +1,11 @@
+namespace garge_api.Services
+{
+    public class VippsOptions
+    {
+        public required string ClientId { get; set; }
+        public required string ClientSecret { get; set; }
+        public required string MerchantSerialNumber { get; set; }
+        public required string SubscriptionKey { get; set; }
+        public required string BaseUrl { get; set; }
+    }
+}

--- a/Services/VippsService.cs
+++ b/Services/VippsService.cs
@@ -1,3 +1,4 @@
+using garge_api.Models;
 using garge_api.Models.Shop;
 using garge_api.Models.Subscription;
 using Microsoft.Extensions.Caching.Memory;
@@ -17,24 +18,28 @@ namespace garge_api.Services
         private readonly AppOptions _appOpts;
         private readonly IMemoryCache _cache;
         private readonly ILogger<VippsService> _logger;
+        private readonly IServiceScopeFactory _scopeFactory;
         private readonly string _systemName;
         private readonly string _systemVersion;
 
-        private const string TokenCacheKey = "vipps_access_token";
         private static readonly JsonSerializerOptions _jsonOpts = new() { PropertyNameCaseInsensitive = true };
+
+        private readonly record struct VippsEffective(string BaseUrl, string Token, string SubscriptionKey, string Msn);
 
         public VippsService(
             HttpClient http,
             IOptions<VippsOptions> opts,
             IOptions<AppOptions> appOpts,
             IMemoryCache cache,
-            ILogger<VippsService> logger)
+            ILogger<VippsService> logger,
+            IServiceScopeFactory scopeFactory)
         {
             _http = http;
             _opts = opts.Value;
             _appOpts = appOpts.Value;
             _cache = cache;
             _logger = logger;
+            _scopeFactory = scopeFactory;
 
             var assembly = Assembly.GetExecutingAssembly();
             _systemName = assembly.GetCustomAttribute<AssemblyProductAttribute>()?.Product ?? "garge";
@@ -43,15 +48,49 @@ namespace garge_api.Services
                              ?? "1.0.0";
         }
 
-        public async Task<string> GetAccessTokenAsync()
+        private async Task<VippsEffective> GetEffectiveAsync()
         {
-            if (_cache.TryGetValue(TokenCacheKey, out string? cached) && cached != null)
-                return cached;
+            bool isTest;
+            using (var scope = _scopeFactory.CreateScope())
+            {
+                var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                var settings = await db.AppSettings.FindAsync(1);
+                isTest = settings?.VippsTestMode ?? false;
+            }
 
-            var request = new HttpRequestMessage(HttpMethod.Post, $"{_opts.BaseUrl}/accesstoken/get");
-            request.Headers.Add("client_id", _opts.ClientId);
-            request.Headers.Add("client_secret", _opts.ClientSecret);
-            request.Headers.Add("Ocp-Apim-Subscription-Key", _opts.SubscriptionKey);
+            string baseUrl, clientId, clientSecret, msn, subKey, cacheKey;
+            if (isTest)
+            {
+                baseUrl      = _opts.TestBaseUrl;
+                clientId     = _opts.TestClientId;
+                clientSecret = _opts.TestClientSecret;
+                msn          = _opts.TestMerchantSerialNumber;
+                subKey       = _opts.TestSubscriptionKey;
+                cacheKey     = "vipps_token_test";
+            }
+            else
+            {
+                baseUrl      = _opts.BaseUrl;
+                clientId     = _opts.ClientId;
+                clientSecret = _opts.ClientSecret;
+                msn          = _opts.MerchantSerialNumber;
+                subKey       = _opts.SubscriptionKey;
+                cacheKey     = "vipps_token_live";
+            }
+
+            if (!_cache.TryGetValue(cacheKey, out string? token) || token == null)
+                token = await FetchTokenAsync(baseUrl, clientId, clientSecret, subKey, cacheKey);
+
+            return new VippsEffective(baseUrl, token, subKey, msn);
+        }
+
+        private async Task<string> FetchTokenAsync(
+            string baseUrl, string clientId, string clientSecret, string subscriptionKey, string cacheKey)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post, $"{baseUrl}/accesstoken/get");
+            request.Headers.Add("client_id", clientId);
+            request.Headers.Add("client_secret", clientSecret);
+            request.Headers.Add("Ocp-Apim-Subscription-Key", subscriptionKey);
             request.Content = new StringContent(string.Empty, Encoding.UTF8, "application/json");
 
             var response = await _http.SendAsync(request);
@@ -60,19 +99,23 @@ namespace garge_api.Services
             var json = await response.Content.ReadAsStringAsync();
             using var doc = JsonDocument.Parse(json);
             var token = doc.RootElement.GetProperty("access_token").GetString()!;
-            // expires_in is returned as a string by Vipps, not an int
             var expiresInStr = doc.RootElement.GetProperty("expires_in").GetString() ?? "3600";
             var expiresIn = int.Parse(expiresInStr);
 
-            _cache.Set(TokenCacheKey, token, TimeSpan.FromSeconds(expiresIn - 60));
-            _logger.LogInformation("Vipps access token refreshed, expires in {ExpiresIn}s", expiresIn);
+            _cache.Set(cacheKey, token, TimeSpan.FromSeconds(expiresIn - 60));
+            _logger.LogInformation("Vipps access token refreshed ({CacheKey}), expires in {ExpiresIn}s", cacheKey, expiresIn);
             return token;
+        }
+
+        public async Task<string> GetAccessTokenAsync()
+        {
+            return (await GetEffectiveAsync()).Token;
         }
 
         public async Task<VippsCreateAgreementResponse> CreateAgreementAsync(
             Product product, string userId, string redirectUrl, string phoneNumber, int effectivePriceInOre)
         {
-            var token = await GetAccessTokenAsync();
+            var e = await GetEffectiveAsync();
 
             var body = new
             {
@@ -94,41 +137,39 @@ namespace garge_api.Services
                 phoneNumber
             };
 
-            var request = new HttpRequestMessage(HttpMethod.Post, $"{_opts.BaseUrl}/recurring/v3/agreements");
-            AddCommonHeaders(request, token, idempotency: true);
+            var request = new HttpRequestMessage(HttpMethod.Post, $"{e.BaseUrl}/recurring/v3/agreements");
+            AddCommonHeaders(request, e, idempotency: true);
             request.Content = BuildJsonContent(body);
 
             var response = await _http.SendAsync(request);
             response.EnsureSuccessStatusCode();
 
             var json = await response.Content.ReadAsStringAsync();
-            return JsonSerializer.Deserialize<VippsCreateAgreementResponse>(json,
-                _jsonOpts)!;
+            return JsonSerializer.Deserialize<VippsCreateAgreementResponse>(json, _jsonOpts)!;
         }
 
         public async Task<VippsAgreementResponse> GetAgreementAsync(string agreementId)
         {
-            var token = await GetAccessTokenAsync();
+            var e = await GetEffectiveAsync();
 
             var request = new HttpRequestMessage(HttpMethod.Get,
-                $"{_opts.BaseUrl}/recurring/v3/agreements/{agreementId}");
-            AddCommonHeaders(request, token);
+                $"{e.BaseUrl}/recurring/v3/agreements/{agreementId}");
+            AddCommonHeaders(request, e);
 
             var response = await _http.SendAsync(request);
             response.EnsureSuccessStatusCode();
 
             var json = await response.Content.ReadAsStringAsync();
-            return JsonSerializer.Deserialize<VippsAgreementResponse>(json,
-                _jsonOpts)!;
+            return JsonSerializer.Deserialize<VippsAgreementResponse>(json, _jsonOpts)!;
         }
 
         public async Task CancelAgreementAsync(string agreementId)
         {
-            var token = await GetAccessTokenAsync();
+            var e = await GetEffectiveAsync();
 
             var request = new HttpRequestMessage(HttpMethod.Patch,
-                $"{_opts.BaseUrl}/recurring/v3/agreements/{agreementId}");
-            AddCommonHeaders(request, token, idempotency: true);
+                $"{e.BaseUrl}/recurring/v3/agreements/{agreementId}");
+            AddCommonHeaders(request, e, idempotency: true);
             request.Content = BuildJsonContent(new { status = "STOPPED" });
 
             var response = await _http.SendAsync(request);
@@ -138,7 +179,7 @@ namespace garge_api.Services
         public async Task<VippsCreatePaymentResponse> CreatePaymentAsync(
             Order order, List<VippsOrderLine> receiptLines, string redirectUrl, string phoneNumber)
         {
-            var token = await GetAccessTokenAsync();
+            var e = await GetEffectiveAsync();
 
             var body = new
             {
@@ -181,41 +222,39 @@ namespace garge_api.Services
                 }
             };
 
-            var request = new HttpRequestMessage(HttpMethod.Post, $"{_opts.BaseUrl}/epayment/v1/payments");
-            AddCommonHeaders(request, token, idempotency: true);
+            var request = new HttpRequestMessage(HttpMethod.Post, $"{e.BaseUrl}/epayment/v1/payments");
+            AddCommonHeaders(request, e, idempotency: true);
             request.Content = BuildJsonContent(body);
 
             var response = await _http.SendAsync(request);
             response.EnsureSuccessStatusCode();
 
             var json = await response.Content.ReadAsStringAsync();
-            return JsonSerializer.Deserialize<VippsCreatePaymentResponse>(json,
-                _jsonOpts)!;
+            return JsonSerializer.Deserialize<VippsCreatePaymentResponse>(json, _jsonOpts)!;
         }
 
         public async Task<VippsPaymentResponse> GetPaymentAsync(string reference)
         {
-            var token = await GetAccessTokenAsync();
+            var e = await GetEffectiveAsync();
 
             var request = new HttpRequestMessage(HttpMethod.Get,
-                $"{_opts.BaseUrl}/epayment/v1/payments/{reference}");
-            AddCommonHeaders(request, token);
+                $"{e.BaseUrl}/epayment/v1/payments/{reference}");
+            AddCommonHeaders(request, e);
 
             var response = await _http.SendAsync(request);
             response.EnsureSuccessStatusCode();
 
             var json = await response.Content.ReadAsStringAsync();
-            return JsonSerializer.Deserialize<VippsPaymentResponse>(json,
-                _jsonOpts)!;
+            return JsonSerializer.Deserialize<VippsPaymentResponse>(json, _jsonOpts)!;
         }
 
         public async Task CapturePaymentAsync(string reference, int amountInOre)
         {
-            var token = await GetAccessTokenAsync();
+            var e = await GetEffectiveAsync();
             var body = new { modificationAmount = new { value = amountInOre, currency = "NOK" } };
             var request = new HttpRequestMessage(HttpMethod.Post,
-                $"{_opts.BaseUrl}/epayment/v1/payments/{reference}/capture");
-            AddCommonHeaders(request, token, idempotency: true);
+                $"{e.BaseUrl}/epayment/v1/payments/{reference}/capture");
+            AddCommonHeaders(request, e, idempotency: true);
             request.Content = BuildJsonContent(body);
             var response = await _http.SendAsync(request);
             response.EnsureSuccessStatusCode();
@@ -223,10 +262,10 @@ namespace garge_api.Services
 
         public async Task CancelPaymentAsync(string reference)
         {
-            var token = await GetAccessTokenAsync();
+            var e = await GetEffectiveAsync();
             var request = new HttpRequestMessage(HttpMethod.Post,
-                $"{_opts.BaseUrl}/epayment/v1/payments/{reference}/cancel");
-            AddCommonHeaders(request, token, idempotency: true);
+                $"{e.BaseUrl}/epayment/v1/payments/{reference}/cancel");
+            AddCommonHeaders(request, e, idempotency: true);
             request.Content = BuildJsonContent(new { });
             var response = await _http.SendAsync(request);
             response.EnsureSuccessStatusCode();
@@ -234,10 +273,10 @@ namespace garge_api.Services
 
         public async Task<(string WebhookId, string Secret)> RegisterWebhookAsync(string url, string[] events)
         {
-            var token = await GetAccessTokenAsync();
+            var e = await GetEffectiveAsync();
             var body = new { url, events };
-            var request = new HttpRequestMessage(HttpMethod.Post, $"{_opts.BaseUrl}/webhooks/v1/webhooks");
-            AddCommonHeaders(request, token, idempotency: true);
+            var request = new HttpRequestMessage(HttpMethod.Post, $"{e.BaseUrl}/webhooks/v1/webhooks");
+            AddCommonHeaders(request, e, idempotency: true);
             request.Content = BuildJsonContent(body);
 
             var response = await _http.SendAsync(request);
@@ -263,11 +302,11 @@ namespace garge_api.Services
                 Encoding.ASCII.GetBytes(receivedHex.ToLowerInvariant()));
         }
 
-        private void AddCommonHeaders(HttpRequestMessage request, string token, bool idempotency = false)
+        private void AddCommonHeaders(HttpRequestMessage request, VippsEffective e, bool idempotency = false)
         {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            request.Headers.Add("Ocp-Apim-Subscription-Key", _opts.SubscriptionKey);
-            request.Headers.Add("Merchant-Serial-Number", _opts.MerchantSerialNumber);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", e.Token);
+            request.Headers.Add("Ocp-Apim-Subscription-Key", e.SubscriptionKey);
+            request.Headers.Add("Merchant-Serial-Number", e.Msn);
             request.Headers.Add("Vipps-System-Name", _systemName);
             request.Headers.Add("Vipps-System-Version", _systemVersion);
             if (idempotency)

--- a/Services/VippsService.cs
+++ b/Services/VippsService.cs
@@ -1,0 +1,280 @@
+using garge_api.Models.Shop;
+using garge_api.Models.Subscription;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace garge_api.Services
+{
+    public class VippsService : IVippsService
+    {
+        private readonly HttpClient _http;
+        private readonly VippsOptions _opts;
+        private readonly AppOptions _appOpts;
+        private readonly IMemoryCache _cache;
+        private readonly ILogger<VippsService> _logger;
+        private readonly string _systemName;
+        private readonly string _systemVersion;
+
+        private const string TokenCacheKey = "vipps_access_token";
+        private static readonly JsonSerializerOptions _jsonOpts = new() { PropertyNameCaseInsensitive = true };
+
+        public VippsService(
+            HttpClient http,
+            IOptions<VippsOptions> opts,
+            IOptions<AppOptions> appOpts,
+            IMemoryCache cache,
+            ILogger<VippsService> logger)
+        {
+            _http = http;
+            _opts = opts.Value;
+            _appOpts = appOpts.Value;
+            _cache = cache;
+            _logger = logger;
+
+            var assembly = Assembly.GetExecutingAssembly();
+            _systemName = assembly.GetCustomAttribute<AssemblyProductAttribute>()?.Product ?? "garge";
+            _systemVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                             ?? assembly.GetName().Version?.ToString()
+                             ?? "1.0.0";
+        }
+
+        public async Task<string> GetAccessTokenAsync()
+        {
+            if (_cache.TryGetValue(TokenCacheKey, out string? cached) && cached != null)
+                return cached;
+
+            var request = new HttpRequestMessage(HttpMethod.Post, $"{_opts.BaseUrl}/accesstoken/get");
+            request.Headers.Add("client_id", _opts.ClientId);
+            request.Headers.Add("client_secret", _opts.ClientSecret);
+            request.Headers.Add("Ocp-Apim-Subscription-Key", _opts.SubscriptionKey);
+            request.Content = new StringContent(string.Empty, Encoding.UTF8, "application/json");
+
+            var response = await _http.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(json);
+            var token = doc.RootElement.GetProperty("access_token").GetString()!;
+            // expires_in is returned as a string by Vipps, not an int
+            var expiresInStr = doc.RootElement.GetProperty("expires_in").GetString() ?? "3600";
+            var expiresIn = int.Parse(expiresInStr);
+
+            _cache.Set(TokenCacheKey, token, TimeSpan.FromSeconds(expiresIn - 60));
+            _logger.LogInformation("Vipps access token refreshed, expires in {ExpiresIn}s", expiresIn);
+            return token;
+        }
+
+        public async Task<VippsCreateAgreementResponse> CreateAgreementAsync(
+            Product product, string userId, string redirectUrl, string phoneNumber, int effectivePriceInOre)
+        {
+            var token = await GetAccessTokenAsync();
+
+            var body = new
+            {
+                pricing = new
+                {
+                    type = "LEGACY",
+                    amount = effectivePriceInOre,
+                    currency = "NOK"
+                },
+                interval = new
+                {
+                    unit = product.Interval == BillingInterval.Monthly ? "MONTH" : "YEAR",
+                    count = 1
+                },
+                merchantRedirectUrl = redirectUrl,
+                merchantAgreementUrl = $"{_appOpts.FrontendBaseUrl}/terms",
+                productName = product.Name,
+                productDescription = product.Description ?? string.Empty,
+                phoneNumber
+            };
+
+            var request = new HttpRequestMessage(HttpMethod.Post, $"{_opts.BaseUrl}/recurring/v3/agreements");
+            AddCommonHeaders(request, token, idempotency: true);
+            request.Content = BuildJsonContent(body);
+
+            var response = await _http.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync();
+            return JsonSerializer.Deserialize<VippsCreateAgreementResponse>(json,
+                _jsonOpts)!;
+        }
+
+        public async Task<VippsAgreementResponse> GetAgreementAsync(string agreementId)
+        {
+            var token = await GetAccessTokenAsync();
+
+            var request = new HttpRequestMessage(HttpMethod.Get,
+                $"{_opts.BaseUrl}/recurring/v3/agreements/{agreementId}");
+            AddCommonHeaders(request, token);
+
+            var response = await _http.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync();
+            return JsonSerializer.Deserialize<VippsAgreementResponse>(json,
+                _jsonOpts)!;
+        }
+
+        public async Task CancelAgreementAsync(string agreementId)
+        {
+            var token = await GetAccessTokenAsync();
+
+            var request = new HttpRequestMessage(HttpMethod.Patch,
+                $"{_opts.BaseUrl}/recurring/v3/agreements/{agreementId}");
+            AddCommonHeaders(request, token, idempotency: true);
+            request.Content = BuildJsonContent(new { status = "STOPPED" });
+
+            var response = await _http.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+        }
+
+        public async Task<VippsCreatePaymentResponse> CreatePaymentAsync(
+            Order order, List<VippsOrderLine> receiptLines, string redirectUrl, string phoneNumber)
+        {
+            var token = await GetAccessTokenAsync();
+
+            var body = new
+            {
+                amount = new { value = order.TotalInOre, currency = "NOK" },
+                paymentMethod = new { type = "WALLET" },
+                customer = new { phoneNumber },
+                reference = order.Id.ToString(),
+                returnUrl = $"{redirectUrl}?orderId={order.Id}",
+                userFlow = "WEB_REDIRECT",
+                paymentDescription = "Sensor purchase",
+                captureType = "RESERVE_CAPTURE",
+                receipt = new
+                {
+                    orderLines = receiptLines.Select(l =>
+                    {
+                        var lineTotal = l.UnitPriceInOre * l.Quantity;
+                        var excludingTax = l.TaxPercentage > 0
+                            ? l.UnitPriceExclVatInOre * l.Quantity
+                            : lineTotal;
+                        return new
+                        {
+                            name = l.Name,
+                            id = l.Id,
+                            totalAmount = lineTotal,
+                            totalAmountExcludingTax = excludingTax,
+                            totalTaxAmount = lineTotal - excludingTax,
+                            taxPercentage = l.TaxPercentage,
+                            unitInfo = new
+                            {
+                                unitPrice = l.UnitPriceInOre,
+                                quantity = l.Quantity.ToString(),
+                                quantityUnit = "PCS"
+                            },
+                            discount = 0,
+                            isReturn = false,
+                            isShipping = false
+                        };
+                    }),
+                    bottomLine = new { currency = "NOK", receiptNumber = order.Id.ToString() }
+                }
+            };
+
+            var request = new HttpRequestMessage(HttpMethod.Post, $"{_opts.BaseUrl}/epayment/v1/payments");
+            AddCommonHeaders(request, token, idempotency: true);
+            request.Content = BuildJsonContent(body);
+
+            var response = await _http.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync();
+            return JsonSerializer.Deserialize<VippsCreatePaymentResponse>(json,
+                _jsonOpts)!;
+        }
+
+        public async Task<VippsPaymentResponse> GetPaymentAsync(string reference)
+        {
+            var token = await GetAccessTokenAsync();
+
+            var request = new HttpRequestMessage(HttpMethod.Get,
+                $"{_opts.BaseUrl}/epayment/v1/payments/{reference}");
+            AddCommonHeaders(request, token);
+
+            var response = await _http.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync();
+            return JsonSerializer.Deserialize<VippsPaymentResponse>(json,
+                _jsonOpts)!;
+        }
+
+        public async Task CapturePaymentAsync(string reference, int amountInOre)
+        {
+            var token = await GetAccessTokenAsync();
+            var body = new { modificationAmount = new { value = amountInOre, currency = "NOK" } };
+            var request = new HttpRequestMessage(HttpMethod.Post,
+                $"{_opts.BaseUrl}/epayment/v1/payments/{reference}/capture");
+            AddCommonHeaders(request, token, idempotency: true);
+            request.Content = BuildJsonContent(body);
+            var response = await _http.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+        }
+
+        public async Task CancelPaymentAsync(string reference)
+        {
+            var token = await GetAccessTokenAsync();
+            var request = new HttpRequestMessage(HttpMethod.Post,
+                $"{_opts.BaseUrl}/epayment/v1/payments/{reference}/cancel");
+            AddCommonHeaders(request, token, idempotency: true);
+            request.Content = BuildJsonContent(new { });
+            var response = await _http.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+        }
+
+        public async Task<(string WebhookId, string Secret)> RegisterWebhookAsync(string url, string[] events)
+        {
+            var token = await GetAccessTokenAsync();
+            var body = new { url, events };
+            var request = new HttpRequestMessage(HttpMethod.Post, $"{_opts.BaseUrl}/webhooks/v1/webhooks");
+            AddCommonHeaders(request, token, idempotency: true);
+            request.Content = BuildJsonContent(body);
+
+            var response = await _http.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(json);
+            var id = doc.RootElement.GetProperty("id").GetString()!;
+            var secret = doc.RootElement.GetProperty("secret").GetString()!;
+            return (id, secret);
+        }
+
+        public bool VerifyWebhookSignature(string rawBody, string signatureHeader, string secret)
+        {
+            if (!signatureHeader.StartsWith("sha256=")) return false;
+            var receivedHex = signatureHeader["sha256=".Length..];
+            var key = Encoding.UTF8.GetBytes(secret);
+            var payload = Encoding.UTF8.GetBytes(rawBody);
+            var computed = HMACSHA256.HashData(key, payload);
+            var computedHex = Convert.ToHexString(computed).ToLowerInvariant();
+            return CryptographicOperations.FixedTimeEquals(
+                Encoding.ASCII.GetBytes(computedHex),
+                Encoding.ASCII.GetBytes(receivedHex.ToLowerInvariant()));
+        }
+
+        private void AddCommonHeaders(HttpRequestMessage request, string token, bool idempotency = false)
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            request.Headers.Add("Ocp-Apim-Subscription-Key", _opts.SubscriptionKey);
+            request.Headers.Add("Merchant-Serial-Number", _opts.MerchantSerialNumber);
+            request.Headers.Add("Vipps-System-Name", _systemName);
+            request.Headers.Add("Vipps-System-Version", _systemVersion);
+            if (idempotency)
+                request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        }
+
+        private static StringContent BuildJsonContent(object body) =>
+            new(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
+    }
+}

--- a/Services/VippsService.cs
+++ b/Services/VippsService.cs
@@ -107,9 +107,7 @@ namespace garge_api.Services
             request.Content = new StringContent(string.Empty, Encoding.UTF8, "application/json");
 
             var response = await _http.SendAsync(request);
-            response.EnsureSuccessStatusCode();
-
-            var json = await response.Content.ReadAsStringAsync();
+            var json = await ReadAsStringAndEnsureSuccessAsync(response, "accesstoken/get");
             using var doc = JsonDocument.Parse(json);
             var token = doc.RootElement.GetProperty("access_token").GetString()!;
 
@@ -162,9 +160,7 @@ namespace garge_api.Services
             request.Content = BuildJsonContent(body);
 
             var response = await _http.SendAsync(request);
-            response.EnsureSuccessStatusCode();
-
-            var json = await response.Content.ReadAsStringAsync();
+            var json = await ReadAsStringAndEnsureSuccessAsync(response, "create-agreement");
             return JsonSerializer.Deserialize<VippsCreateAgreementResponse>(json, _jsonOpts)!;
         }
 
@@ -177,9 +173,7 @@ namespace garge_api.Services
             AddCommonHeaders(request, e);
 
             var response = await _http.SendAsync(request);
-            response.EnsureSuccessStatusCode();
-
-            var json = await response.Content.ReadAsStringAsync();
+            var json = await ReadAsStringAndEnsureSuccessAsync(response, "get-agreement");
             return JsonSerializer.Deserialize<VippsAgreementResponse>(json, _jsonOpts)!;
         }
 
@@ -193,7 +187,7 @@ namespace garge_api.Services
             request.Content = BuildJsonContent(new { status = "STOPPED" });
 
             var response = await _http.SendAsync(request);
-            response.EnsureSuccessStatusCode();
+            await ReadAsStringAndEnsureSuccessAsync(response, "cancel-agreement");
         }
 
         public async Task<VippsCreatePaymentResponse> CreatePaymentAsync(
@@ -202,12 +196,13 @@ namespace garge_api.Services
         {
             var e = await GetEffectiveAsync();
 
+            var reference = $"garge-order-{order.Id:D6}";
             var body = new
             {
                 amount = new { value = order.TotalInOre, currency = "NOK" },
                 paymentMethod = new { type = "WALLET" },
                 customer = new { phoneNumber },
-                reference = order.Id.ToString(),
+                reference,
                 returnUrl = $"{redirectUrl}?orderId={order.Id}",
                 userFlow = "WEB_REDIRECT",
                 paymentDescription = $"Garge order #{order.Id}",
@@ -239,7 +234,7 @@ namespace garge_api.Services
                             isShipping = false
                         };
                     }),
-                    bottomLine = new { currency = "NOK", receiptNumber = order.Id.ToString() }
+                    bottomLine = new { currency = "NOK", receiptNumber = reference }
                 }
             };
 
@@ -248,9 +243,7 @@ namespace garge_api.Services
             request.Content = BuildJsonContent(body);
 
             var response = await _http.SendAsync(request);
-            response.EnsureSuccessStatusCode();
-
-            var json = await response.Content.ReadAsStringAsync();
+            var json = await ReadAsStringAndEnsureSuccessAsync(response, "create-payment");
             return JsonSerializer.Deserialize<VippsCreatePaymentResponse>(json, _jsonOpts)!;
         }
 
@@ -263,9 +256,7 @@ namespace garge_api.Services
             AddCommonHeaders(request, e);
 
             var response = await _http.SendAsync(request);
-            response.EnsureSuccessStatusCode();
-
-            var json = await response.Content.ReadAsStringAsync();
+            var json = await ReadAsStringAndEnsureSuccessAsync(response, "get-payment");
             return JsonSerializer.Deserialize<VippsPaymentResponse>(json, _jsonOpts)!;
         }
 
@@ -278,7 +269,7 @@ namespace garge_api.Services
             AddCommonHeaders(request, e, idempotencyKey);
             request.Content = BuildJsonContent(body);
             var response = await _http.SendAsync(request);
-            response.EnsureSuccessStatusCode();
+            await ReadAsStringAndEnsureSuccessAsync(response, "capture-payment");
         }
 
         public async Task CancelPaymentAsync(string reference, string idempotencyKey)
@@ -289,7 +280,7 @@ namespace garge_api.Services
             AddCommonHeaders(request, e, idempotencyKey);
             request.Content = BuildJsonContent(new { });
             var response = await _http.SendAsync(request);
-            response.EnsureSuccessStatusCode();
+            await ReadAsStringAndEnsureSuccessAsync(response, "cancel-payment");
         }
 
         public async Task<(string WebhookId, string Secret)> RegisterWebhookAsync(string url, string[] events)
@@ -301,9 +292,7 @@ namespace garge_api.Services
             request.Content = BuildJsonContent(body);
 
             var response = await _http.SendAsync(request);
-            response.EnsureSuccessStatusCode();
-
-            var json = await response.Content.ReadAsStringAsync();
+            var json = await ReadAsStringAndEnsureSuccessAsync(response, "register-webhook");
             using var doc = JsonDocument.Parse(json);
             var id = doc.RootElement.GetProperty("id").GetString()!;
             var secret = doc.RootElement.GetProperty("secret").GetString()!;
@@ -372,5 +361,17 @@ namespace garge_api.Services
 
         private static StringContent BuildJsonContent(object body) =>
             new(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
+
+        private async Task<string> ReadAsStringAndEnsureSuccessAsync(HttpResponseMessage response, string operation)
+        {
+            var body = await response.Content.ReadAsStringAsync();
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogError("Vipps {Operation} failed: {Status} {Body}",
+                    operation, (int)response.StatusCode, body);
+                response.EnsureSuccessStatusCode();
+            }
+            return body;
+        }
     }
 }

--- a/Services/VippsService.cs
+++ b/Services/VippsService.cs
@@ -22,6 +22,7 @@ namespace garge_api.Services
         private readonly string _systemName;
         private readonly string _systemVersion;
 
+        private const string TestModeCacheKey = "vipps_test_mode";
         private static readonly JsonSerializerOptions _jsonOpts = new() { PropertyNameCaseInsensitive = true };
 
         private readonly record struct VippsEffective(string BaseUrl, string Token, string SubscriptionKey, string Msn);
@@ -48,15 +49,22 @@ namespace garge_api.Services
                              ?? "1.0.0";
         }
 
+        private async Task<bool> IsTestModeAsync()
+        {
+            if (_cache.TryGetValue(TestModeCacheKey, out bool cached))
+                return cached;
+
+            using var scope = _scopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var settings = await db.AppSettings.FindAsync(1);
+            var isTest = settings?.VippsTestMode ?? false;
+            _cache.Set(TestModeCacheKey, isTest, TimeSpan.FromSeconds(30));
+            return isTest;
+        }
+
         private async Task<VippsEffective> GetEffectiveAsync()
         {
-            bool isTest;
-            using (var scope = _scopeFactory.CreateScope())
-            {
-                var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-                var settings = await db.AppSettings.FindAsync(1);
-                isTest = settings?.VippsTestMode ?? false;
-            }
+            var isTest = await IsTestModeAsync();
 
             string baseUrl, clientId, clientSecret, msn, subKey, cacheKey;
             if (isTest)

--- a/Services/VippsService.cs
+++ b/Services/VippsService.cs
@@ -1,13 +1,16 @@
 using garge_api.Models;
 using garge_api.Models.Shop;
 using garge_api.Models.Subscription;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
+using System.Globalization;
 using System.Net.Http.Headers;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 
 namespace garge_api.Services
 {
@@ -24,6 +27,8 @@ namespace garge_api.Services
 
         private const string TestModeCacheKey = "vipps_test_mode";
         private static readonly JsonSerializerOptions _jsonOpts = new() { PropertyNameCaseInsensitive = true };
+        private static readonly TimeSpan ReplayWindow = TimeSpan.FromMinutes(5);
+        private static readonly Regex SigRegex = new(@"Signature=([^,&\s]+)", RegexOptions.Compiled);
 
         private readonly record struct VippsEffective(string BaseUrl, string Token, string SubscriptionKey, string Msn);
 
@@ -107,10 +112,16 @@ namespace garge_api.Services
             var json = await response.Content.ReadAsStringAsync();
             using var doc = JsonDocument.Parse(json);
             var token = doc.RootElement.GetProperty("access_token").GetString()!;
-            var expiresInStr = doc.RootElement.GetProperty("expires_in").GetString() ?? "3600";
-            var expiresIn = int.Parse(expiresInStr);
 
-            _cache.Set(cacheKey, token, TimeSpan.FromSeconds(expiresIn - 60));
+            var expiresIn = 3600;
+            if (doc.RootElement.TryGetProperty("expires_in", out var exp))
+            {
+                var expStr = exp.ValueKind == JsonValueKind.String ? exp.GetString() : exp.GetRawText();
+                if (!int.TryParse(expStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out expiresIn))
+                    expiresIn = 3600;
+            }
+
+            _cache.Set(cacheKey, token, TimeSpan.FromSeconds(Math.Max(60, expiresIn - 60)));
             _logger.LogInformation("Vipps access token refreshed ({CacheKey}), expires in {ExpiresIn}s", cacheKey, expiresIn);
             return token;
         }
@@ -121,7 +132,8 @@ namespace garge_api.Services
         }
 
         public async Task<VippsCreateAgreementResponse> CreateAgreementAsync(
-            Product product, string userId, string redirectUrl, string phoneNumber, int effectivePriceInOre)
+            Product product, string userId, string redirectUrl, string phoneNumber,
+            int effectivePriceInOre, string idempotencyKey)
         {
             var e = await GetEffectiveAsync();
 
@@ -146,7 +158,7 @@ namespace garge_api.Services
             };
 
             var request = new HttpRequestMessage(HttpMethod.Post, $"{e.BaseUrl}/recurring/v3/agreements");
-            AddCommonHeaders(request, e, idempotency: true);
+            AddCommonHeaders(request, e, idempotencyKey);
             request.Content = BuildJsonContent(body);
 
             var response = await _http.SendAsync(request);
@@ -171,13 +183,13 @@ namespace garge_api.Services
             return JsonSerializer.Deserialize<VippsAgreementResponse>(json, _jsonOpts)!;
         }
 
-        public async Task CancelAgreementAsync(string agreementId)
+        public async Task CancelAgreementAsync(string agreementId, string idempotencyKey)
         {
             var e = await GetEffectiveAsync();
 
             var request = new HttpRequestMessage(HttpMethod.Patch,
                 $"{e.BaseUrl}/recurring/v3/agreements/{agreementId}");
-            AddCommonHeaders(request, e, idempotency: true);
+            AddCommonHeaders(request, e, idempotencyKey);
             request.Content = BuildJsonContent(new { status = "STOPPED" });
 
             var response = await _http.SendAsync(request);
@@ -185,7 +197,8 @@ namespace garge_api.Services
         }
 
         public async Task<VippsCreatePaymentResponse> CreatePaymentAsync(
-            Order order, List<VippsOrderLine> receiptLines, string redirectUrl, string phoneNumber)
+            Order order, List<VippsOrderLine> receiptLines, string redirectUrl,
+            string phoneNumber, string idempotencyKey)
         {
             var e = await GetEffectiveAsync();
 
@@ -197,14 +210,14 @@ namespace garge_api.Services
                 reference = order.Id.ToString(),
                 returnUrl = $"{redirectUrl}?orderId={order.Id}",
                 userFlow = "WEB_REDIRECT",
-                paymentDescription = "Sensor purchase",
+                paymentDescription = $"Garge order #{order.Id}",
                 captureType = "RESERVE_CAPTURE",
                 receipt = new
                 {
                     orderLines = receiptLines.Select(l =>
                     {
                         var lineTotal = l.UnitPriceInOre * l.Quantity;
-                        var excludingTax = l.TaxPercentage > 0
+                        var excludingTax = l.TaxPercentageBasisPoints > 0
                             ? l.UnitPriceExclVatInOre * l.Quantity
                             : lineTotal;
                         return new
@@ -214,7 +227,7 @@ namespace garge_api.Services
                             totalAmount = lineTotal,
                             totalAmountExcludingTax = excludingTax,
                             totalTaxAmount = lineTotal - excludingTax,
-                            taxPercentage = l.TaxPercentage,
+                            taxPercentage = l.TaxPercentageBasisPoints,
                             unitInfo = new
                             {
                                 unitPrice = l.UnitPriceInOre,
@@ -231,7 +244,7 @@ namespace garge_api.Services
             };
 
             var request = new HttpRequestMessage(HttpMethod.Post, $"{e.BaseUrl}/epayment/v1/payments");
-            AddCommonHeaders(request, e, idempotency: true);
+            AddCommonHeaders(request, e, idempotencyKey);
             request.Content = BuildJsonContent(body);
 
             var response = await _http.SendAsync(request);
@@ -256,24 +269,24 @@ namespace garge_api.Services
             return JsonSerializer.Deserialize<VippsPaymentResponse>(json, _jsonOpts)!;
         }
 
-        public async Task CapturePaymentAsync(string reference, int amountInOre)
+        public async Task CapturePaymentAsync(string reference, int amountInOre, string idempotencyKey)
         {
             var e = await GetEffectiveAsync();
             var body = new { modificationAmount = new { value = amountInOre, currency = "NOK" } };
             var request = new HttpRequestMessage(HttpMethod.Post,
                 $"{e.BaseUrl}/epayment/v1/payments/{reference}/capture");
-            AddCommonHeaders(request, e, idempotency: true);
+            AddCommonHeaders(request, e, idempotencyKey);
             request.Content = BuildJsonContent(body);
             var response = await _http.SendAsync(request);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task CancelPaymentAsync(string reference)
+        public async Task CancelPaymentAsync(string reference, string idempotencyKey)
         {
             var e = await GetEffectiveAsync();
             var request = new HttpRequestMessage(HttpMethod.Post,
                 $"{e.BaseUrl}/epayment/v1/payments/{reference}/cancel");
-            AddCommonHeaders(request, e, idempotency: true);
+            AddCommonHeaders(request, e, idempotencyKey);
             request.Content = BuildJsonContent(new { });
             var response = await _http.SendAsync(request);
             response.EnsureSuccessStatusCode();
@@ -284,7 +297,7 @@ namespace garge_api.Services
             var e = await GetEffectiveAsync();
             var body = new { url, events };
             var request = new HttpRequestMessage(HttpMethod.Post, $"{e.BaseUrl}/webhooks/v1/webhooks");
-            AddCommonHeaders(request, e, idempotency: true);
+            AddCommonHeaders(request, e, Guid.NewGuid().ToString());
             request.Content = BuildJsonContent(body);
 
             var response = await _http.SendAsync(request);
@@ -297,28 +310,64 @@ namespace garge_api.Services
             return (id, secret);
         }
 
-        public bool VerifyWebhookSignature(string rawBody, string signatureHeader, string secret)
+        public WebhookVerifyResult VerifyWebhookSignature(HttpRequest request, string rawBody, string secret)
         {
-            if (!signatureHeader.StartsWith("sha256=")) return false;
-            var receivedHex = signatureHeader["sha256=".Length..];
-            var key = Encoding.UTF8.GetBytes(secret);
-            var payload = Encoding.UTF8.GetBytes(rawBody);
-            var computed = HMACSHA256.HashData(key, payload);
-            var computedHex = Convert.ToHexString(computed).ToLowerInvariant();
+            if (string.IsNullOrEmpty(secret))
+                return WebhookVerifyResult.MissingSecret;
+
+            var auth = request.Headers["Authorization"].ToString();
+            if (string.IsNullOrEmpty(auth) || !auth.StartsWith("HMAC-SHA256 ", StringComparison.Ordinal))
+                return WebhookVerifyResult.MissingHeader;
+
+            var sigMatch = SigRegex.Match(auth);
+            if (!sigMatch.Success) return WebhookVerifyResult.MissingHeader;
+            var receivedSig = sigMatch.Groups[1].Value;
+
+            var dateHeader = request.Headers["x-ms-date"].ToString();
+            var contentHashHeader = request.Headers["x-ms-content-sha256"].ToString();
+            if (string.IsNullOrEmpty(dateHeader) || string.IsNullOrEmpty(contentHashHeader))
+                return WebhookVerifyResult.MissingHeader;
+
+            // Replay protection: x-ms-date must be within 5 min window
+            if (!DateTimeOffset.TryParse(dateHeader, CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var sentAt))
+                return WebhookVerifyResult.BadDate;
+            var skew = DateTimeOffset.UtcNow - sentAt;
+            if (skew.Duration() > ReplayWindow)
+                return WebhookVerifyResult.Stale;
+
+            // Content hash check
+            var bodyHashBase64 = Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(rawBody)));
+            if (!CryptographicOperations.FixedTimeEquals(
+                    Encoding.ASCII.GetBytes(bodyHashBase64),
+                    Encoding.ASCII.GetBytes(contentHashHeader)))
+                return WebhookVerifyResult.BadContentHash;
+
+            // Canonical: METHOD\n<pathAndQuery>\n<x-ms-date>;<host>;<x-ms-content-sha256>
+            var pathAndQuery = request.Path.Value + request.QueryString.Value;
+            var host = request.Headers["Host"].ToString();
+            if (string.IsNullOrEmpty(host)) host = request.Host.Value ?? string.Empty;
+            var canonical = $"{request.Method}\n{pathAndQuery}\n{dateHeader};{host};{contentHashHeader}";
+
+            using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+            var computed = Convert.ToBase64String(hmac.ComputeHash(Encoding.UTF8.GetBytes(canonical)));
+
             return CryptographicOperations.FixedTimeEquals(
-                Encoding.ASCII.GetBytes(computedHex),
-                Encoding.ASCII.GetBytes(receivedHex.ToLowerInvariant()));
+                Encoding.ASCII.GetBytes(computed),
+                Encoding.ASCII.GetBytes(receivedSig))
+                ? WebhookVerifyResult.Valid
+                : WebhookVerifyResult.BadSignature;
         }
 
-        private void AddCommonHeaders(HttpRequestMessage request, VippsEffective e, bool idempotency = false)
+        private void AddCommonHeaders(HttpRequestMessage request, VippsEffective e, string? idempotencyKey = null)
         {
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", e.Token);
             request.Headers.Add("Ocp-Apim-Subscription-Key", e.SubscriptionKey);
             request.Headers.Add("Merchant-Serial-Number", e.Msn);
             request.Headers.Add("Vipps-System-Name", _systemName);
             request.Headers.Add("Vipps-System-Version", _systemVersion);
-            if (idempotency)
-                request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+            if (!string.IsNullOrEmpty(idempotencyKey))
+                request.Headers.Add("Idempotency-Key", idempotencyKey);
         }
 
         private static StringContent BuildJsonContent(object body) =>

--- a/Services/VippsWebhookRegistrationService.cs
+++ b/Services/VippsWebhookRegistrationService.cs
@@ -1,0 +1,74 @@
+using garge_api.Models;
+using garge_api.Models.Admin;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace garge_api.Services
+{
+    public class VippsWebhookRegistrationService : IHostedService
+    {
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly AppOptions _appOpts;
+        private readonly ILogger<VippsWebhookRegistrationService> _logger;
+
+        public VippsWebhookRegistrationService(
+            IServiceScopeFactory scopeFactory,
+            IOptions<AppOptions> appOpts,
+            ILogger<VippsWebhookRegistrationService> logger)
+        {
+            _scopeFactory = scopeFactory;
+            _appOpts = appOpts.Value;
+            _logger = logger;
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var vipps = scope.ServiceProvider.GetRequiredService<IVippsService>();
+
+            var settings = await db.AppSettings.FindAsync([1], cancellationToken);
+            if (settings == null) return;
+
+            var shopTask = string.IsNullOrEmpty(settings.VippsShopWebhookId)
+                ? TryRegisterAsync(vipps,
+                    $"{_appOpts.ApiBaseUrl}/api/shop/webhook",
+                    ["epayments.payment.authorized.v1", "epayments.payment.terminated.v1", "epayments.payment.refunded.v1"],
+                    (id, secret) => { settings.VippsShopWebhookId = id; settings.VippsShopWebhookSecret = secret; },
+                    "shop")
+                : Task.FromResult(false);
+
+            var subTask = string.IsNullOrEmpty(settings.VippsSubscriptionWebhookId)
+                ? TryRegisterAsync(vipps,
+                    $"{_appOpts.ApiBaseUrl}/api/subscriptions/webhook",
+                    ["recurring.agreement-activated.v1", "recurring.agreement-stopped.v1", "recurring.agreement-expired.v1"],
+                    (id, secret) => { settings.VippsSubscriptionWebhookId = id; settings.VippsSubscriptionWebhookSecret = secret; },
+                    "subscription")
+                : Task.FromResult(false);
+
+            var results = await Task.WhenAll(shopTask, subTask);
+            if (results.Any(r => r))
+                await db.SaveChangesAsync(cancellationToken);
+        }
+
+        private async Task<bool> TryRegisterAsync(
+            IVippsService vipps, string url, string[] events,
+            Action<string, string> persist, string label)
+        {
+            try
+            {
+                var (id, secret) = await vipps.RegisterWebhookAsync(url, events);
+                persist(id, secret);
+                _logger.LogInformation("Registered Vipps {Label} webhook {WebhookId}", label, id);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to register Vipps {Label} webhook", label);
+                return false;
+            }
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/Services/VippsWebhookRegistrationService.cs
+++ b/Services/VippsWebhookRegistrationService.cs
@@ -1,5 +1,5 @@
+using garge_api.Constants;
 using garge_api.Models;
-using garge_api.Models.Admin;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 
@@ -26,39 +26,59 @@ namespace garge_api.Services
             using var scope = _scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
             var vipps = scope.ServiceProvider.GetRequiredService<IVippsService>();
+            var protector = scope.ServiceProvider.GetRequiredService<IWebhookSecretProtector>();
+            var settingsCache = scope.ServiceProvider.GetRequiredService<IAppSettingsCache>();
 
             var settings = await db.AppSettings.FindAsync([1], cancellationToken);
             if (settings == null) return;
 
-            var shopTask = string.IsNullOrEmpty(settings.VippsShopWebhookId)
-                ? TryRegisterAsync(vipps,
-                    $"{_appOpts.ApiBaseUrl}/api/shop/webhook",
-                    ["epayments.payment.authorized.v1", "epayments.payment.terminated.v1", "epayments.payment.refunded.v1"],
-                    (id, secret) => { settings.VippsShopWebhookId = id; settings.VippsShopWebhookSecret = secret; },
-                    "shop")
-                : Task.FromResult(false);
+            var changed = false;
 
-            var subTask = string.IsNullOrEmpty(settings.VippsSubscriptionWebhookId)
-                ? TryRegisterAsync(vipps,
-                    $"{_appOpts.ApiBaseUrl}/api/subscriptions/webhook",
-                    ["recurring.agreement-activated.v1", "recurring.agreement-stopped.v1", "recurring.agreement-expired.v1"],
-                    (id, secret) => { settings.VippsSubscriptionWebhookId = id; settings.VippsSubscriptionWebhookSecret = secret; },
-                    "subscription")
-                : Task.FromResult(false);
+            if (string.IsNullOrEmpty(settings.VippsShopWebhookId))
+            {
+                if (await TryRegisterAsync(vipps, protector,
+                        $"{_appOpts.ApiBaseUrl}/api/shop/webhook",
+                        VippsEvents.ShopEvents,
+                        (id, secret) =>
+                        {
+                            settings.VippsShopWebhookId = id;
+                            settings.VippsShopWebhookSecret = secret;
+                        },
+                        "shop"))
+                    changed = true;
+            }
 
-            var results = await Task.WhenAll(shopTask, subTask);
-            if (results.Any(r => r))
+            if (string.IsNullOrEmpty(settings.VippsSubscriptionWebhookId))
+            {
+                if (await TryRegisterAsync(vipps, protector,
+                        $"{_appOpts.ApiBaseUrl}/api/subscriptions/webhook",
+                        VippsEvents.SubscriptionEvents,
+                        (id, secret) =>
+                        {
+                            settings.VippsSubscriptionWebhookId = id;
+                            settings.VippsSubscriptionWebhookSecret = secret;
+                        },
+                        "subscription"))
+                    changed = true;
+            }
+
+            if (changed)
+            {
                 await db.SaveChangesAsync(cancellationToken);
+                settingsCache.Invalidate();
+            }
         }
 
         private async Task<bool> TryRegisterAsync(
-            IVippsService vipps, string url, string[] events,
+            IVippsService vipps,
+            IWebhookSecretProtector protector,
+            string url, string[] events,
             Action<string, string> persist, string label)
         {
             try
             {
                 var (id, secret) = await vipps.RegisterWebhookAsync(url, events);
-                persist(id, secret);
+                persist(id, protector.Protect(secret));
                 _logger.LogInformation("Registered Vipps {Label} webhook {WebhookId}", label, id);
                 return true;
             }

--- a/Services/WebhookSecretProtector.cs
+++ b/Services/WebhookSecretProtector.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.DataProtection;
+
+namespace garge_api.Services
+{
+    public interface IWebhookSecretProtector
+    {
+        string Protect(string plaintext);
+        string Unprotect(string stored);
+    }
+
+    public class WebhookSecretProtector : IWebhookSecretProtector
+    {
+        private const string Prefix = "enc:v1:";
+        private readonly IDataProtector _protector;
+
+        public WebhookSecretProtector(IDataProtectionProvider provider)
+        {
+            _protector = provider.CreateProtector("garge.vipps.webhook-secret.v1");
+        }
+
+        public string Protect(string plaintext) =>
+            string.IsNullOrEmpty(plaintext) ? plaintext : Prefix + _protector.Protect(plaintext);
+
+        public string Unprotect(string stored)
+        {
+            if (string.IsNullOrEmpty(stored)) return stored;
+            return stored.StartsWith(Prefix, StringComparison.Ordinal)
+                ? _protector.Unprotect(stored[Prefix.Length..])
+                : stored;
+        }
+    }
+}

--- a/appsettings.json
+++ b/appsettings.json
@@ -52,10 +52,15 @@
     "ApiBaseUrl": "https://garge-api.prod.tumogroup.com"
   },
   "Vipps": {
-    "BaseUrl": "https://apitest.vipps.no",
+    "BaseUrl": "https://api.vipps.no",
     "ClientId": "",
     "ClientSecret": "",
     "MerchantSerialNumber": "",
-    "SubscriptionKey": ""
+    "SubscriptionKey": "",
+    "TestBaseUrl": "https://apitest.vipps.no",
+    "TestClientId": "",
+    "TestClientSecret": "",
+    "TestMerchantSerialNumber": "",
+    "TestSubscriptionKey": ""
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -54,13 +54,9 @@
   "Vipps": {
     "BaseUrl": "https://api.vipps.no",
     "ClientId": "",
-    "ClientSecret": "",
     "MerchantSerialNumber": "",
-    "SubscriptionKey": "",
     "TestBaseUrl": "https://apitest.vipps.no",
-    "TestClientId": "",
-    "TestClientSecret": "",
-    "TestMerchantSerialNumber": "",
-    "TestSubscriptionKey": ""
+    "TestClientId": "b5bb59fa-770e-4050-8c56-eed275e16138",
+    "TestMerchantSerialNumber": "380165"
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -39,7 +39,23 @@
       { "Endpoint": "*:/api/auth/refresh-token", "Period": "1m", "Limit": 20 },
       { "Endpoint": "*:/api/auth/request-password-reset", "Period": "1m", "Limit": 5 },
       { "Endpoint": "*:/api/auth/reset-password", "Period": "1m", "Limit": 5 },
-      { "Endpoint": "*:/api/auth/resend-email-verification", "Period": "1m", "Limit": 1 }
+      { "Endpoint": "*:/api/auth/resend-email-verification", "Period": "1m", "Limit": 1 },
+      { "Endpoint": "*:/api/products", "Period": "1m", "Limit": 60 },
+      { "Endpoint": "*:/api/subscriptions/initiate", "Period": "1m", "Limit": 10 },
+      { "Endpoint": "*:/api/subscriptions/webhook", "Period": "1m", "Limit": 200 },
+      { "Endpoint": "*:/api/shop/checkout", "Period": "1m", "Limit": 10 },
+      { "Endpoint": "*:/api/shop/webhook", "Period": "1m", "Limit": 200 }
     ]
+  },
+  "App": {
+    "FrontendBaseUrl": "https://www.garge.no",
+    "ApiBaseUrl": "https://garge-api.prod.tumogroup.com"
+  },
+  "Vipps": {
+    "BaseUrl": "https://apitest.vipps.no",
+    "ClientId": "",
+    "ClientSecret": "",
+    "MerchantSerialNumber": "",
+    "SubscriptionKey": ""
   }
 }

--- a/garge-api.Tests/ActiveSubscriptionHandlerTests.cs
+++ b/garge-api.Tests/ActiveSubscriptionHandlerTests.cs
@@ -1,0 +1,216 @@
+using garge_api.Authorization;
+using garge_api.Models;
+using garge_api.Models.Admin;
+using garge_api.Models.Sensor;
+using garge_api.Models.Subscription;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System.Security.Claims;
+using Xunit;
+
+namespace garge_api.Tests;
+
+public class ActiveSubscriptionHandlerTests
+{
+    private static (ActiveSubscriptionHandler handler, ApplicationDbContext db) Create()
+    {
+        var db = new ApplicationDbContext(
+            new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString()).Options);
+
+        var serviceProvider = new Mock<IServiceProvider>();
+        serviceProvider.Setup(sp => sp.GetService(typeof(ApplicationDbContext))).Returns(db);
+
+        var scope = new Mock<IServiceScope>();
+        scope.SetupGet(s => s.ServiceProvider).Returns(serviceProvider.Object);
+
+        var scopeFactory = new Mock<IServiceScopeFactory>();
+        scopeFactory.Setup(f => f.CreateScope()).Returns(scope.Object);
+
+        var handler = new ActiveSubscriptionHandler(scopeFactory.Object, new MemoryCache(new MemoryCacheOptions()));
+        return (handler, db);
+    }
+
+    private static AuthorizationHandlerContext MakeContext(string userId, params string[] roles)
+    {
+        var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, userId) };
+        foreach (var role in roles)
+            claims.Add(new(ClaimTypes.Role, role));
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
+        return new AuthorizationHandlerContext([new ActiveSubscriptionRequirement()], principal, null);
+    }
+
+    private static async Task Handle(ActiveSubscriptionHandler handler, AuthorizationHandlerContext ctx)
+        => await ((IAuthorizationHandler)handler).HandleAsync(ctx);
+
+    [Theory]
+    [InlineData("Admin")]
+    [InlineData("SensorAdmin")]
+    [InlineData("MqttAdmin")]
+    public async Task BypassRole_Succeeds_WithoutCheckingDb(string role)
+    {
+        var (handler, _) = Create();
+        var ctx = MakeContext("user-1", role);
+
+        await Handle(handler, ctx);
+
+        Assert.True(ctx.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task PureViewer_NoOwnedSensors_Succeeds()
+    {
+        var (handler, db) = Create();
+        await db.AppSettings.AddAsync(new AppSettings { Id = 1 });
+        await db.SaveChangesAsync();
+
+        var ctx = MakeContext("viewer-1");
+        await Handle(handler, ctx);
+
+        Assert.True(ctx.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task OneOwnedSensor_OneActiveSubscription_Succeeds()
+    {
+        var (handler, db) = Create();
+        await db.AppSettings.AddAsync(new AppSettings { Id = 1 });
+        await db.UserSensors.AddAsync(new UserSensor { UserId = "user-1", SensorId = 1, IsOwner = true });
+        await db.Subscriptions.AddAsync(new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr1", Status = SubscriptionStatus.Active
+        });
+        await db.SaveChangesAsync();
+
+        var ctx = MakeContext("user-1");
+        await Handle(handler, ctx);
+
+        Assert.True(ctx.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task TwoOwnedSensors_OneSubscription_Fails()
+    {
+        var (handler, db) = Create();
+        await db.AppSettings.AddAsync(new AppSettings { Id = 1 });
+        await db.UserSensors.AddRangeAsync(
+            new UserSensor { UserId = "user-1", SensorId = 1, IsOwner = true },
+            new UserSensor { UserId = "user-1", SensorId = 2, IsOwner = true });
+        await db.Subscriptions.AddAsync(new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr1", Status = SubscriptionStatus.Active
+        });
+        await db.SaveChangesAsync();
+
+        var ctx = MakeContext("user-1");
+        await Handle(handler, ctx);
+
+        Assert.False(ctx.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task TwoOwnedSensors_TwoSubscriptions_Succeeds()
+    {
+        var (handler, db) = Create();
+        await db.AppSettings.AddAsync(new AppSettings { Id = 1 });
+        await db.UserSensors.AddRangeAsync(
+            new UserSensor { UserId = "user-1", SensorId = 1, IsOwner = true },
+            new UserSensor { UserId = "user-1", SensorId = 2, IsOwner = true });
+        await db.Subscriptions.AddRangeAsync(
+            new Subscription { UserId = "user-1", ProductId = 1, VippsAgreementId = "agr1", Status = SubscriptionStatus.Active },
+            new Subscription { UserId = "user-1", ProductId = 2, VippsAgreementId = "agr2", Status = SubscriptionStatus.Active });
+        await db.SaveChangesAsync();
+
+        var ctx = MakeContext("user-1");
+        await Handle(handler, ctx);
+
+        Assert.True(ctx.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task OwnedSensor_PendingSubscriptionOnly_Fails()
+    {
+        var (handler, db) = Create();
+        await db.AppSettings.AddAsync(new AppSettings { Id = 1 });
+        await db.UserSensors.AddAsync(new UserSensor { UserId = "user-1", SensorId = 1, IsOwner = true });
+        await db.Subscriptions.AddAsync(new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr1", Status = SubscriptionStatus.Pending
+        });
+        await db.SaveChangesAsync();
+
+        var ctx = MakeContext("user-1");
+        await Handle(handler, ctx);
+
+        Assert.False(ctx.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task SharedSensor_IsOwnerFalse_NotCountedForBilling()
+    {
+        var (handler, db) = Create();
+        await db.AppSettings.AddAsync(new AppSettings { Id = 1 });
+        // User owns 1 sensor, has 1 subscription — should succeed
+        // Plus 1 shared sensor (IsOwner=false) that must NOT count towards billing
+        await db.UserSensors.AddRangeAsync(
+            new UserSensor { UserId = "user-1", SensorId = 1, IsOwner = true },
+            new UserSensor { UserId = "user-1", SensorId = 2, IsOwner = false });
+        await db.Subscriptions.AddAsync(new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr1", Status = SubscriptionStatus.Active
+        });
+        await db.SaveChangesAsync();
+
+        var ctx = MakeContext("user-1");
+        await Handle(handler, ctx);
+
+        Assert.True(ctx.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task TestModeOff_TestSubscription_NotCounted()
+    {
+        var (handler, db) = Create();
+        await db.AppSettings.AddAsync(new AppSettings { Id = 1, VippsTestMode = false });
+        await db.UserSensors.AddAsync(new UserSensor { UserId = "user-1", SensorId = 1, IsOwner = true });
+        await db.Subscriptions.AddAsync(new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr1", Status = SubscriptionStatus.Active,
+            IsTest = true
+        });
+        await db.SaveChangesAsync();
+
+        var ctx = MakeContext("user-1");
+        await Handle(handler, ctx);
+
+        Assert.False(ctx.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task TestModeOn_TestSubscription_Counted()
+    {
+        var (handler, db) = Create();
+        await db.AppSettings.AddAsync(new AppSettings { Id = 1, VippsTestMode = true });
+        await db.UserSensors.AddAsync(new UserSensor { UserId = "user-1", SensorId = 1, IsOwner = true });
+        await db.Subscriptions.AddAsync(new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr1", Status = SubscriptionStatus.Active,
+            IsTest = true
+        });
+        await db.SaveChangesAsync();
+
+        var ctx = MakeContext("user-1");
+        await Handle(handler, ctx);
+
+        Assert.True(ctx.HasSucceeded);
+    }
+}

--- a/garge-api.Tests/AdminControllerTests.cs
+++ b/garge-api.Tests/AdminControllerTests.cs
@@ -34,7 +34,7 @@ public class AdminControllerTests : ControllerTestBase
                 It.IsAny<UpdateAppSettingsDto>(), It.IsAny<AppSettings>()))
             .Returns<UpdateAppSettingsDto, AppSettings>((src, dst) =>
             {
-                dst.CookieBannerEnabled = src.CookieBannerEnabled;
+                if (src.CookieBannerEnabled.HasValue) dst.CookieBannerEnabled = src.CookieBannerEnabled.Value;
                 return dst;
             });
 
@@ -102,5 +102,44 @@ public class AdminControllerTests : ControllerTestBase
         var settings = await db.AppSettings.FindAsync([1], TestContext.Current.CancellationToken);
         Assert.False(settings!.CookieBannerEnabled);
         Assert.Equal(1, await db.AppSettings.CountAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task UpdateAppSettings_PartialUpdate_DoesNotWipeOtherFields()
+    {
+        var db = CreateDbContext();
+        db.AppSettings.Add(new AppSettings
+        {
+            Id = 1,
+            CookieBannerEnabled = true,
+            CompanyName = "Garge AS",
+            CompanyOrgNumber = "934 531 035",
+            CompanyEmail = "hello@garge.no",
+            VippsShopWebhookSecret = "must-not-disappear"
+        });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        MockMapper.Setup(m => m.Map<UpdateAppSettingsDto, AppSettings>(
+                It.IsAny<UpdateAppSettingsDto>(), It.IsAny<AppSettings>()))
+            .Returns<UpdateAppSettingsDto, AppSettings>((src, dst) =>
+            {
+                if (src.CookieBannerEnabled.HasValue) dst.CookieBannerEnabled = src.CookieBannerEnabled.Value;
+                if (src.VatEnabled.HasValue) dst.VatEnabled = src.VatEnabled.Value;
+                if (src.VippsTestMode.HasValue) dst.VippsTestMode = src.VippsTestMode.Value;
+                if (src.CompanyName != null) dst.CompanyName = src.CompanyName;
+                if (src.CompanyOrgNumber != null) dst.CompanyOrgNumber = src.CompanyOrgNumber;
+                if (src.CompanyEmail != null) dst.CompanyEmail = src.CompanyEmail;
+                return dst;
+            });
+
+        await CreateAdminController(db).UpdateAppSettings(
+            new UpdateAppSettingsDto { CookieBannerEnabled = false });
+
+        var settings = await db.AppSettings.FindAsync([1], TestContext.Current.CancellationToken);
+        Assert.False(settings!.CookieBannerEnabled);
+        Assert.Equal("Garge AS", settings.CompanyName);
+        Assert.Equal("934 531 035", settings.CompanyOrgNumber);
+        Assert.Equal("hello@garge.no", settings.CompanyEmail);
+        Assert.Equal("must-not-disappear", settings.VippsShopWebhookSecret);
     }
 }

--- a/garge-api.Tests/ControllerTestBase.cs
+++ b/garge-api.Tests/ControllerTestBase.cs
@@ -44,6 +44,7 @@ public abstract class ControllerTestBase
     protected ApplicationDbContext CreateDbContext() =>
         new(new DbContextOptionsBuilder<ApplicationDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
             .Options);
 
     protected AuthController CreateAuthController(ApplicationDbContext? db = null) =>

--- a/garge-api.Tests/PhoneNumberTests.cs
+++ b/garge-api.Tests/PhoneNumberTests.cs
@@ -1,0 +1,30 @@
+using garge_api.Helpers;
+using Xunit;
+
+namespace garge_api.Tests;
+
+public class PhoneNumberTests
+{
+    [Theory]
+    [InlineData("91234567",        "4791234567")]
+    [InlineData("4791234567",      "4791234567")]
+    [InlineData("+47 91 23 45 67", "4791234567")]
+    [InlineData("(91) 23-45-67",   "4791234567")]
+    [InlineData("12345678",        "4712345678")]
+    public void TryNormalizeNo_AcceptsValidNorwegianFormats(string input, string expected)
+    {
+        Assert.True(PhoneNumber.TryNormalizeNo(input, out var result));
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("123")]
+    [InlineData("4691234567")]
+    [InlineData("479123456789")]
+    public void TryNormalizeNo_RejectsInvalid(string input)
+    {
+        Assert.False(PhoneNumber.TryNormalizeNo(input, out _));
+    }
+}

--- a/garge-api.Tests/PricingTests.cs
+++ b/garge-api.Tests/PricingTests.cs
@@ -1,0 +1,26 @@
+using garge_api.Services;
+using Xunit;
+
+namespace garge_api.Tests;
+
+public class PricingTests
+{
+    [Theory]
+    [InlineData(0,    false, 0)]
+    [InlineData(100,  false, 100)]
+    [InlineData(8000, true,  10000)]
+    [InlineData(4900, true,  6125)]
+    [InlineData(4902, true,  6128)]
+    [InlineData(29900, true, 37375)]
+    public void EffectiveInOre_AppliesVatWithMidpointAwayFromZero(int input, bool vat, int expected)
+    {
+        Assert.Equal(expected, Pricing.EffectiveInOre(input, vat));
+    }
+
+    [Fact]
+    public void Constants_MatchVippsBasisPoints()
+    {
+        Assert.Equal(25, Pricing.VatPercent);
+        Assert.Equal(2500, Pricing.VatBasisPoints);
+    }
+}

--- a/garge-api.Tests/ShopControllerTests.cs
+++ b/garge-api.Tests/ShopControllerTests.cs
@@ -8,8 +8,8 @@ using garge_api.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
-using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Xunit;
@@ -24,27 +24,61 @@ public class ShopControllerTests : ControllerTestBase
     {
         var mock = new Mock<IVippsService>();
         mock.Setup(v => v.VerifyWebhookSignature(
-                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-            .Returns((string body, string sig, string secret) =>
-            {
-                if (string.IsNullOrEmpty(secret) || !sig.StartsWith("sha256=")) return false;
-                var computed = "sha256=" + Convert.ToHexString(
-                    HMACSHA256.HashData(Encoding.UTF8.GetBytes(secret), Encoding.UTF8.GetBytes(body))
-                ).ToLowerInvariant();
-                return CryptographicOperations.FixedTimeEquals(
-                    Encoding.ASCII.GetBytes(computed),
-                    Encoding.ASCII.GetBytes(sig.ToLowerInvariant()));
-            });
+                It.IsAny<HttpRequest>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Returns((HttpRequest req, string body, string secret) =>
+                string.IsNullOrEmpty(secret)
+                    ? WebhookVerifyResult.MissingSecret
+                    : (req.Headers["X-Test-Valid"] == "1"
+                        ? WebhookVerifyResult.Valid
+                        : WebhookVerifyResult.BadSignature));
         return mock;
     }
 
+    private static Mock<IWebhookSecretProtector> MockProtector()
+    {
+        var m = new Mock<IWebhookSecretProtector>();
+        m.Setup(p => p.Protect(It.IsAny<string>())).Returns<string>(s => s);
+        m.Setup(p => p.Unprotect(It.IsAny<string>())).Returns<string>(s => s);
+        return m;
+    }
+
+    private static Mock<IAppSettingsCache> MockSettingsCache(AppSettings? settings = null)
+    {
+        var m = new Mock<IAppSettingsCache>();
+        m.Setup(c => c.GetAsync()).ReturnsAsync(settings ?? new AppSettings { Id = 1 });
+        return m;
+    }
+
+    private static IOptions<VippsOptions> VippsOpts() => Options.Create(new VippsOptions
+    {
+        ClientId = "id", ClientSecret = "s", MerchantSerialNumber = "msn-prod",
+        SubscriptionKey = "k", BaseUrl = "https://api.vipps.no",
+        TestMerchantSerialNumber = "msn-test"
+    });
+
+    private static IOptions<AppOptions> AppOpts() => Options.Create(new AppOptions
+    {
+        FrontendBaseUrl = "https://www.garge.no",
+        ApiBaseUrl = "https://garge-api.prod.tumogroup.com"
+    });
+
     private ShopController CreateController(
         ApplicationDbContext db, string userId = "user-1",
-        IVippsService? vipps = null, IInvoiceService? invoice = null)
+        Mock<IVippsService>? vipps = null, IInvoiceService? invoice = null,
+        AppSettings? settings = null)
     {
+        var push = new Mock<IWebPushService>();
+        push.Setup(p => p.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
         var ctrl = new ShopController(
-            db, vipps ?? MockVipps().Object,
+            db, (vipps ?? MockVipps()).Object,
             invoice ?? MockInvoice().Object,
+            MockSettingsCache(settings).Object,
+            MockProtector().Object,
+            push.Object,
+            VippsOpts(),
+            AppOpts(),
             MockMapper.Object,
             NullLogger<ShopController>.Instance);
         ctrl.ControllerContext = MakeControllerContext(userId);
@@ -55,7 +89,6 @@ public class ShopControllerTests : ControllerTestBase
     public async Task Webhook_ValidHmac_AuthorizedEvent_SetsReserved()
     {
         using var db = CreateDbContext();
-        await db.AppSettings.AddAsync(new AppSettings { Id = 1, VippsShopWebhookSecret = "secret" });
         var order = new Order
         {
             UserId = "user-1", VippsOrderId = "vipps-ref",
@@ -64,12 +97,18 @@ public class ShopControllerTests : ControllerTestBase
         await db.Orders.AddAsync(order);
         await db.SaveChangesAsync();
 
-        var payload = new { reference = order.Id.ToString(), name = "AUTHORIZED" };
+        var payload = new
+        {
+            reference = order.Id.ToString(),
+            pspReference = "psp-1",
+            name = "AUTHORIZED",
+            amount = new { value = 10000, currency = "NOK" },
+            msn = "msn-prod"
+        };
         var body = JsonSerializer.Serialize(payload);
-        var sig = BuildSig(body, "secret");
 
-        var ctrl = CreateController(db);
-        SetupWebhookRequest(ctrl, body, sig);
+        var ctrl = CreateController(db, settings: new AppSettings { Id = 1, VippsShopWebhookSecret = "secret" });
+        SetupValidWebhookRequest(ctrl, body);
 
         var result = await ctrl.Webhook();
 
@@ -82,12 +121,11 @@ public class ShopControllerTests : ControllerTestBase
     public async Task Webhook_InvalidHmac_Returns401()
     {
         using var db = CreateDbContext();
-        await db.AppSettings.AddAsync(new AppSettings { Id = 1, VippsShopWebhookSecret = "secret" });
         await db.SaveChangesAsync();
 
         var body = """{"reference":"1","name":"AUTHORIZED"}""";
-        var ctrl = CreateController(db);
-        SetupWebhookRequest(ctrl, body, "sha256=badhash");
+        var ctrl = CreateController(db, settings: new AppSettings { Id = 1, VippsShopWebhookSecret = "secret" });
+        SetupInvalidWebhookRequest(ctrl, body);
 
         var result = await ctrl.Webhook();
 
@@ -96,21 +134,30 @@ public class ShopControllerTests : ControllerTestBase
 
     [Theory]
     [InlineData("AUTHORIZED",  OrderStatus.Reserved)]
+    [InlineData("CAPTURED",    OrderStatus.Paid)]
     [InlineData("TERMINATED",  OrderStatus.Failed)]
+    [InlineData("ABORTED",     OrderStatus.Failed)]
+    [InlineData("EXPIRED",     OrderStatus.Failed)]
+    [InlineData("CANCELLED",   OrderStatus.Cancelled)]
     [InlineData("REFUNDED",    OrderStatus.Refunded)]
     [InlineData("UNKNOWN_EVT", OrderStatus.Pending)]
     public async Task Webhook_EventNames_MapToCorrectStatus(string eventName, OrderStatus expected)
     {
         using var db = CreateDbContext();
-        await db.AppSettings.AddAsync(new AppSettings { Id = 1, VippsShopWebhookSecret = "s" });
         var order = new Order { UserId = "u", TotalInOre = 100, Status = OrderStatus.Pending };
         await db.Orders.AddAsync(order);
         await db.SaveChangesAsync();
 
-        var body = JsonSerializer.Serialize(new { reference = order.Id.ToString(), name = eventName });
-        var sig = BuildSig(body, "s");
-        var ctrl = CreateController(db);
-        SetupWebhookRequest(ctrl, body, sig);
+        var body = JsonSerializer.Serialize(new
+        {
+            reference = order.Id.ToString(),
+            pspReference = $"psp-{eventName}",
+            name = eventName,
+            amount = new { value = 100, currency = "NOK" },
+            msn = "msn-prod"
+        });
+        var ctrl = CreateController(db, settings: new AppSettings { Id = 1, VippsShopWebhookSecret = "s" });
+        SetupValidWebhookRequest(ctrl, body);
         await ctrl.Webhook();
 
         var updated = await db.Orders.FindAsync(order.Id);
@@ -118,10 +165,62 @@ public class ShopControllerTests : ControllerTestBase
     }
 
     [Fact]
+    public async Task Webhook_AmountMismatch_Returns401()
+    {
+        using var db = CreateDbContext();
+        var order = new Order { UserId = "u", TotalInOre = 10000, Status = OrderStatus.Pending };
+        await db.Orders.AddAsync(order);
+        await db.SaveChangesAsync();
+
+        var body = JsonSerializer.Serialize(new
+        {
+            reference = order.Id.ToString(),
+            pspReference = "psp-bad",
+            name = "AUTHORIZED",
+            amount = new { value = 9999, currency = "NOK" },
+            msn = "msn-prod"
+        });
+        var ctrl = CreateController(db, settings: new AppSettings { Id = 1, VippsShopWebhookSecret = "s" });
+        SetupValidWebhookRequest(ctrl, body);
+
+        var result = await ctrl.Webhook();
+        Assert.IsType<UnauthorizedResult>(result);
+    }
+
+    [Fact]
+    public async Task Webhook_DuplicateEvent_Idempotent()
+    {
+        using var db = CreateDbContext();
+        var order = new Order { UserId = "u", TotalInOre = 100, Status = OrderStatus.Pending };
+        await db.Orders.AddAsync(order);
+        await db.SaveChangesAsync();
+
+        var body = JsonSerializer.Serialize(new
+        {
+            reference = order.Id.ToString(),
+            pspReference = "psp-once",
+            name = "AUTHORIZED",
+            amount = new { value = 100, currency = "NOK" },
+            msn = "msn-prod"
+        });
+
+        var settings = new AppSettings { Id = 1, VippsShopWebhookSecret = "s" };
+
+        var c1 = CreateController(db, settings: settings);
+        SetupValidWebhookRequest(c1, body);
+        await c1.Webhook();
+
+        var c2 = CreateController(db, settings: settings);
+        SetupValidWebhookRequest(c2, body);
+        await c2.Webhook();
+
+        Assert.Equal(1, await db.ProcessedWebhookEvents.CountAsync(e => e.Id == "psp-once"));
+    }
+
+    [Fact]
     public async Task Checkout_InactiveItem_ReturnsBadRequest()
     {
         using var db = CreateDbContext();
-        await db.AppSettings.AddAsync(new AppSettings { Id = 1 });
         var item = new ShopItem { Name = "Sensor", PriceInOre = 5000, IsActive = false };
         await db.ShopItems.AddAsync(item);
         await db.SaveChangesAsync();
@@ -131,7 +230,6 @@ public class ShopControllerTests : ControllerTestBase
         {
             Items = [new OrderItemRequestDto { ShopItemId = item.Id, Quantity = 1 }],
             PhoneNumber = "4791234567",
-            RedirectUrl = "https://garge.no/shop/return",
             ShippingAddress = "Testgata 1, 0001 Oslo"
         };
 
@@ -144,18 +242,36 @@ public class ShopControllerTests : ControllerTestBase
     public async Task Checkout_InsufficientStock_ReturnsBadRequest()
     {
         using var db = CreateDbContext();
-        await db.AppSettings.AddAsync(new AppSettings { Id = 1 });
         var item = new ShopItem { Name = "Sensor", PriceInOre = 5000, IsActive = true, StockCount = 1 };
         await db.ShopItems.AddAsync(item);
         await db.SaveChangesAsync();
 
-        var vipps = MockVipps();
-        var ctrl = CreateController(db, vipps: vipps.Object);
+        var ctrl = CreateController(db);
         var dto = new CreateOrderDto
         {
             Items = [new OrderItemRequestDto { ShopItemId = item.Id, Quantity = 2 }],
             PhoneNumber = "4791234567",
-            RedirectUrl = "https://garge.no/shop/return",
+            ShippingAddress = "Testgata 1, 0001 Oslo"
+        };
+
+        var result = await ctrl.Checkout(dto);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Checkout_InvalidPhone_ReturnsBadRequest()
+    {
+        using var db = CreateDbContext();
+        var item = new ShopItem { Name = "Sensor", PriceInOre = 5000, IsActive = true };
+        await db.ShopItems.AddAsync(item);
+        await db.SaveChangesAsync();
+
+        var ctrl = CreateController(db);
+        var dto = new CreateOrderDto
+        {
+            Items = [new OrderItemRequestDto { ShopItemId = item.Id, Quantity = 1 }],
+            PhoneNumber = "1234",
             ShippingAddress = "Testgata 1, 0001 Oslo"
         };
 
@@ -168,22 +284,21 @@ public class ShopControllerTests : ControllerTestBase
     public async Task Checkout_ValidOrder_StoresShippingAddressAndVatSnapshot()
     {
         using var db = CreateDbContext();
-        await db.AppSettings.AddAsync(new AppSettings { Id = 1, VatEnabled = true });
         var item = new ShopItem { Name = "Sensor", PriceInOre = 8000, IsActive = true, StockCount = -1 };
         await db.ShopItems.AddAsync(item);
         await db.SaveChangesAsync();
 
         var vipps = MockVipps();
         vipps.Setup(v => v.CreatePaymentAsync(It.IsAny<Order>(), It.IsAny<List<VippsOrderLine>>(),
-                It.IsAny<string>(), It.IsAny<string>()))
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync(new VippsCreatePaymentResponse { Reference = "vipps-ref", RedirectUrl = "https://vipps.no/pay" });
 
-        var ctrl = CreateController(db, vipps: vipps.Object);
+        var ctrl = CreateController(db, vipps: vipps,
+            settings: new AppSettings { Id = 1, VatEnabled = true });
         var dto = new CreateOrderDto
         {
             Items = [new OrderItemRequestDto { ShopItemId = item.Id, Quantity = 1 }],
             PhoneNumber = "4791234567",
-            RedirectUrl = "https://garge.no/shop/return",
             ShippingAddress = "Testgata 1, 0001 Oslo"
         };
 
@@ -195,19 +310,46 @@ public class ShopControllerTests : ControllerTestBase
         Assert.Equal("Testgata 1, 0001 Oslo", savedOrder.ShippingAddress);
         Assert.Equal(8000, savedItem.UnitPriceExclVatInOre);
         Assert.Equal(25, savedItem.VatPercentage);
-        Assert.Equal(10000, savedItem.PriceAtPurchaseInOre); // 8000 * 1.25
+        Assert.Equal(10000, savedItem.PriceAtPurchaseInOre);
     }
 
-    private static string BuildSig(string body, string secret) =>
-        "sha256=" + Convert.ToHexString(
-            HMACSHA256.HashData(Encoding.UTF8.GetBytes(secret), Encoding.UTF8.GetBytes(body))
-        ).ToLowerInvariant();
+    [Fact]
+    public async Task Checkout_DecrementsStock()
+    {
+        using var db = CreateDbContext();
+        var item = new ShopItem { Name = "Sensor", PriceInOre = 5000, IsActive = true, StockCount = 3 };
+        await db.ShopItems.AddAsync(item);
+        await db.SaveChangesAsync();
 
-    private static void SetupWebhookRequest(ShopController ctrl, string body, string signature)
+        var vipps = MockVipps();
+        vipps.Setup(v => v.CreatePaymentAsync(It.IsAny<Order>(), It.IsAny<List<VippsOrderLine>>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new VippsCreatePaymentResponse { Reference = "ref", RedirectUrl = "x" });
+
+        var ctrl = CreateController(db, vipps: vipps);
+        await ctrl.Checkout(new CreateOrderDto
+        {
+            Items = [new OrderItemRequestDto { ShopItemId = item.Id, Quantity = 2 }],
+            PhoneNumber = "4791234567",
+            ShippingAddress = "Test"
+        });
+
+        var reloaded = await db.ShopItems.FirstAsync();
+        Assert.Equal(1, reloaded.StockCount);
+    }
+
+    private static void SetupValidWebhookRequest(ShopController ctrl, string body) =>
+        SetupWebhookRequest(ctrl, body, valid: true);
+
+    private static void SetupInvalidWebhookRequest(ShopController ctrl, string body) =>
+        SetupWebhookRequest(ctrl, body, valid: false);
+
+    private static void SetupWebhookRequest(ShopController ctrl, string body, bool valid)
     {
         var bytes = Encoding.UTF8.GetBytes(body);
         ctrl.ControllerContext.HttpContext.Request.Body = new MemoryStream(bytes);
         ctrl.ControllerContext.HttpContext.Request.ContentLength = bytes.Length;
-        ctrl.ControllerContext.HttpContext.Request.Headers["X-Vipps-Signature"] = signature;
+        if (valid)
+            ctrl.ControllerContext.HttpContext.Request.Headers["X-Test-Valid"] = "1";
     }
 }

--- a/garge-api.Tests/ShopControllerTests.cs
+++ b/garge-api.Tests/ShopControllerTests.cs
@@ -91,7 +91,7 @@ public class ShopControllerTests : ControllerTestBase
         using var db = CreateDbContext();
         var order = new Order
         {
-            UserId = "user-1", VippsOrderId = "vipps-ref",
+            UserId = "user-1", VippsOrderId = "garge-order-000001",
             TotalInOre = 10000, Status = OrderStatus.Pending
         };
         await db.Orders.AddAsync(order);
@@ -99,7 +99,7 @@ public class ShopControllerTests : ControllerTestBase
 
         var payload = new
         {
-            reference = order.Id.ToString(),
+            reference = order.VippsOrderId,
             pspReference = "psp-1",
             name = "AUTHORIZED",
             amount = new { value = 10000, currency = "NOK" },
@@ -144,13 +144,13 @@ public class ShopControllerTests : ControllerTestBase
     public async Task Webhook_EventNames_MapToCorrectStatus(string eventName, OrderStatus expected)
     {
         using var db = CreateDbContext();
-        var order = new Order { UserId = "u", TotalInOre = 100, Status = OrderStatus.Pending };
+        var order = new Order { UserId = "u", VippsOrderId = $"garge-order-evt-{eventName}", TotalInOre = 100, Status = OrderStatus.Pending };
         await db.Orders.AddAsync(order);
         await db.SaveChangesAsync();
 
         var body = JsonSerializer.Serialize(new
         {
-            reference = order.Id.ToString(),
+            reference = order.VippsOrderId,
             pspReference = $"psp-{eventName}",
             name = eventName,
             amount = new { value = 100, currency = "NOK" },
@@ -168,13 +168,13 @@ public class ShopControllerTests : ControllerTestBase
     public async Task Webhook_AmountMismatch_Returns401()
     {
         using var db = CreateDbContext();
-        var order = new Order { UserId = "u", TotalInOre = 10000, Status = OrderStatus.Pending };
+        var order = new Order { UserId = "u", VippsOrderId = "garge-order-amount", TotalInOre = 10000, Status = OrderStatus.Pending };
         await db.Orders.AddAsync(order);
         await db.SaveChangesAsync();
 
         var body = JsonSerializer.Serialize(new
         {
-            reference = order.Id.ToString(),
+            reference = order.VippsOrderId,
             pspReference = "psp-bad",
             name = "AUTHORIZED",
             amount = new { value = 9999, currency = "NOK" },
@@ -191,13 +191,13 @@ public class ShopControllerTests : ControllerTestBase
     public async Task Webhook_DuplicateEvent_Idempotent()
     {
         using var db = CreateDbContext();
-        var order = new Order { UserId = "u", TotalInOre = 100, Status = OrderStatus.Pending };
+        var order = new Order { UserId = "u", VippsOrderId = "garge-order-dup", TotalInOre = 100, Status = OrderStatus.Pending };
         await db.Orders.AddAsync(order);
         await db.SaveChangesAsync();
 
         var body = JsonSerializer.Serialize(new
         {
-            reference = order.Id.ToString(),
+            reference = order.VippsOrderId,
             pspReference = "psp-once",
             name = "AUTHORIZED",
             amount = new { value = 100, currency = "NOK" },

--- a/garge-api.Tests/ShopControllerTests.cs
+++ b/garge-api.Tests/ShopControllerTests.cs
@@ -1,0 +1,213 @@
+using garge_api.Controllers;
+using garge_api.Dtos.Shop;
+using Microsoft.AspNetCore.Http;
+using garge_api.Models;
+using garge_api.Models.Admin;
+using garge_api.Models.Shop;
+using garge_api.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace garge_api.Tests;
+
+public class ShopControllerTests : ControllerTestBase
+{
+    private static Mock<IInvoiceService> MockInvoice() => new();
+
+    private static Mock<IVippsService> MockVipps()
+    {
+        var mock = new Mock<IVippsService>();
+        mock.Setup(v => v.VerifyWebhookSignature(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Returns((string body, string sig, string secret) =>
+            {
+                if (string.IsNullOrEmpty(secret) || !sig.StartsWith("sha256=")) return false;
+                var computed = "sha256=" + Convert.ToHexString(
+                    HMACSHA256.HashData(Encoding.UTF8.GetBytes(secret), Encoding.UTF8.GetBytes(body))
+                ).ToLowerInvariant();
+                return CryptographicOperations.FixedTimeEquals(
+                    Encoding.ASCII.GetBytes(computed),
+                    Encoding.ASCII.GetBytes(sig.ToLowerInvariant()));
+            });
+        return mock;
+    }
+
+    private ShopController CreateController(
+        ApplicationDbContext db, string userId = "user-1",
+        IVippsService? vipps = null, IInvoiceService? invoice = null)
+    {
+        var ctrl = new ShopController(
+            db, vipps ?? MockVipps().Object,
+            invoice ?? MockInvoice().Object,
+            MockMapper.Object,
+            NullLogger<ShopController>.Instance);
+        ctrl.ControllerContext = MakeControllerContext(userId);
+        return ctrl;
+    }
+
+    [Fact]
+    public async Task Webhook_ValidHmac_AuthorizedEvent_SetsReserved()
+    {
+        using var db = CreateDbContext();
+        await db.AppSettings.AddAsync(new AppSettings { Id = 1, VippsShopWebhookSecret = "secret" });
+        var order = new Order
+        {
+            UserId = "user-1", VippsOrderId = "vipps-ref",
+            TotalInOre = 10000, Status = OrderStatus.Pending
+        };
+        await db.Orders.AddAsync(order);
+        await db.SaveChangesAsync();
+
+        var payload = new { reference = order.Id.ToString(), name = "AUTHORIZED" };
+        var body = JsonSerializer.Serialize(payload);
+        var sig = BuildSig(body, "secret");
+
+        var ctrl = CreateController(db);
+        SetupWebhookRequest(ctrl, body, sig);
+
+        var result = await ctrl.Webhook();
+
+        Assert.IsType<OkResult>(result);
+        var updated = await db.Orders.FindAsync(order.Id);
+        Assert.Equal(OrderStatus.Reserved, updated!.Status);
+    }
+
+    [Fact]
+    public async Task Webhook_InvalidHmac_Returns401()
+    {
+        using var db = CreateDbContext();
+        await db.AppSettings.AddAsync(new AppSettings { Id = 1, VippsShopWebhookSecret = "secret" });
+        await db.SaveChangesAsync();
+
+        var body = """{"reference":"1","name":"AUTHORIZED"}""";
+        var ctrl = CreateController(db);
+        SetupWebhookRequest(ctrl, body, "sha256=badhash");
+
+        var result = await ctrl.Webhook();
+
+        Assert.IsType<UnauthorizedResult>(result);
+    }
+
+    [Theory]
+    [InlineData("AUTHORIZED",  OrderStatus.Reserved)]
+    [InlineData("TERMINATED",  OrderStatus.Failed)]
+    [InlineData("REFUNDED",    OrderStatus.Refunded)]
+    [InlineData("UNKNOWN_EVT", OrderStatus.Pending)]
+    public async Task Webhook_EventNames_MapToCorrectStatus(string eventName, OrderStatus expected)
+    {
+        using var db = CreateDbContext();
+        await db.AppSettings.AddAsync(new AppSettings { Id = 1, VippsShopWebhookSecret = "s" });
+        var order = new Order { UserId = "u", TotalInOre = 100, Status = OrderStatus.Pending };
+        await db.Orders.AddAsync(order);
+        await db.SaveChangesAsync();
+
+        var body = JsonSerializer.Serialize(new { reference = order.Id.ToString(), name = eventName });
+        var sig = BuildSig(body, "s");
+        var ctrl = CreateController(db);
+        SetupWebhookRequest(ctrl, body, sig);
+        await ctrl.Webhook();
+
+        var updated = await db.Orders.FindAsync(order.Id);
+        Assert.Equal(expected, updated!.Status);
+    }
+
+    [Fact]
+    public async Task Checkout_InactiveItem_ReturnsBadRequest()
+    {
+        using var db = CreateDbContext();
+        await db.AppSettings.AddAsync(new AppSettings { Id = 1 });
+        var item = new ShopItem { Name = "Sensor", PriceInOre = 5000, IsActive = false };
+        await db.ShopItems.AddAsync(item);
+        await db.SaveChangesAsync();
+
+        var ctrl = CreateController(db);
+        var dto = new CreateOrderDto
+        {
+            Items = [new OrderItemRequestDto { ShopItemId = item.Id, Quantity = 1 }],
+            PhoneNumber = "4791234567",
+            RedirectUrl = "https://garge.no/shop/return",
+            ShippingAddress = "Testgata 1, 0001 Oslo"
+        };
+
+        var result = await ctrl.Checkout(dto);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Checkout_InsufficientStock_ReturnsBadRequest()
+    {
+        using var db = CreateDbContext();
+        await db.AppSettings.AddAsync(new AppSettings { Id = 1 });
+        var item = new ShopItem { Name = "Sensor", PriceInOre = 5000, IsActive = true, StockCount = 1 };
+        await db.ShopItems.AddAsync(item);
+        await db.SaveChangesAsync();
+
+        var vipps = MockVipps();
+        var ctrl = CreateController(db, vipps: vipps.Object);
+        var dto = new CreateOrderDto
+        {
+            Items = [new OrderItemRequestDto { ShopItemId = item.Id, Quantity = 2 }],
+            PhoneNumber = "4791234567",
+            RedirectUrl = "https://garge.no/shop/return",
+            ShippingAddress = "Testgata 1, 0001 Oslo"
+        };
+
+        var result = await ctrl.Checkout(dto);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Checkout_ValidOrder_StoresShippingAddressAndVatSnapshot()
+    {
+        using var db = CreateDbContext();
+        await db.AppSettings.AddAsync(new AppSettings { Id = 1, VatEnabled = true });
+        var item = new ShopItem { Name = "Sensor", PriceInOre = 8000, IsActive = true, StockCount = -1 };
+        await db.ShopItems.AddAsync(item);
+        await db.SaveChangesAsync();
+
+        var vipps = MockVipps();
+        vipps.Setup(v => v.CreatePaymentAsync(It.IsAny<Order>(), It.IsAny<List<VippsOrderLine>>(),
+                It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new VippsCreatePaymentResponse { Reference = "vipps-ref", RedirectUrl = "https://vipps.no/pay" });
+
+        var ctrl = CreateController(db, vipps: vipps.Object);
+        var dto = new CreateOrderDto
+        {
+            Items = [new OrderItemRequestDto { ShopItemId = item.Id, Quantity = 1 }],
+            PhoneNumber = "4791234567",
+            RedirectUrl = "https://garge.no/shop/return",
+            ShippingAddress = "Testgata 1, 0001 Oslo"
+        };
+
+        await ctrl.Checkout(dto);
+
+        var savedOrder = await db.Orders.FirstAsync();
+        var savedItem = await db.OrderItems.FirstAsync();
+
+        Assert.Equal("Testgata 1, 0001 Oslo", savedOrder.ShippingAddress);
+        Assert.Equal(8000, savedItem.UnitPriceExclVatInOre);
+        Assert.Equal(25, savedItem.VatPercentage);
+        Assert.Equal(10000, savedItem.PriceAtPurchaseInOre); // 8000 * 1.25
+    }
+
+    private static string BuildSig(string body, string secret) =>
+        "sha256=" + Convert.ToHexString(
+            HMACSHA256.HashData(Encoding.UTF8.GetBytes(secret), Encoding.UTF8.GetBytes(body))
+        ).ToLowerInvariant();
+
+    private static void SetupWebhookRequest(ShopController ctrl, string body, string signature)
+    {
+        var bytes = Encoding.UTF8.GetBytes(body);
+        ctrl.ControllerContext.HttpContext.Request.Body = new MemoryStream(bytes);
+        ctrl.ControllerContext.HttpContext.Request.ContentLength = bytes.Length;
+        ctrl.ControllerContext.HttpContext.Request.Headers["X-Vipps-Signature"] = signature;
+    }
+}

--- a/garge-api.Tests/SubscriptionsControllerTests.cs
+++ b/garge-api.Tests/SubscriptionsControllerTests.cs
@@ -8,9 +8,8 @@ using garge_api.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
-using System.Security.Cryptography;
-using System.Text;
 using System.Text.Json;
 using Xunit;
 
@@ -22,24 +21,52 @@ public class SubscriptionsControllerTests : ControllerTestBase
     {
         var mock = new Mock<IVippsService>();
         mock.Setup(v => v.VerifyWebhookSignature(
-                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-            .Returns((string body, string sig, string secret) =>
-            {
-                if (string.IsNullOrEmpty(secret) || !sig.StartsWith("sha256=")) return false;
-                var computed = "sha256=" + Convert.ToHexString(
-                    HMACSHA256.HashData(Encoding.UTF8.GetBytes(secret), Encoding.UTF8.GetBytes(body))
-                ).ToLowerInvariant();
-                return CryptographicOperations.FixedTimeEquals(
-                    Encoding.ASCII.GetBytes(computed),
-                    Encoding.ASCII.GetBytes(sig.ToLowerInvariant()));
-            });
+                It.IsAny<HttpRequest>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Returns((HttpRequest req, string body, string secret) =>
+                string.IsNullOrEmpty(secret)
+                    ? WebhookVerifyResult.MissingSecret
+                    : (req.Headers["X-Test-Valid"] == "1"
+                        ? WebhookVerifyResult.Valid
+                        : WebhookVerifyResult.BadSignature));
         return mock;
     }
 
-    private SubscriptionsController CreateController(ApplicationDbContext db, string userId = "user-1")
+    private static Mock<IWebhookSecretProtector> MockProtector()
     {
+        var m = new Mock<IWebhookSecretProtector>();
+        m.Setup(p => p.Protect(It.IsAny<string>())).Returns<string>(s => s);
+        m.Setup(p => p.Unprotect(It.IsAny<string>())).Returns<string>(s => s);
+        return m;
+    }
+
+    private static Mock<IAppSettingsCache> MockSettingsCache(AppSettings? settings = null)
+    {
+        var m = new Mock<IAppSettingsCache>();
+        m.Setup(c => c.GetAsync()).ReturnsAsync(settings ?? new AppSettings { Id = 1 });
+        return m;
+    }
+
+    private static IOptions<AppOptions> AppOpts() => Options.Create(new AppOptions
+    {
+        FrontendBaseUrl = "https://www.garge.no",
+        ApiBaseUrl = "https://garge-api.prod.tumogroup.com"
+    });
+
+    private SubscriptionsController CreateController(
+        ApplicationDbContext db, string userId = "user-1",
+        Mock<IVippsService>? vipps = null, AppSettings? settings = null)
+    {
+        var push = new Mock<IWebPushService>();
+        push.Setup(p => p.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
         var ctrl = new SubscriptionsController(
-            db, MockVipps().Object, MockMapper.Object,
+            db, (vipps ?? MockVipps()).Object,
+            MockSettingsCache(settings).Object,
+            MockProtector().Object,
+            push.Object,
+            AppOpts(),
+            MockMapper.Object,
             NullLogger<SubscriptionsController>.Instance);
         ctrl.ControllerContext = MakeControllerContext(userId);
         return ctrl;
@@ -69,16 +96,14 @@ public class SubscriptionsControllerTests : ControllerTestBase
         var payload = new VippsAgreementWebhookDto
         {
             AgreementId = "agr_test",
+            EventId = $"evt-{eventType}",
             EventType = eventType,
             Occurred = DateTime.UtcNow
         };
         var body = JsonSerializer.Serialize(payload);
-        var sig = "sha256=" + Convert.ToHexString(
-            HMACSHA256.HashData(Encoding.UTF8.GetBytes("secret"), Encoding.UTF8.GetBytes(body))
-        ).ToLowerInvariant();
 
-        var ctrl = CreateController(db);
-        SetupWebhookRequest(ctrl, body, sig);
+        var ctrl = CreateController(db, settings: new AppSettings { Id = 1, VippsSubscriptionWebhookSecret = "secret" });
+        SetupValidWebhookRequest(ctrl, body);
 
         var result = await ctrl.Webhook();
 
@@ -91,12 +116,11 @@ public class SubscriptionsControllerTests : ControllerTestBase
     public async Task Webhook_InvalidHmac_Returns401()
     {
         using var db = CreateDbContext();
-        await db.AppSettings.AddAsync(new AppSettings { Id = 1, VippsSubscriptionWebhookSecret = "correct" });
         await db.SaveChangesAsync();
 
         var body = """{"agreementId":"agr_test","eventType":"recurring.agreement-activated.v1"}""";
-        var ctrl = CreateController(db);
-        SetupWebhookRequest(ctrl, body, "sha256=badhash");
+        var ctrl = CreateController(db, settings: new AppSettings { Id = 1, VippsSubscriptionWebhookSecret = "correct" });
+        SetupInvalidWebhookRequest(ctrl, body);
 
         var result = await ctrl.Webhook();
 
@@ -104,11 +128,43 @@ public class SubscriptionsControllerTests : ControllerTestBase
     }
 
     [Fact]
+    public async Task Webhook_DuplicateEvent_SkipsSecondProcessing()
+    {
+        using var db = CreateDbContext();
+        var sub = new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr_dup", Status = SubscriptionStatus.Pending
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        var payload = new VippsAgreementWebhookDto
+        {
+            AgreementId = "agr_dup",
+            EventId = "evt-1",
+            EventType = "recurring.agreement-activated.v1",
+            Occurred = DateTime.UtcNow
+        };
+        var body = JsonSerializer.Serialize(payload);
+
+        var settings = new AppSettings { Id = 1, VippsSubscriptionWebhookSecret = "secret" };
+        var ctrl1 = CreateController(db, settings: settings);
+        SetupValidWebhookRequest(ctrl1, body);
+        await ctrl1.Webhook();
+
+        var ctrl2 = CreateController(db, settings: settings);
+        SetupValidWebhookRequest(ctrl2, body);
+        await ctrl2.Webhook();
+
+        Assert.Equal(1, await db.ProcessedWebhookEvents.CountAsync(e => e.Id == "evt-1"));
+    }
+
+    [Fact]
     public async Task Webhook_ActivatedEvent_SetsStartDate()
     {
         using var db = CreateDbContext();
         var occurred = new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc);
-        await db.AppSettings.AddAsync(new AppSettings { Id = 1, VippsSubscriptionWebhookSecret = "secret" });
         var sub = new Subscription
         {
             UserId = "user-1", ProductId = 1,
@@ -118,25 +174,221 @@ public class SubscriptionsControllerTests : ControllerTestBase
         await db.Subscriptions.AddAsync(sub);
         await db.SaveChangesAsync();
 
-        var payload = new { agreementId = "agr_start", eventType = "recurring.agreement-activated.v1", occurred };
+        var payload = new
+        {
+            agreementId = "agr_start",
+            eventId = "evt-start",
+            eventType = "recurring.agreement-activated.v1",
+            occurred
+        };
         var body = JsonSerializer.Serialize(payload);
-        var sig = "sha256=" + Convert.ToHexString(
-            HMACSHA256.HashData(Encoding.UTF8.GetBytes("secret"), Encoding.UTF8.GetBytes(body))
-        ).ToLowerInvariant();
 
-        var ctrl = CreateController(db);
-        SetupWebhookRequest(ctrl, body, sig);
+        var ctrl = CreateController(db, settings: new AppSettings { Id = 1, VippsSubscriptionWebhookSecret = "secret" });
+        SetupValidWebhookRequest(ctrl, body);
         await ctrl.Webhook();
 
         var updated = await db.Subscriptions.FirstAsync();
         Assert.Equal(occurred, updated.StartDate);
     }
 
-    private static void SetupWebhookRequest(SubscriptionsController ctrl, string body, string signature)
+    [Fact]
+    public async Task Webhook_ChargeCaptured_SetsNextChargeDateByInterval()
     {
-        var bytes = Encoding.UTF8.GetBytes(body);
+        using var db = CreateDbContext();
+        var occurred = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc);
+        await db.Products.AddAsync(MakePrimaryProduct());
+        var sub = new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr_charge", Status = SubscriptionStatus.Active
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        var payload = new
+        {
+            agreementId = "agr_charge",
+            eventId = "evt-charge",
+            eventType = "recurring.charge-captured.v1",
+            occurred
+        };
+        var body = JsonSerializer.Serialize(payload);
+
+        var ctrl = CreateController(db, settings: new AppSettings { Id = 1, VippsSubscriptionWebhookSecret = "secret" });
+        SetupValidWebhookRequest(ctrl, body);
+        await ctrl.Webhook();
+
+        var updated = await db.Subscriptions.FirstAsync();
+        Assert.Equal(occurred.AddMonths(1), updated.NextChargeDate);
+    }
+
+    private static void SetupValidWebhookRequest(SubscriptionsController ctrl, string body) =>
+        SetupWebhookRequest(ctrl, body, valid: true);
+
+    private static void SetupInvalidWebhookRequest(SubscriptionsController ctrl, string body) =>
+        SetupWebhookRequest(ctrl, body, valid: false);
+
+    private static void SetupWebhookRequest(SubscriptionsController ctrl, string body, bool valid)
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(body);
         ctrl.ControllerContext.HttpContext.Request.Body = new MemoryStream(bytes);
         ctrl.ControllerContext.HttpContext.Request.ContentLength = bytes.Length;
-        ctrl.ControllerContext.HttpContext.Request.Headers["X-Vipps-Signature"] = signature;
+        if (valid)
+            ctrl.ControllerContext.HttpContext.Request.Headers["X-Test-Valid"] = "1";
+    }
+
+    private static Product MakePrimaryProduct(int id = 1) => new()
+    {
+        Id = id, Name = "Garge Basic", PriceInOre = 29900,
+        Interval = BillingInterval.Monthly, Type = ProductType.Primary, IsActive = true
+    };
+
+    private static Product MakeAddOnProduct(int id = 2) => new()
+    {
+        Id = id, Name = "Garge Extra Sensor", PriceInOre = 4900,
+        Interval = BillingInterval.Monthly, Type = ProductType.AddOn, IsActive = true
+    };
+
+    [Fact]
+    public async Task InitiatePrimary_NoExisting_Returns200WithConfirmationUrl()
+    {
+        using var db = CreateDbContext();
+        await db.Products.AddAsync(MakePrimaryProduct());
+        await db.SaveChangesAsync();
+
+        var vipps = MockVipps();
+        vipps.Setup(v => v.CreateAgreementAsync(It.IsAny<Product>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
+            .ReturnsAsync(new VippsCreateAgreementResponse
+            {
+                AgreementId = "agr_new",
+                VippsConfirmationUrl = "https://vipps.no/confirm/agr_new"
+            });
+
+        var ctrl = CreateController(db, vipps: vipps);
+
+        var result = await ctrl.InitiateSubscription(
+            new InitiateSubscriptionDto { ProductId = 1, PhoneNumber = "47912345678".Substring(0, 10), ConsentToWaiveWithdrawal = true });
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var dto = Assert.IsType<InitiateSubscriptionResponseDto>(ok.Value);
+        Assert.Equal("agr_new", dto.VippsAgreementId);
+        Assert.Equal("https://vipps.no/confirm/agr_new", dto.VippsConfirmationUrl);
+    }
+
+    [Fact]
+    public async Task InitiatePrimary_WithoutConsent_Returns400()
+    {
+        using var db = CreateDbContext();
+        await db.Products.AddAsync(MakePrimaryProduct());
+        await db.SaveChangesAsync();
+
+        var ctrl = CreateController(db);
+
+        var result = await ctrl.InitiateSubscription(
+            new InitiateSubscriptionDto { ProductId = 1, PhoneNumber = "4791234567", ConsentToWaiveWithdrawal = false });
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task InitiatePrimary_ExistingActivePrimary_Returns409()
+    {
+        using var db = CreateDbContext();
+        await db.Products.AddAsync(MakePrimaryProduct());
+        await db.Subscriptions.AddAsync(new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "existing", Status = SubscriptionStatus.Active
+        });
+        await db.SaveChangesAsync();
+
+        var ctrl = CreateController(db);
+        var result = await ctrl.InitiateSubscription(
+            new InitiateSubscriptionDto { ProductId = 1, PhoneNumber = "4791234567", ConsentToWaiveWithdrawal = true });
+
+        Assert.IsType<ConflictObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task InitiateAddOn_WithActivePrimary_Returns200()
+    {
+        using var db = CreateDbContext();
+        await db.Products.AddRangeAsync(MakePrimaryProduct(), MakeAddOnProduct());
+        await db.Subscriptions.AddAsync(new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "primary_agr", Status = SubscriptionStatus.Active
+        });
+        await db.SaveChangesAsync();
+
+        var vipps = MockVipps();
+        vipps.Setup(v => v.CreateAgreementAsync(It.IsAny<Product>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
+            .ReturnsAsync(new VippsCreateAgreementResponse { AgreementId = "addon_agr", VippsConfirmationUrl = "https://vipps.no/confirm/addon" });
+
+        var ctrl = CreateController(db, vipps: vipps);
+
+        var result = await ctrl.InitiateSubscription(
+            new InitiateSubscriptionDto { ProductId = 2, PhoneNumber = "4791234567", ConsentToWaiveWithdrawal = true });
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(2, await db.Subscriptions.CountAsync(s => s.UserId == "user-1"));
+    }
+
+    [Fact]
+    public async Task InitiateAddOn_WithoutPrimary_Returns400()
+    {
+        using var db = CreateDbContext();
+        await db.Products.AddAsync(MakeAddOnProduct());
+        await db.SaveChangesAsync();
+
+        var ctrl = CreateController(db);
+        var result = await ctrl.InitiateSubscription(
+            new InitiateSubscriptionDto { ProductId = 2, PhoneNumber = "4791234567", ConsentToWaiveWithdrawal = true });
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task CancelById_OwnActiveSubscription_Returns200()
+    {
+        using var db = CreateDbContext();
+        var sub = new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr_cancel", Status = SubscriptionStatus.Active
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        var vipps = MockVipps();
+        vipps.Setup(v => v.CancelAgreementAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
+
+        var ctrl = CreateController(db, vipps: vipps);
+
+        var result = await ctrl.CancelSubscription(sub.Id);
+
+        Assert.IsType<OkResult>(result);
+        var updated = await db.Subscriptions.FirstAsync();
+        Assert.Equal(SubscriptionStatus.Stopped, updated.Status);
+    }
+
+    [Fact]
+    public async Task CancelById_OtherUsersSubscription_Returns404()
+    {
+        using var db = CreateDbContext();
+        var sub = new Subscription
+        {
+            UserId = "other-user", ProductId = 1,
+            VippsAgreementId = "agr_other", Status = SubscriptionStatus.Active
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        var ctrl = CreateController(db, userId: "user-1");
+        var result = await ctrl.CancelSubscription(sub.Id);
+
+        Assert.IsType<NotFoundObjectResult>(result);
     }
 }

--- a/garge-api.Tests/SubscriptionsControllerTests.cs
+++ b/garge-api.Tests/SubscriptionsControllerTests.cs
@@ -1,0 +1,142 @@
+using garge_api.Controllers;
+using garge_api.Dtos.Subscription;
+using Microsoft.AspNetCore.Http;
+using garge_api.Models;
+using garge_api.Models.Admin;
+using garge_api.Models.Subscription;
+using garge_api.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace garge_api.Tests;
+
+public class SubscriptionsControllerTests : ControllerTestBase
+{
+    private static Mock<IVippsService> MockVipps()
+    {
+        var mock = new Mock<IVippsService>();
+        mock.Setup(v => v.VerifyWebhookSignature(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Returns((string body, string sig, string secret) =>
+            {
+                if (string.IsNullOrEmpty(secret) || !sig.StartsWith("sha256=")) return false;
+                var computed = "sha256=" + Convert.ToHexString(
+                    HMACSHA256.HashData(Encoding.UTF8.GetBytes(secret), Encoding.UTF8.GetBytes(body))
+                ).ToLowerInvariant();
+                return CryptographicOperations.FixedTimeEquals(
+                    Encoding.ASCII.GetBytes(computed),
+                    Encoding.ASCII.GetBytes(sig.ToLowerInvariant()));
+            });
+        return mock;
+    }
+
+    private SubscriptionsController CreateController(ApplicationDbContext db, string userId = "user-1")
+    {
+        var ctrl = new SubscriptionsController(
+            db, MockVipps().Object, MockMapper.Object,
+            NullLogger<SubscriptionsController>.Instance);
+        ctrl.ControllerContext = MakeControllerContext(userId);
+        return ctrl;
+    }
+
+    [Theory]
+    [InlineData("recurring.agreement-activated.v1", SubscriptionStatus.Active)]
+    [InlineData("recurring.agreement-stopped.v1",   SubscriptionStatus.Stopped)]
+    [InlineData("recurring.agreement-expired.v1",   SubscriptionStatus.Expired)]
+    [InlineData("recurring.agreement-rejected.v1",  SubscriptionStatus.Stopped)]
+    [InlineData("unknown.event.v1",                 SubscriptionStatus.Pending)]
+    public async Task Webhook_KnownEventTypes_UpdatesStatusCorrectly(
+        string eventType, SubscriptionStatus expected)
+    {
+        using var db = CreateDbContext();
+        await db.AppSettings.AddAsync(new AppSettings { Id = 1, VippsSubscriptionWebhookSecret = "secret" });
+        var sub = new Subscription
+        {
+            UserId = "user-1",
+            ProductId = 1,
+            VippsAgreementId = "agr_test",
+            Status = SubscriptionStatus.Pending
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        var payload = new VippsAgreementWebhookDto
+        {
+            AgreementId = "agr_test",
+            EventType = eventType,
+            Occurred = DateTime.UtcNow
+        };
+        var body = JsonSerializer.Serialize(payload);
+        var sig = "sha256=" + Convert.ToHexString(
+            HMACSHA256.HashData(Encoding.UTF8.GetBytes("secret"), Encoding.UTF8.GetBytes(body))
+        ).ToLowerInvariant();
+
+        var ctrl = CreateController(db);
+        SetupWebhookRequest(ctrl, body, sig);
+
+        var result = await ctrl.Webhook();
+
+        Assert.IsType<OkResult>(result);
+        var updated = await db.Subscriptions.FirstAsync();
+        Assert.Equal(expected, updated.Status);
+    }
+
+    [Fact]
+    public async Task Webhook_InvalidHmac_Returns401()
+    {
+        using var db = CreateDbContext();
+        await db.AppSettings.AddAsync(new AppSettings { Id = 1, VippsSubscriptionWebhookSecret = "correct" });
+        await db.SaveChangesAsync();
+
+        var body = """{"agreementId":"agr_test","eventType":"recurring.agreement-activated.v1"}""";
+        var ctrl = CreateController(db);
+        SetupWebhookRequest(ctrl, body, "sha256=badhash");
+
+        var result = await ctrl.Webhook();
+
+        Assert.IsType<UnauthorizedResult>(result);
+    }
+
+    [Fact]
+    public async Task Webhook_ActivatedEvent_SetsStartDate()
+    {
+        using var db = CreateDbContext();
+        var occurred = new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc);
+        await db.AppSettings.AddAsync(new AppSettings { Id = 1, VippsSubscriptionWebhookSecret = "secret" });
+        var sub = new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr_start",
+            Status = SubscriptionStatus.Pending
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        var payload = new { agreementId = "agr_start", eventType = "recurring.agreement-activated.v1", occurred };
+        var body = JsonSerializer.Serialize(payload);
+        var sig = "sha256=" + Convert.ToHexString(
+            HMACSHA256.HashData(Encoding.UTF8.GetBytes("secret"), Encoding.UTF8.GetBytes(body))
+        ).ToLowerInvariant();
+
+        var ctrl = CreateController(db);
+        SetupWebhookRequest(ctrl, body, sig);
+        await ctrl.Webhook();
+
+        var updated = await db.Subscriptions.FirstAsync();
+        Assert.Equal(occurred, updated.StartDate);
+    }
+
+    private static void SetupWebhookRequest(SubscriptionsController ctrl, string body, string signature)
+    {
+        var bytes = Encoding.UTF8.GetBytes(body);
+        ctrl.ControllerContext.HttpContext.Request.Body = new MemoryStream(bytes);
+        ctrl.ControllerContext.HttpContext.Request.ContentLength = bytes.Length;
+        ctrl.ControllerContext.HttpContext.Request.Headers["X-Vipps-Signature"] = signature;
+    }
+}

--- a/garge-api.Tests/VippsServiceTests.cs
+++ b/garge-api.Tests/VippsServiceTests.cs
@@ -1,5 +1,6 @@
 using garge_api.Services;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -28,7 +29,8 @@ public class VippsServiceTests
         });
         var http = new HttpClient();
         var cache = new MemoryCache(new MemoryCacheOptions());
-        return new VippsService(http, opts, appOpts, cache, NullLogger<VippsService>.Instance);
+        var scopeFactory = new Mock<IServiceScopeFactory>().Object;
+        return new VippsService(http, opts, appOpts, cache, NullLogger<VippsService>.Instance, scopeFactory);
     }
 
     private static string BuildSignature(string body, string secret)

--- a/garge-api.Tests/VippsServiceTests.cs
+++ b/garge-api.Tests/VippsServiceTests.cs
@@ -1,4 +1,5 @@
 using garge_api.Services;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -12,7 +13,7 @@ namespace garge_api.Tests;
 
 public class VippsServiceTests
 {
-    private static VippsService CreateService(string webhookSecret = "test-secret")
+    private static VippsService CreateService()
     {
         var opts = Options.Create(new VippsOptions
         {
@@ -33,63 +34,119 @@ public class VippsServiceTests
         return new VippsService(http, opts, appOpts, cache, NullLogger<VippsService>.Instance, scopeFactory);
     }
 
-    private static string BuildSignature(string body, string secret)
+    private static HttpRequest BuildRequest(string body, string secret, DateTimeOffset? when = null,
+        string method = "POST", string path = "/api/shop/webhook", string host = "garge-api.prod.tumogroup.com",
+        string? overrideAuth = null, string? overrideContentHash = null, string? overrideDate = null)
     {
-        var key = Encoding.UTF8.GetBytes(secret);
-        var computed = HMACSHA256.HashData(key, Encoding.UTF8.GetBytes(body));
-        return "sha256=" + Convert.ToHexString(computed).ToLowerInvariant();
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Method = method;
+        ctx.Request.Path = path;
+        ctx.Request.Host = new HostString(host);
+        ctx.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(body));
+        ctx.Request.ContentLength = Encoding.UTF8.GetByteCount(body);
+
+        var date = overrideDate ?? (when ?? DateTimeOffset.UtcNow).ToString("R");
+        var contentHash = overrideContentHash ?? Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(body)));
+        ctx.Request.Headers["x-ms-date"] = date;
+        ctx.Request.Headers["x-ms-content-sha256"] = contentHash;
+        ctx.Request.Headers["Host"] = host;
+
+        if (overrideAuth != null)
+        {
+            ctx.Request.Headers["Authorization"] = overrideAuth;
+        }
+        else
+        {
+            var canonical = $"{method}\n{path}\n{date};{host};{contentHash}";
+            using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+            var sig = Convert.ToBase64String(hmac.ComputeHash(Encoding.UTF8.GetBytes(canonical)));
+            ctx.Request.Headers["Authorization"] =
+                $"HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature={sig}";
+        }
+        return ctx.Request;
     }
 
     [Fact]
-    public void VerifyWebhookSignature_ValidHmac_ReturnsTrue()
-    {
-        var svc = CreateService("my-secret");
-        var body = """{"reference":"42","name":"AUTHORIZED"}""";
-        var sig = BuildSignature(body, "my-secret");
-
-        Assert.True(svc.VerifyWebhookSignature(body, sig, "my-secret"));
-    }
-
-    [Fact]
-    public void VerifyWebhookSignature_WrongSecret_ReturnsFalse()
+    public void Verify_ValidHmac_ReturnsValid()
     {
         var svc = CreateService();
         var body = """{"reference":"42","name":"AUTHORIZED"}""";
-        var sig = BuildSignature(body, "correct-secret");
+        var req = BuildRequest(body, "my-secret");
 
-        Assert.False(svc.VerifyWebhookSignature(body, sig, "wrong-secret"));
+        Assert.Equal(WebhookVerifyResult.Valid, svc.VerifyWebhookSignature(req, body, "my-secret"));
     }
 
     [Fact]
-    public void VerifyWebhookSignature_TamperedBody_ReturnsFalse()
+    public void Verify_WrongSecret_ReturnsBadSignature()
+    {
+        var svc = CreateService();
+        var body = """{"reference":"42","name":"AUTHORIZED"}""";
+        var req = BuildRequest(body, "correct-secret");
+
+        Assert.Equal(WebhookVerifyResult.BadSignature, svc.VerifyWebhookSignature(req, body, "wrong-secret"));
+    }
+
+    [Fact]
+    public void Verify_TamperedBody_ReturnsBadContentHash()
     {
         var svc = CreateService();
         var original = """{"reference":"42","name":"AUTHORIZED"}""";
         var tampered = """{"reference":"99","name":"AUTHORIZED"}""";
-        var sig = BuildSignature(original, "my-secret");
+        var req = BuildRequest(original, "secret");
 
-        Assert.False(svc.VerifyWebhookSignature(tampered, sig, "my-secret"));
+        Assert.Equal(WebhookVerifyResult.BadContentHash,
+            svc.VerifyWebhookSignature(req, tampered, "secret"));
     }
 
     [Fact]
-    public void VerifyWebhookSignature_MissingPrefix_ReturnsFalse()
+    public void Verify_MissingAuthHeader_ReturnsMissingHeader()
     {
         var svc = CreateService();
         var body = """{"reference":"42"}""";
-        var sig = Convert.ToHexString(HMACSHA256.HashData(
-            Encoding.UTF8.GetBytes("secret"),
-            Encoding.UTF8.GetBytes(body))).ToLowerInvariant(); // missing "sha256=" prefix
+        var req = BuildRequest(body, "secret", overrideAuth: "");
 
-        Assert.False(svc.VerifyWebhookSignature(body, sig, "secret"));
+        Assert.Equal(WebhookVerifyResult.MissingHeader, svc.VerifyWebhookSignature(req, body, "secret"));
     }
 
     [Fact]
-    public void VerifyWebhookSignature_EmptySecret_ReturnsFalse()
+    public void Verify_EmptySecret_ReturnsMissingSecret()
     {
         var svc = CreateService();
         var body = """{"reference":"42"}""";
-        var sig = BuildSignature(body, "real-secret");
+        var req = BuildRequest(body, "real");
 
-        Assert.False(svc.VerifyWebhookSignature(body, sig, string.Empty));
+        Assert.Equal(WebhookVerifyResult.MissingSecret, svc.VerifyWebhookSignature(req, body, string.Empty));
+    }
+
+    [Fact]
+    public void Verify_StaleDate_ReturnsStale()
+    {
+        var svc = CreateService();
+        var body = """{"reference":"42"}""";
+        var req = BuildRequest(body, "secret", when: DateTimeOffset.UtcNow.AddMinutes(-30));
+
+        Assert.Equal(WebhookVerifyResult.Stale, svc.VerifyWebhookSignature(req, body, "secret"));
+    }
+
+    [Fact]
+    public void Verify_BadDate_ReturnsBadDate()
+    {
+        var svc = CreateService();
+        var body = """{"reference":"42"}""";
+        var req = BuildRequest(body, "secret", overrideDate: "not-a-date");
+
+        Assert.Equal(WebhookVerifyResult.BadDate, svc.VerifyWebhookSignature(req, body, "secret"));
+    }
+
+    [Fact]
+    public void Verify_TamperedContentHashHeader_ReturnsBadContentHash()
+    {
+        var svc = CreateService();
+        var body = """{"reference":"42"}""";
+        var bogus = Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes("other")));
+        var req = BuildRequest(body, "secret", overrideContentHash: bogus);
+
+        Assert.Equal(WebhookVerifyResult.BadContentHash,
+            svc.VerifyWebhookSignature(req, body, "secret"));
     }
 }

--- a/garge-api.Tests/VippsServiceTests.cs
+++ b/garge-api.Tests/VippsServiceTests.cs
@@ -1,0 +1,93 @@
+using garge_api.Services;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using System.Security.Cryptography;
+using System.Text;
+using Xunit;
+
+namespace garge_api.Tests;
+
+public class VippsServiceTests
+{
+    private static VippsService CreateService(string webhookSecret = "test-secret")
+    {
+        var opts = Options.Create(new VippsOptions
+        {
+            ClientId = "id",
+            ClientSecret = "secret",
+            MerchantSerialNumber = "msn",
+            SubscriptionKey = "key",
+            BaseUrl = "https://apitest.vipps.no"
+        });
+        var appOpts = Options.Create(new AppOptions
+        {
+            FrontendBaseUrl = "https://www.garge.no",
+            ApiBaseUrl = "https://garge-api.prod.tumogroup.com"
+        });
+        var http = new HttpClient();
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        return new VippsService(http, opts, appOpts, cache, NullLogger<VippsService>.Instance);
+    }
+
+    private static string BuildSignature(string body, string secret)
+    {
+        var key = Encoding.UTF8.GetBytes(secret);
+        var computed = HMACSHA256.HashData(key, Encoding.UTF8.GetBytes(body));
+        return "sha256=" + Convert.ToHexString(computed).ToLowerInvariant();
+    }
+
+    [Fact]
+    public void VerifyWebhookSignature_ValidHmac_ReturnsTrue()
+    {
+        var svc = CreateService("my-secret");
+        var body = """{"reference":"42","name":"AUTHORIZED"}""";
+        var sig = BuildSignature(body, "my-secret");
+
+        Assert.True(svc.VerifyWebhookSignature(body, sig, "my-secret"));
+    }
+
+    [Fact]
+    public void VerifyWebhookSignature_WrongSecret_ReturnsFalse()
+    {
+        var svc = CreateService();
+        var body = """{"reference":"42","name":"AUTHORIZED"}""";
+        var sig = BuildSignature(body, "correct-secret");
+
+        Assert.False(svc.VerifyWebhookSignature(body, sig, "wrong-secret"));
+    }
+
+    [Fact]
+    public void VerifyWebhookSignature_TamperedBody_ReturnsFalse()
+    {
+        var svc = CreateService();
+        var original = """{"reference":"42","name":"AUTHORIZED"}""";
+        var tampered = """{"reference":"99","name":"AUTHORIZED"}""";
+        var sig = BuildSignature(original, "my-secret");
+
+        Assert.False(svc.VerifyWebhookSignature(tampered, sig, "my-secret"));
+    }
+
+    [Fact]
+    public void VerifyWebhookSignature_MissingPrefix_ReturnsFalse()
+    {
+        var svc = CreateService();
+        var body = """{"reference":"42"}""";
+        var sig = Convert.ToHexString(HMACSHA256.HashData(
+            Encoding.UTF8.GetBytes("secret"),
+            Encoding.UTF8.GetBytes(body))).ToLowerInvariant(); // missing "sha256=" prefix
+
+        Assert.False(svc.VerifyWebhookSignature(body, sig, "secret"));
+    }
+
+    [Fact]
+    public void VerifyWebhookSignature_EmptySecret_ReturnsFalse()
+    {
+        var svc = CreateService();
+        var body = """{"reference":"42"}""";
+        var sig = BuildSignature(body, "real-secret");
+
+        Assert.False(svc.VerifyWebhookSignature(body, sig, string.Empty));
+    }
+}

--- a/garge-api.Tests/WebhookSecretProtectorTests.cs
+++ b/garge-api.Tests/WebhookSecretProtectorTests.cs
@@ -1,0 +1,52 @@
+using garge_api.Services;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace garge_api.Tests;
+
+public class WebhookSecretProtectorTests
+{
+    private static IWebhookSecretProtector CreateProtector()
+    {
+        var services = new ServiceCollection();
+        services.AddDataProtection();
+        var provider = services.BuildServiceProvider().GetRequiredService<IDataProtectionProvider>();
+        return new WebhookSecretProtector(provider);
+    }
+
+    [Fact]
+    public void RoundTrip_RestoresOriginalSecret()
+    {
+        var p = CreateProtector();
+        var secret = "vipps-webhook-secret-abc-123";
+        var protectedSecret = p.Protect(secret);
+
+        Assert.NotEqual(secret, protectedSecret);
+        Assert.StartsWith("enc:v1:", protectedSecret);
+        Assert.Equal(secret, p.Unprotect(protectedSecret));
+    }
+
+    [Fact]
+    public void Unprotect_PlaintextLegacyValue_ReturnsAsIs()
+    {
+        var p = CreateProtector();
+        var legacy = "old-plaintext-secret";
+
+        Assert.Equal(legacy, p.Unprotect(legacy));
+    }
+
+    [Fact]
+    public void Protect_EmptyString_ReturnsEmpty()
+    {
+        var p = CreateProtector();
+        Assert.Equal(string.Empty, p.Protect(string.Empty));
+    }
+
+    [Fact]
+    public void Unprotect_EmptyString_ReturnsEmpty()
+    {
+        var p = CreateProtector();
+        Assert.Equal(string.Empty, p.Unprotect(string.Empty));
+    }
+}

--- a/garge-api.Tests/garge-api.Tests.csproj
+++ b/garge-api.Tests/garge-api.Tests.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/garge-api.csproj
+++ b/garge-api.csproj
@@ -10,6 +10,8 @@
     <UserSecretsId>a0e33732-a687-460d-ae97-563565a27798</UserSecretsId>
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	<NoWarn>$(NoWarn);1591</NoWarn>
+    <Product>garge</Product>
+    <Version>1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -31,6 +33,7 @@
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+    <PackageReference Include="PuppeteerSharp" Version="24.40.0" />
     <PackageReference Include="SendGrid" Version="9.29.3" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />

--- a/garge-api.csproj
+++ b/garge-api.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
     <PackageReference Include="brevo_csharp" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />


### PR DESCRIPTION
## Summary

- Subscription plans (Vipps Recurring v3): create agreements, webhook status updates, cancel
- Sensor shop (Vipps ePayment): checkout, stock control, VAT snapshots, PDF invoice generation
- `ActiveSubscription` auth policy gates all feature endpoints (bypass for operator roles)
- Webhook auto-registration on startup via `VippsWebhookRegistrationService`
- `SettingsController` for public app settings (VAT flag, company info)
- Fix: `phoneNumber` now sent as `customer.phoneNumber` in ePayment request body
- Fix: empty `AddAppSettings` migration guarded in `AddSubscriptionConsent`
- 59 passing tests

## Test plan

- [ ] `dotnet test` passes (59 tests)
- [ ] `dotnet ef database update` runs cleanly on fresh DB
- [ ] `GET /api/products` unauthenticated → 200
- [ ] `GET /api/sensors` without subscription → 403
- [ ] Mock webhook `POST /api/subscriptions/webhook` with valid HMAC → status updated
- [ ] Mock webhook `POST /api/shop/webhook` with AUTHORIZED event → order Reserved
- [ ] Fill Vipps credentials and test end-to-end in test environment