### PR TITLE
fix: Vipps shipping-address, subscription URL length, invoice PDF rendering

### DIFF
--- a/Controllers/ShopController.cs
+++ b/Controllers/ShopController.cs
@@ -453,26 +453,12 @@ namespace garge_api.Controllers
             try
             {
                 var payment = await _vipps.GetPaymentAsync(order.VippsOrderId);
-                if (string.IsNullOrEmpty(payment.ProfileSub)) return;
+                if (string.IsNullOrEmpty(payment?.ProfileSub)) return;
 
                 var info = await _vipps.GetUserInfoAsync(payment.ProfileSub);
-                if (info?.Address == null) return;
-
-                var formatted = !string.IsNullOrEmpty(info.Address.Formatted)
-                    ? info.Address.Formatted
-                    : string.Join(", ", new[]
-                    {
-                        info.Address.StreetAddress,
-                        info.Address.PostalCode,
-                        info.Address.Region,
-                        info.Address.Country
-                    }.Where(s => !string.IsNullOrEmpty(s)));
-
+                var formatted = VippsAddressFormatter.Format(info?.Address);
                 if (!string.IsNullOrEmpty(formatted))
-                {
-                    if (formatted.Length > 500) formatted = formatted[..500];
                     order.ShippingAddress = formatted;
-                }
             }
             catch (Exception ex)
             {

--- a/Controllers/ShopController.cs
+++ b/Controllers/ShopController.cs
@@ -388,6 +388,7 @@ namespace garge_api.Controllers
             {
                 case "AUTHORIZED":
                     order.Status = OrderStatus.Reserved;
+                    await TryPopulateShippingFromVippsAsync(order);
                     break;
                 case "CAPTURED":
                     order.Status = OrderStatus.Paid;
@@ -444,6 +445,39 @@ namespace garge_api.Controllers
         {
             try { await _push.SendAsync(userId, title, body); }
             catch (Exception ex) { _logger.LogWarning(ex, "Push send failed for user {UserId}", userId); }
+        }
+
+        private async Task TryPopulateShippingFromVippsAsync(Order order)
+        {
+            if (string.IsNullOrEmpty(order.VippsOrderId)) return;
+            try
+            {
+                var payment = await _vipps.GetPaymentAsync(order.VippsOrderId);
+                if (string.IsNullOrEmpty(payment.ProfileSub)) return;
+
+                var info = await _vipps.GetUserInfoAsync(payment.ProfileSub);
+                if (info?.Address == null) return;
+
+                var formatted = !string.IsNullOrEmpty(info.Address.Formatted)
+                    ? info.Address.Formatted
+                    : string.Join(", ", new[]
+                    {
+                        info.Address.StreetAddress,
+                        info.Address.PostalCode,
+                        info.Address.Region,
+                        info.Address.Country
+                    }.Where(s => !string.IsNullOrEmpty(s)));
+
+                if (!string.IsNullOrEmpty(formatted))
+                {
+                    if (formatted.Length > 500) formatted = formatted[..500];
+                    order.ShippingAddress = formatted;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to fetch Vipps user info for order {OrderId}", order.Id);
+            }
         }
 
         private async Task RestoreStockAsync(Order order)

--- a/Controllers/ShopController.cs
+++ b/Controllers/ShopController.cs
@@ -21,6 +21,7 @@ namespace garge_api.Controllers
         private readonly ApplicationDbContext _context;
         private readonly IVippsService _vipps;
         private readonly IInvoiceService _invoice;
+        private readonly IOrderEmailService _orderEmail;
         private readonly IAppSettingsCache _settingsCache;
         private readonly IWebhookSecretProtector _protector;
         private readonly IWebPushService _push;
@@ -33,6 +34,7 @@ namespace garge_api.Controllers
             ApplicationDbContext context,
             IVippsService vipps,
             IInvoiceService invoice,
+            IOrderEmailService orderEmail,
             IAppSettingsCache settingsCache,
             IWebhookSecretProtector protector,
             IWebPushService push,
@@ -44,6 +46,7 @@ namespace garge_api.Controllers
             _context = context;
             _vipps = vipps;
             _invoice = invoice;
+            _orderEmail = orderEmail;
             _settingsCache = settingsCache;
             _protector = protector;
             _push = push;
@@ -433,6 +436,9 @@ namespace garge_api.Controllers
             }
             else if (prevStatus != OrderStatus.Reserved && order.Status == OrderStatus.Reserved)
             {
+                try { await _orderEmail.SendOrderReservedAsync(order.Id); }
+                catch (Exception ex) { _logger.LogError(ex, "Reserved email failed for order {OrderId}", order.Id); }
+
                 _ = SafePushAsync(order.UserId, "Order reserved",
                     $"Order #{order.Id} is reserved. We'll capture payment when it ships.");
             }

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,23 @@ FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 WORKDIR /app
 EXPOSE 7297
 
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        chromium \
+        fonts-liberation \
+        fonts-noto-color-emoji \
+        libnss3 \
+        libatk-bridge2.0-0 \
+        libgtk-3-0 \
+        libxss1 \
+        libgbm1 \
+        libasound2 \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+ENV PUPPETEER_SKIP_DOWNLOAD=true
+
 # This stage is used to build the service project
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release

--- a/Dtos/Shop/ShopDtos.cs
+++ b/Dtos/Shop/ShopDtos.cs
@@ -67,9 +67,8 @@ namespace garge_api.Dtos.Shop
         [RegularExpression(@"^(?:47)?\d{8}$", ErrorMessage = "Phone number must be 8 Norwegian digits, optionally prefixed with 47.")]
         public required string PhoneNumber { get; set; }
 
-        [Required]
         [MaxLength(500)]
-        public required string ShippingAddress { get; set; }
+        public string? ShippingAddress { get; set; }
     }
 
     public class OrderItemResponseDto

--- a/Helpers/MoneyFormat.cs
+++ b/Helpers/MoneyFormat.cs
@@ -1,0 +1,10 @@
+using System.Globalization;
+
+namespace garge_api.Helpers
+{
+    public static class MoneyFormat
+    {
+        public static string Nok(int ore) =>
+            (ore / 100.0).ToString("N2", CultureInfo.InvariantCulture);
+    }
+}

--- a/Migrations/20260507154303_IncreaseVippsConfirmationUrlLength.Designer.cs
+++ b/Migrations/20260507154303_IncreaseVippsConfirmationUrlLength.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260507154303_IncreaseVippsConfirmationUrlLength")]
+    partial class IncreaseVippsConfirmationUrlLength
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260507154303_IncreaseVippsConfirmationUrlLength.cs
+++ b/Migrations/20260507154303_IncreaseVippsConfirmationUrlLength.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class IncreaseVippsConfirmationUrlLength : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "VippsConfirmationUrl",
+                table: "Subscriptions",
+                type: "character varying(2000)",
+                maxLength: 2000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "VippsConfirmationUrl",
+                table: "Subscriptions",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(2000)",
+                oldMaxLength: 2000,
+                oldNullable: true);
+        }
+    }
+}

