### PR TITLE
fix: use libasound2t64 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libgtk-3-0 \
         libxss1 \
         libgbm1 \
-        libasound2 \
+        libasound2t64 \
         ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Ubuntu Noble (.NET 10 aspnet base) renamed `libasound2` to `libasound2t64` as part of the time_t 64-bit transition. The image build hit `E: Package 'libasound2' has no installation candidate`. Switch the package name so the Chromium runtime deps install cleanly.