--- a/Models/Subscription/Subscription.cs
+++ b/Models/Subscription/Subscription.cs
@@ -33,7 +33,7 @@ namespace garge_api.Models.Subscription
         [MaxLength(200)]
         public required string VippsAgreementId { get; set; }
 
-        [MaxLength(500)]
+        [MaxLength(2000)]
         public string? VippsConfirmationUrl { get; set; }
 
         [Required]

--- a/Program.cs
+++ b/Program.cs
@@ -140,6 +140,7 @@ namespace garge_api
             builder.Services.AddSingleton<IWebhookSecretProtector, WebhookSecretProtector>();
             builder.Services.AddSingleton<IAppSettingsCache, AppSettingsCache>();
             builder.Services.AddScoped<IInvoiceService, InvoiceService>();
+            builder.Services.AddScoped<IOrderEmailService, OrderEmailService>();
             builder.Services.AddHttpClient<IVippsService, VippsService>();
             builder.Services.AddHostedService<VippsWebhookRegistrationService>();
             builder.Services.AddHostedService<ProcessedWebhookEventCleanupService>();

--- a/Services/EmailService.cs
+++ b/Services/EmailService.cs
@@ -15,7 +15,9 @@ public class EmailService : IEmailService
         _logger = logger;
     }
 
-    public async System.Threading.Tasks.Task SendEmailAsync(string email, string subject, string message)
+    public async System.Threading.Tasks.Task SendEmailAsync(
+        string email, string subject, string message,
+        IReadOnlyList<EmailAttachment>? attachments = null)
     {
         if (string.IsNullOrWhiteSpace(email))
         {
@@ -41,6 +43,13 @@ public class EmailService : IEmailService
                 new SendSmtpEmailTo(email)
             }
         };
+
+        if (attachments != null && attachments.Count > 0)
+        {
+            sendSmtpEmail.Attachment = attachments
+                .Select(a => new SendSmtpEmailAttachment(content: a.Content, name: a.FileName))
+                .ToList();
+        }
 
         try
         {

--- a/Services/IEmailService.cs
+++ b/Services/IEmailService.cs
@@ -1,7 +1,14 @@
 using garge_api.Dtos.Admin;
 
+public sealed class EmailAttachment
+{
+    public required string FileName { get; set; }
+    public required byte[] Content { get; set; }
+    public string ContentType { get; set; } = "application/octet-stream";
+}
+
 public interface IEmailService
 {
-    Task SendEmailAsync(string email, string subject, string message);
+    Task SendEmailAsync(string email, string subject, string message, IReadOnlyList<EmailAttachment>? attachments = null);
     Task<EmailStatsDto> GetEmailStatsAsync(int days = 30);
 }

--- a/Services/IOrderEmailService.cs
+++ b/Services/IOrderEmailService.cs
@@ -1,0 +1,7 @@
+namespace garge_api.Services
+{
+    public interface IOrderEmailService
+    {
+        Task SendOrderReservedAsync(int orderId);
+    }
+}

--- a/Services/IVippsService.cs
+++ b/Services/IVippsService.cs
@@ -39,6 +39,24 @@ namespace garge_api.Services
     {
         public string Reference { get; set; } = string.Empty;
         public string State { get; set; } = string.Empty;
+        public string? ProfileSub { get; set; }
+    }
+
+    public class VippsUserInfo
+    {
+        public string? Name { get; set; }
+        public string? Email { get; set; }
+        public string? PhoneNumber { get; set; }
+        public VippsAddress? Address { get; set; }
+    }
+
+    public class VippsAddress
+    {
+        public string? StreetAddress { get; set; }
+        public string? PostalCode { get; set; }
+        public string? Region { get; set; }
+        public string? Country { get; set; }
+        public string? Formatted { get; set; }
     }
 
     public class VippsOrderLine
@@ -66,6 +84,7 @@ namespace garge_api.Services
             Order order, List<VippsOrderLine> receiptLines, string redirectUrl,
             string phoneNumber, string idempotencyKey);
         Task<VippsPaymentResponse> GetPaymentAsync(string reference);
+        Task<VippsUserInfo?> GetUserInfoAsync(string sub);
         Task CapturePaymentAsync(string reference, int amountInOre, string idempotencyKey);
         Task CancelPaymentAsync(string reference, string idempotencyKey);
 

--- a/Services/InvoiceService.cs
+++ b/Services/InvoiceService.cs
@@ -68,12 +68,17 @@ namespace garge_api.Services
 
         private static async Task<byte[]> RenderPdfAsync(string html)
         {
-            var browserFetcher = new BrowserFetcher();
-            await browserFetcher.DownloadAsync();
+            var execPath = Environment.GetEnvironmentVariable("PUPPETEER_EXECUTABLE_PATH");
+            if (string.IsNullOrEmpty(execPath))
+            {
+                var browserFetcher = new BrowserFetcher();
+                await browserFetcher.DownloadAsync();
+            }
 
             await using var browser = await Puppeteer.LaunchAsync(new LaunchOptions
             {
                 Headless = true,
+                ExecutablePath = execPath,
                 Args = ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage"]
             });
             await using var page = await browser.NewPageAsync();

--- a/Services/InvoiceService.cs
+++ b/Services/InvoiceService.cs
@@ -1,10 +1,10 @@
+using garge_api.Helpers;
 using garge_api.Models;
 using garge_api.Models.Admin;
 using garge_api.Models.Shop;
 using Microsoft.EntityFrameworkCore;
 using PuppeteerSharp;
 using PuppeteerSharp.Media;
-using System.Globalization;
 using System.Text;
 using System.Web;
 
@@ -106,7 +106,7 @@ namespace garge_api.Services
 
         private static string BuildInvoiceHtml(Order order, AppSettings s, int invoiceId, DateTime issuedAt)
         {
-            static string Nok(int ore) => (ore / 100.0).ToString("N2", CultureInfo.InvariantCulture);
+            static string Nok(int ore) => MoneyFormat.Nok(ore);
             static string H(string? v) => HttpUtility.HtmlEncode(v ?? string.Empty);
 
             var orgLine = s.VatEnabled ? $"{s.CompanyOrgNumber} MVA" : s.CompanyOrgNumber;

--- a/Services/InvoiceService.cs
+++ b/Services/InvoiceService.cs
@@ -52,10 +52,19 @@ namespace garge_api.Services
             {
                 var buyerEmail = order.User?.Email;
                 if (!string.IsNullOrEmpty(buyerEmail))
+                {
+                    var attachment = new EmailAttachment
+                    {
+                        FileName = $"invoice-{invoice.Id:D4}.pdf",
+                        Content = invoice.PdfData,
+                        ContentType = "application/pdf"
+                    };
                     await _emailService.SendEmailAsync(
                         buyerEmail,
                         $"Invoice #{invoice.Id:D4} — {settings.CompanyName}",
-                        html);
+                        html,
+                        [attachment]);
+                }
             }
             catch (Exception ex)
             {

--- a/Services/OrderEmailService.cs
+++ b/Services/OrderEmailService.cs
@@ -1,8 +1,8 @@
+using garge_api.Helpers;
 using garge_api.Models;
 using garge_api.Models.Admin;
 using garge_api.Models.Shop;
 using Microsoft.EntityFrameworkCore;
-using System.Globalization;
 using System.Text;
 using System.Web;
 
@@ -59,7 +59,7 @@ namespace garge_api.Services
 
         private static string BuildHtml(Order order, AppSettings s)
         {
-            static string Nok(int ore) => (ore / 100.0).ToString("N2", CultureInfo.InvariantCulture);
+            static string Nok(int ore) => MoneyFormat.Nok(ore);
             static string H(string? v) => HttpUtility.HtmlEncode(v ?? string.Empty);
 
             var lines = new StringBuilder();

--- a/Services/OrderEmailService.cs
+++ b/Services/OrderEmailService.cs
@@ -1,0 +1,97 @@
+using garge_api.Models;
+using garge_api.Models.Admin;
+using garge_api.Models.Shop;
+using Microsoft.EntityFrameworkCore;
+using System.Globalization;
+using System.Text;
+using System.Web;
+
+namespace garge_api.Services
+{
+    public class OrderEmailService : IOrderEmailService
+    {
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly IEmailService _emailService;
+        private readonly ILogger<OrderEmailService> _logger;
+
+        public OrderEmailService(
+            IServiceScopeFactory scopeFactory,
+            IEmailService emailService,
+            ILogger<OrderEmailService> logger)
+        {
+            _scopeFactory = scopeFactory;
+            _emailService = emailService;
+            _logger = logger;
+        }
+
+        public async Task SendOrderReservedAsync(int orderId)
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+            var order = await db.Orders
+                .Include(o => o.User)
+                .Include(o => o.OrderItems).ThenInclude(i => i.ShopItem)
+                .FirstOrDefaultAsync(o => o.Id == orderId);
+
+            if (order?.User?.Email == null)
+            {
+                _logger.LogWarning("Order {OrderId} missing user/email — reserved email skipped", orderId);
+                return;
+            }
+
+            var settings = await db.AppSettings.FindAsync(1) ?? new AppSettings();
+            var html = BuildHtml(order, settings);
+
+            try
+            {
+                await _emailService.SendEmailAsync(
+                    order.User.Email,
+                    $"Order #{order.Id} reserved — {settings.CompanyName}",
+                    html);
+                _logger.LogInformation("Order reserved email sent for order {OrderId}", orderId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to send reserved email for order {OrderId}", orderId);
+            }
+        }
+
+        private static string BuildHtml(Order order, AppSettings s)
+        {
+            static string Nok(int ore) => (ore / 100.0).ToString("N2", CultureInfo.InvariantCulture);
+            static string H(string? v) => HttpUtility.HtmlEncode(v ?? string.Empty);
+
+            var lines = new StringBuilder();
+            foreach (var item in order.OrderItems)
+            {
+                var lineTotal = item.PriceAtPurchaseInOre * item.Quantity;
+                lines.Append($"""
+                    <tr>
+                      <td style="padding:6px 8px;border-bottom:1px solid #e5e7eb;">{H(item.ShopItem?.Name)} × {item.Quantity}</td>
+                      <td style="padding:6px 8px;border-bottom:1px solid #e5e7eb;text-align:right;">NOK {Nok(lineTotal)}</td>
+                    </tr>
+                    """);
+            }
+
+            var shipBlock = string.IsNullOrEmpty(order.ShippingAddress)
+                ? string.Empty
+                : $"""<p style="margin:12px 0 0;"><strong>Ship to:</strong> {H(order.ShippingAddress)}</p>""";
+
+            return $$"""
+                <!DOCTYPE html>
+                <html><body style="font-family:Arial,Helvetica,sans-serif;color:#1a1a1a;font-size:14px;">
+                <div style="max-width:560px;margin:0 auto;padding:24px;">
+                  <h1 style="font-size:20px;margin:0 0 8px;">Thanks for your order, {{H(order.User?.FirstName)}}!</h1>
+                  <p style="color:#555;margin:0 0 16px;">Order <strong>#{{order.Id}}</strong> is reserved with Vipps. We'll capture payment when it ships.</p>
+                  <table style="width:100%;border-collapse:collapse;margin:16px 0;">{{lines}}
+                    <tr><td style="padding:8px;font-weight:700;">Total</td><td style="padding:8px;text-align:right;font-weight:700;">NOK {{Nok(order.TotalInOre)}}</td></tr>
+                  </table>
+                  {{shipBlock}}
+                  <p style="color:#888;font-size:12px;margin-top:24px;">{{H(s.CompanyLegalName)}} · Org. no. {{H(s.CompanyOrgNumber)}}</p>
+                </div>
+                </body></html>
+                """;
+        }
+    }
+}

--- a/Services/VippsAddressFormatter.cs
+++ b/Services/VippsAddressFormatter.cs
@@ -1,0 +1,25 @@
+namespace garge_api.Services
+{
+    public static class VippsAddressFormatter
+    {
+        public const int DefaultMaxLength = 500;
+
+        public static string? Format(VippsAddress? address, int maxLength = DefaultMaxLength)
+        {
+            if (address == null) return null;
+
+            var formatted = !string.IsNullOrEmpty(address.Formatted)
+                ? address.Formatted
+                : string.Join(", ", new[]
+                {
+                    address.StreetAddress,
+                    address.PostalCode,
+                    address.Region,
+                    address.Country
+                }.Where(s => !string.IsNullOrEmpty(s)));
+
+            if (string.IsNullOrEmpty(formatted)) return null;
+            return formatted.Length > maxLength ? formatted[..maxLength] : formatted;
+        }
+    }
+}

--- a/Services/VippsService.cs
+++ b/Services/VippsService.cs
@@ -235,7 +235,8 @@ namespace garge_api.Services
                         };
                     }),
                     bottomLine = new { currency = "NOK", receiptNumber = reference }
-                }
+                },
+                profile = new { scope = "name address email phoneNumber" }
             };
 
             var request = new HttpRequestMessage(HttpMethod.Post, $"{e.BaseUrl}/epayment/v1/payments");
@@ -257,7 +258,55 @@ namespace garge_api.Services
 
             var response = await _http.SendAsync(request);
             var json = await ReadAsStringAndEnsureSuccessAsync(response, "get-payment");
-            return JsonSerializer.Deserialize<VippsPaymentResponse>(json, _jsonOpts)!;
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            var result = new VippsPaymentResponse
+            {
+                Reference = root.TryGetProperty("reference", out var refEl) ? refEl.GetString() ?? string.Empty : string.Empty,
+                State = root.TryGetProperty("state", out var stateEl) ? stateEl.GetString() ?? string.Empty : string.Empty
+            };
+            if (root.TryGetProperty("profile", out var profileEl) &&
+                profileEl.TryGetProperty("sub", out var subEl))
+            {
+                result.ProfileSub = subEl.GetString();
+            }
+            return result;
+        }
+
+        public async Task<VippsUserInfo?> GetUserInfoAsync(string sub)
+        {
+            if (string.IsNullOrEmpty(sub)) return null;
+
+            var e = await GetEffectiveAsync();
+            var request = new HttpRequestMessage(HttpMethod.Get,
+                $"{e.BaseUrl}/vipps-userinfo-api/userinfo/{sub}");
+            AddCommonHeaders(request, e);
+
+            var response = await _http.SendAsync(request);
+            var json = await ReadAsStringAndEnsureSuccessAsync(response, "get-userinfo");
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            var info = new VippsUserInfo
+            {
+                Name = root.TryGetProperty("name", out var n) ? n.GetString() : null,
+                Email = root.TryGetProperty("email", out var em) ? em.GetString() : null,
+                PhoneNumber = root.TryGetProperty("phone_number", out var ph) ? ph.GetString() : null
+            };
+
+            if (root.TryGetProperty("address", out var addr) && addr.ValueKind == JsonValueKind.Object)
+            {
+                info.Address = new VippsAddress
+                {
+                    StreetAddress = addr.TryGetProperty("street_address", out var sa) ? sa.GetString() : null,
+                    PostalCode = addr.TryGetProperty("postal_code", out var pc) ? pc.GetString() : null,
+                    Region = addr.TryGetProperty("region", out var rg) ? rg.GetString() : null,
+                    Country = addr.TryGetProperty("country", out var co) ? co.GetString() : null,
+                    Formatted = addr.TryGetProperty("formatted", out var fm) ? fm.GetString() : null
+                };
+            }
+
+            return info;
         }
 
         public async Task CapturePaymentAsync(string reference, int amountInOre, string idempotencyKey)

--- a/Services/VippsService.cs
+++ b/Services/VippsService.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 
 namespace garge_api.Services
@@ -258,19 +259,13 @@ namespace garge_api.Services
 
             var response = await _http.SendAsync(request);
             var json = await ReadAsStringAndEnsureSuccessAsync(response, "get-payment");
-            using var doc = JsonDocument.Parse(json);
-            var root = doc.RootElement;
-            var result = new VippsPaymentResponse
+            var dto = JsonSerializer.Deserialize<PaymentApiDto>(json, _jsonOpts) ?? new PaymentApiDto();
+            return new VippsPaymentResponse
             {
-                Reference = root.TryGetProperty("reference", out var refEl) ? refEl.GetString() ?? string.Empty : string.Empty,
-                State = root.TryGetProperty("state", out var stateEl) ? stateEl.GetString() ?? string.Empty : string.Empty
+                Reference = dto.Reference ?? string.Empty,
+                State = dto.State ?? string.Empty,
+                ProfileSub = dto.Profile?.Sub
             };
-            if (root.TryGetProperty("profile", out var profileEl) &&
-                profileEl.TryGetProperty("sub", out var subEl))
-            {
-                result.ProfileSub = subEl.GetString();
-            }
-            return result;
         }
 
         public async Task<VippsUserInfo?> GetUserInfoAsync(string sub)
@@ -284,29 +279,59 @@ namespace garge_api.Services
 
             var response = await _http.SendAsync(request);
             var json = await ReadAsStringAndEnsureSuccessAsync(response, "get-userinfo");
-            using var doc = JsonDocument.Parse(json);
-            var root = doc.RootElement;
+            var dto = JsonSerializer.Deserialize<UserInfoApiDto>(json, _jsonOpts);
+            if (dto == null) return null;
 
-            var info = new VippsUserInfo
+            return new VippsUserInfo
             {
-                Name = root.TryGetProperty("name", out var n) ? n.GetString() : null,
-                Email = root.TryGetProperty("email", out var em) ? em.GetString() : null,
-                PhoneNumber = root.TryGetProperty("phone_number", out var ph) ? ph.GetString() : null
-            };
-
-            if (root.TryGetProperty("address", out var addr) && addr.ValueKind == JsonValueKind.Object)
-            {
-                info.Address = new VippsAddress
+                Name = dto.Name,
+                Email = dto.Email,
+                PhoneNumber = dto.PhoneNumber,
+                Address = dto.Address == null ? null : new VippsAddress
                 {
-                    StreetAddress = addr.TryGetProperty("street_address", out var sa) ? sa.GetString() : null,
-                    PostalCode = addr.TryGetProperty("postal_code", out var pc) ? pc.GetString() : null,
-                    Region = addr.TryGetProperty("region", out var rg) ? rg.GetString() : null,
-                    Country = addr.TryGetProperty("country", out var co) ? co.GetString() : null,
-                    Formatted = addr.TryGetProperty("formatted", out var fm) ? fm.GetString() : null
-                };
-            }
+                    StreetAddress = dto.Address.StreetAddress,
+                    PostalCode = dto.Address.PostalCode,
+                    Region = dto.Address.Region,
+                    Country = dto.Address.Country,
+                    Formatted = dto.Address.Formatted
+                }
+            };
+        }
 
-            return info;
+        private sealed class PaymentApiDto
+        {
+            public string? Reference { get; set; }
+            public string? State { get; set; }
+            public PaymentProfileApiDto? Profile { get; set; }
+        }
+
+        private sealed class PaymentProfileApiDto
+        {
+            public string? Sub { get; set; }
+        }
+
+        private sealed class UserInfoApiDto
+        {
+            public string? Name { get; set; }
+            public string? Email { get; set; }
+
+            [JsonPropertyName("phone_number")]
+            public string? PhoneNumber { get; set; }
+
+            public AddressApiDto? Address { get; set; }
+        }
+
+        private sealed class AddressApiDto
+        {
+            [JsonPropertyName("street_address")]
+            public string? StreetAddress { get; set; }
+
+            [JsonPropertyName("postal_code")]
+            public string? PostalCode { get; set; }
+
+            public string? Region { get; set; }
+            public string? Country { get; set; }
+            public string? Formatted { get; set; }
         }
 
         public async Task CapturePaymentAsync(string reference, int amountInOre, string idempotencyKey)

--- a/garge-api.Tests/MoneyFormatTests.cs
+++ b/garge-api.Tests/MoneyFormatTests.cs
@@ -1,0 +1,35 @@
+using garge_api.Helpers;
+using Xunit;
+
+namespace garge_api.Tests;
+
+public class MoneyFormatTests
+{
+    [Theory]
+    [InlineData(0, "0.00")]
+    [InlineData(1, "0.01")]
+    [InlineData(99, "0.99")]
+    [InlineData(100, "1.00")]
+    [InlineData(50000, "500.00")]
+    [InlineData(123456, "1,234.56")]
+    public void Nok_FormatsOreToTwoDecimalString(int ore, string expected)
+    {
+        Assert.Equal(expected, MoneyFormat.Nok(ore));
+    }
+
+    [Fact]
+    public void Nok_UsesInvariantCulture()
+    {
+        var prev = System.Threading.Thread.CurrentThread.CurrentCulture;
+        try
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture =
+                new System.Globalization.CultureInfo("nb-NO");
+            Assert.Equal("1,234.56", MoneyFormat.Nok(123456));
+        }
+        finally
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture = prev;
+        }
+    }
+}

--- a/garge-api.Tests/OrderEmailServiceTests.cs
+++ b/garge-api.Tests/OrderEmailServiceTests.cs
@@ -1,0 +1,149 @@
+using garge_api.Models;
+using garge_api.Models.Admin;
+using garge_api.Models.Shop;
+using garge_api.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace garge_api.Tests;
+
+public class OrderEmailServiceTests
+{
+    private static (OrderEmailService svc, ApplicationDbContext db, Mock<IEmailService> email) Create()
+    {
+        var db = new ApplicationDbContext(
+            new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString()).Options);
+
+        var serviceProvider = new Mock<IServiceProvider>();
+        serviceProvider.Setup(sp => sp.GetService(typeof(ApplicationDbContext))).Returns(db);
+
+        var scope = new Mock<IServiceScope>();
+        scope.SetupGet(s => s.ServiceProvider).Returns(serviceProvider.Object);
+
+        var scopeFactory = new Mock<IServiceScopeFactory>();
+        scopeFactory.Setup(f => f.CreateScope()).Returns(scope.Object);
+
+        var email = new Mock<IEmailService>();
+        var svc = new OrderEmailService(scopeFactory.Object, email.Object,
+            NullLogger<OrderEmailService>.Instance);
+        return (svc, db, email);
+    }
+
+    private static async Task<Order> SeedOrderAsync(ApplicationDbContext db, string? email = "buyer@example.com",
+        string? shippingAddress = null, string firstName = "Sondre")
+    {
+        await db.AppSettings.AddAsync(new AppSettings { Id = 1, CompanyName = "Garge" });
+        var user = new User
+        {
+            Id = "user-1", Email = email, UserName = email,
+            FirstName = firstName, LastName = "Sjølyst"
+        };
+        await db.Users.AddAsync(user);
+
+        var item = new ShopItem { Id = 1, Name = "Garge Sensor", PriceInOre = 50000, IsActive = true };
+        await db.ShopItems.AddAsync(item);
+
+        var order = new Order
+        {
+            UserId = user.Id, TotalInOre = 50000, Status = OrderStatus.Reserved,
+            ShippingAddress = shippingAddress
+        };
+        await db.Orders.AddAsync(order);
+        await db.SaveChangesAsync();
+
+        await db.OrderItems.AddAsync(new OrderItem
+        {
+            OrderId = order.Id, ShopItemId = item.Id, Quantity = 1,
+            PriceAtPurchaseInOre = 50000, UnitPriceExclVatInOre = 50000, VatPercentage = 0
+        });
+        await db.SaveChangesAsync();
+        return order;
+    }
+
+    [Fact]
+    public async Task SendOrderReservedAsync_SendsEmailWithSubjectAndItemTotal()
+    {
+        var (svc, db, email) = Create();
+        var order = await SeedOrderAsync(db);
+
+        await svc.SendOrderReservedAsync(order.Id);
+
+        email.Verify(e => e.SendEmailAsync(
+            "buyer@example.com",
+            It.Is<string>(s => s.Contains($"#{order.Id}") && s.Contains("Garge")),
+            It.Is<string>(html => html.Contains("Garge Sensor") && html.Contains("500.00")),
+            It.IsAny<IReadOnlyList<EmailAttachment>?>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SendOrderReservedAsync_IncludesShippingAddress_WhenPresent()
+    {
+        var (svc, db, email) = Create();
+        var order = await SeedOrderAsync(db, shippingAddress: "Mårvegen 21a, 4347 Lye");
+
+        await svc.SendOrderReservedAsync(order.Id);
+
+        email.Verify(e => e.SendEmailAsync(
+            It.IsAny<string>(), It.IsAny<string>(),
+            It.Is<string>(html => html.Contains("21a, 4347 Lye") && html.Contains("Ship to:")),
+            It.IsAny<IReadOnlyList<EmailAttachment>?>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SendOrderReservedAsync_OmitsShippingBlock_WhenNull()
+    {
+        var (svc, db, email) = Create();
+        var order = await SeedOrderAsync(db, shippingAddress: null);
+
+        await svc.SendOrderReservedAsync(order.Id);
+
+        email.Verify(e => e.SendEmailAsync(
+            It.IsAny<string>(), It.IsAny<string>(),
+            It.Is<string>(html => !html.Contains("Ship to:")),
+            It.IsAny<IReadOnlyList<EmailAttachment>?>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SendOrderReservedAsync_DoesNotSend_WhenUserMissingEmail()
+    {
+        var (svc, db, email) = Create();
+        var order = await SeedOrderAsync(db, email: null);
+
+        await svc.SendOrderReservedAsync(order.Id);
+
+        email.Verify(e => e.SendEmailAsync(
+            It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<string>(), It.IsAny<IReadOnlyList<EmailAttachment>?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SendOrderReservedAsync_DoesNotSend_WhenOrderMissing()
+    {
+        var (svc, db, email) = Create();
+        await db.AppSettings.AddAsync(new AppSettings { Id = 1 });
+        await db.SaveChangesAsync();
+
+        await svc.SendOrderReservedAsync(orderId: 99999);
+
+        email.Verify(e => e.SendEmailAsync(
+            It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<string>(), It.IsAny<IReadOnlyList<EmailAttachment>?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SendOrderReservedAsync_SwallowsEmailServiceException()
+    {
+        var (svc, db, email) = Create();
+        var order = await SeedOrderAsync(db);
+        email.Setup(e => e.SendEmailAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<EmailAttachment>?>()))
+            .ThrowsAsync(new Exception("brevo down"));
+
+        await svc.SendOrderReservedAsync(order.Id);
+    }
+}

--- a/garge-api.Tests/ShopControllerTests.cs
+++ b/garge-api.Tests/ShopControllerTests.cs
@@ -65,6 +65,7 @@ public class ShopControllerTests : ControllerTestBase
     private ShopController CreateController(
         ApplicationDbContext db, string userId = "user-1",
         Mock<IVippsService>? vipps = null, IInvoiceService? invoice = null,
+        IOrderEmailService? orderEmail = null,
         AppSettings? settings = null)
     {
         var push = new Mock<IWebPushService>();
@@ -74,6 +75,7 @@ public class ShopControllerTests : ControllerTestBase
         var ctrl = new ShopController(
             db, (vipps ?? MockVipps()).Object,
             invoice ?? MockInvoice().Object,
+            orderEmail ?? new Mock<IOrderEmailService>().Object,
             MockSettingsCache(settings).Object,
             MockProtector().Object,
             push.Object,
@@ -115,6 +117,74 @@ public class ShopControllerTests : ControllerTestBase
         Assert.IsType<OkResult>(result);
         var updated = await db.Orders.FindAsync(order.Id);
         Assert.Equal(OrderStatus.Reserved, updated!.Status);
+    }
+
+    [Fact]
+    public async Task Webhook_AuthorizedEvent_SendsReservedEmail()
+    {
+        using var db = CreateDbContext();
+        var order = new Order
+        {
+            UserId = "user-1", VippsOrderId = "garge-order-email-1",
+            TotalInOre = 10000, Status = OrderStatus.Pending
+        };
+        await db.Orders.AddAsync(order);
+        await db.SaveChangesAsync();
+
+        var orderEmail = new Mock<IOrderEmailService>();
+        orderEmail.Setup(o => o.SendOrderReservedAsync(order.Id))
+            .Returns(Task.CompletedTask).Verifiable();
+
+        var payload = new
+        {
+            reference = order.VippsOrderId,
+            pspReference = "psp-email-1",
+            name = "AUTHORIZED",
+            amount = new { value = 10000, currency = "NOK" },
+            msn = "msn-prod"
+        };
+        var body = JsonSerializer.Serialize(payload);
+
+        var ctrl = CreateController(db, orderEmail: orderEmail.Object,
+            settings: new AppSettings { Id = 1, VippsShopWebhookSecret = "secret" });
+        SetupValidWebhookRequest(ctrl, body);
+
+        await ctrl.Webhook();
+
+        orderEmail.Verify(o => o.SendOrderReservedAsync(order.Id), Times.Once);
+    }
+
+    [Fact]
+    public async Task Webhook_CapturedEvent_DoesNotSendReservedEmail()
+    {
+        using var db = CreateDbContext();
+        var order = new Order
+        {
+            UserId = "user-1", VippsOrderId = "garge-order-email-2",
+            TotalInOre = 10000, Status = OrderStatus.Reserved
+        };
+        await db.Orders.AddAsync(order);
+        await db.SaveChangesAsync();
+
+        var orderEmail = new Mock<IOrderEmailService>();
+
+        var payload = new
+        {
+            reference = order.VippsOrderId,
+            pspReference = "psp-email-2",
+            name = "CAPTURED",
+            amount = new { value = 10000, currency = "NOK" },
+            msn = "msn-prod"
+        };
+        var body = JsonSerializer.Serialize(payload);
+
+        var ctrl = CreateController(db, orderEmail: orderEmail.Object,
+            settings: new AppSettings { Id = 1, VippsShopWebhookSecret = "secret" });
+        SetupValidWebhookRequest(ctrl, body);
+
+        await ctrl.Webhook();
+
+        orderEmail.Verify(o => o.SendOrderReservedAsync(It.IsAny<int>()), Times.Never);
     }
 
     [Fact]

--- a/garge-api.Tests/ShopControllerTests.cs
+++ b/garge-api.Tests/ShopControllerTests.cs
@@ -118,6 +118,92 @@ public class ShopControllerTests : ControllerTestBase
     }
 
     [Fact]
+    public async Task Webhook_AuthorizedEvent_PopulatesShippingFromVippsProfile()
+    {
+        using var db = CreateDbContext();
+        var order = new Order
+        {
+            UserId = "user-1", VippsOrderId = "garge-order-000002",
+            TotalInOre = 10000, Status = OrderStatus.Pending
+        };
+        await db.Orders.AddAsync(order);
+        await db.SaveChangesAsync();
+
+        var vipps = MockVipps();
+        vipps.Setup(v => v.GetPaymentAsync(order.VippsOrderId))
+            .ReturnsAsync(new VippsPaymentResponse
+            {
+                Reference = order.VippsOrderId, State = "AUTHORIZED", ProfileSub = "sub-abc"
+            });
+        vipps.Setup(v => v.GetUserInfoAsync("sub-abc"))
+            .ReturnsAsync(new VippsUserInfo
+            {
+                Address = new VippsAddress
+                {
+                    Formatted = "Mårvegen 21a, 4347 Lye, Norway"
+                }
+            });
+
+        var payload = new
+        {
+            reference = order.VippsOrderId,
+            pspReference = "psp-2",
+            name = "AUTHORIZED",
+            amount = new { value = 10000, currency = "NOK" },
+            msn = "msn-prod"
+        };
+        var body = JsonSerializer.Serialize(payload);
+
+        var ctrl = CreateController(db, vipps: vipps,
+            settings: new AppSettings { Id = 1, VippsShopWebhookSecret = "secret" });
+        SetupValidWebhookRequest(ctrl, body);
+
+        var result = await ctrl.Webhook();
+
+        Assert.IsType<OkResult>(result);
+        var updated = await db.Orders.FindAsync(order.Id);
+        Assert.Equal("Mårvegen 21a, 4347 Lye, Norway", updated!.ShippingAddress);
+    }
+
+    [Fact]
+    public async Task Webhook_AuthorizedEvent_KeepsExistingAddress_WhenVippsHasNone()
+    {
+        using var db = CreateDbContext();
+        var order = new Order
+        {
+            UserId = "user-1", VippsOrderId = "garge-order-000003",
+            TotalInOre = 10000, Status = OrderStatus.Pending,
+            ShippingAddress = "Existing address 1"
+        };
+        await db.Orders.AddAsync(order);
+        await db.SaveChangesAsync();
+
+        var vipps = MockVipps();
+        vipps.Setup(v => v.GetPaymentAsync(order.VippsOrderId))
+            .ReturnsAsync(new VippsPaymentResponse { Reference = order.VippsOrderId, State = "AUTHORIZED" });
+
+        var payload = new
+        {
+            reference = order.VippsOrderId,
+            pspReference = "psp-3",
+            name = "AUTHORIZED",
+            amount = new { value = 10000, currency = "NOK" },
+            msn = "msn-prod"
+        };
+        var body = JsonSerializer.Serialize(payload);
+
+        var ctrl = CreateController(db, vipps: vipps,
+            settings: new AppSettings { Id = 1, VippsShopWebhookSecret = "secret" });
+        SetupValidWebhookRequest(ctrl, body);
+
+        await ctrl.Webhook();
+
+        var updated = await db.Orders.FindAsync(order.Id);
+        Assert.Equal("Existing address 1", updated!.ShippingAddress);
+        vipps.Verify(v => v.GetUserInfoAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
     public async Task Webhook_InvalidHmac_Returns401()
     {
         using var db = CreateDbContext();

--- a/garge-api.Tests/VippsAddressFormatterTests.cs
+++ b/garge-api.Tests/VippsAddressFormatterTests.cs
@@ -1,0 +1,89 @@
+using garge_api.Services;
+using Xunit;
+
+namespace garge_api.Tests;
+
+public class VippsAddressFormatterTests
+{
+    [Fact]
+    public void Format_NullAddress_ReturnsNull()
+    {
+        Assert.Null(VippsAddressFormatter.Format(null));
+    }
+
+    [Fact]
+    public void Format_PrefersFormattedField()
+    {
+        var address = new VippsAddress
+        {
+            Formatted = "Mårvegen 21a, 4347 Lye, Norway",
+            StreetAddress = "ignored",
+            PostalCode = "ignored",
+            Region = "ignored",
+            Country = "ignored"
+        };
+
+        Assert.Equal("Mårvegen 21a, 4347 Lye, Norway", VippsAddressFormatter.Format(address));
+    }
+
+    [Fact]
+    public void Format_FallsBackToJoinedParts_WhenFormattedMissing()
+    {
+        var address = new VippsAddress
+        {
+            StreetAddress = "Mårvegen 21a",
+            PostalCode = "4347",
+            Region = "Lye",
+            Country = "NO"
+        };
+
+        Assert.Equal("Mårvegen 21a, 4347, Lye, NO", VippsAddressFormatter.Format(address));
+    }
+
+    [Fact]
+    public void Format_SkipsNullAndEmptyParts()
+    {
+        var address = new VippsAddress
+        {
+            StreetAddress = "Mårvegen 21a",
+            PostalCode = null,
+            Region = "",
+            Country = "NO"
+        };
+
+        Assert.Equal("Mårvegen 21a, NO", VippsAddressFormatter.Format(address));
+    }
+
+    [Fact]
+    public void Format_AllPartsEmpty_ReturnsNull()
+    {
+        var address = new VippsAddress
+        {
+            StreetAddress = null,
+            PostalCode = "",
+            Region = null,
+            Country = ""
+        };
+
+        Assert.Null(VippsAddressFormatter.Format(address));
+    }
+
+    [Fact]
+    public void Format_TruncatesToMaxLength()
+    {
+        var address = new VippsAddress { Formatted = new string('x', 600) };
+
+        var result = VippsAddressFormatter.Format(address, maxLength: 500);
+
+        Assert.NotNull(result);
+        Assert.Equal(500, result!.Length);
+    }
+
+    [Fact]
+    public void Format_WithinMaxLength_NotTruncated()
+    {
+        var address = new VippsAddress { Formatted = new string('x', 100) };
+
+        Assert.Equal(new string('x', 100), VippsAddressFormatter.Format(address, maxLength: 500));
+    }
+}


### PR DESCRIPTION
## Summary
- Bump `Subscription.VippsConfirmationUrl` from `varchar(500)` to `varchar(2000)` so subscription confirmation URLs (which include long signed Vipps tokens) no longer trip the 22001 / 502 path on `/api/subscriptions/initiate`.
- Pre-install Chromium in the runtime image and point Puppeteer at it via `PUPPETEER_EXECUTABLE_PATH`, so invoice PDF generation stops producing blank files inside the Kubernetes pod (`BrowserFetcher.DownloadAsync` was failing silently in-container).
- Collect the shop shipping address from the Vipps user profile instead of re-asking the buyer: request the `name address email phoneNumber` scope on `CreatePayment`, and on the `AUTHORIZED` webhook fetch `userinfo` and store the formatted address on the order. `CreateOrderDto.ShippingAddress` becomes optional so the frontend can drop the address form.
- Extract `VippsAddressFormatter` for the address-flattening + truncation logic; replace ad-hoc `JsonDocument` walking in `VippsService.GetPaymentAsync` / `GetUserInfoAsync` with typed DTOs.

## Test plan
- [x] `dotnet build` clean
- [x] `dotnet test` — 121/121 pass, including new `VippsAddressFormatterTests` and two webhook tests covering populate-from-Vipps and keep-existing-address fallback
- [ ] After deploy: confirm registered webhook URLs no longer have the trailing-slash duplicate
- [ ] After deploy: hit `/api/subscriptions/initiate` and verify the subscription confirmation URL persists without 22001
- [ ] After deploy: download an invoice for a paid order and confirm the PDF renders (not blank)
- [ ] After deploy: place a shop order without supplying `shippingAddress`, complete in Vipps test app, confirm `Order.ShippingAddress` populated from Vipps profile on AUTHORIZED webhook
- [ ] Frontend follow-up (separate repo): show `shippingAddress` in admin orders view; optionally drop the address field from checkout

## Notes
- Trailing-slash webhook URL fix already landed on `development` in commit `b058468`.
- Change touches shop checkout only; subscription flow address handling unchanged.
