### PR TITLE
refactor: rename order email to 'confirmed' with customer-facing copy

### DIFF
--- a/Controllers/ShopController.cs
+++ b/Controllers/ShopController.cs
@@ -436,11 +436,11 @@ namespace garge_api.Controllers
             }
             else if (prevStatus != OrderStatus.Reserved && order.Status == OrderStatus.Reserved)
             {
-                try { await _orderEmail.SendOrderReservedAsync(order.Id); }
-                catch (Exception ex) { _logger.LogError(ex, "Reserved email failed for order {OrderId}", order.Id); }
+                try { await _orderEmail.SendOrderConfirmedAsync(order.Id); }
+                catch (Exception ex) { _logger.LogError(ex, "Order confirmation email failed for order {OrderId}", order.Id); }
 
-                _ = SafePushAsync(order.UserId, "Order reserved",
-                    $"Order #{order.Id} is reserved. We'll capture payment when it ships.");
+                _ = SafePushAsync(order.UserId, "Order confirmed",
+                    $"Order #{order.Id} confirmed. We'll get it ready to ship.");
             }
 
             _logger.LogInformation("Shop webhook: order {OrderId} -> {Status}", order.Id, payload.Name);

--- a/Services/IOrderEmailService.cs
+++ b/Services/IOrderEmailService.cs
@@ -2,6 +2,6 @@ namespace garge_api.Services
 {
     public interface IOrderEmailService
     {
-        Task SendOrderReservedAsync(int orderId);
+        Task SendOrderConfirmedAsync(int orderId);
     }
 }

--- a/Services/OrderEmailService.cs
+++ b/Services/OrderEmailService.cs
@@ -24,7 +24,7 @@ namespace garge_api.Services
             _logger = logger;
         }
 
-        public async Task SendOrderReservedAsync(int orderId)
+        public async Task SendOrderConfirmedAsync(int orderId)
         {
             using var scope = _scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
@@ -36,7 +36,7 @@ namespace garge_api.Services
 
             if (order?.User?.Email == null)
             {
-                _logger.LogWarning("Order {OrderId} missing user/email — reserved email skipped", orderId);
+                _logger.LogWarning("Order {OrderId} missing user/email — confirmation email skipped", orderId);
                 return;
             }
 
@@ -47,13 +47,13 @@ namespace garge_api.Services
             {
                 await _emailService.SendEmailAsync(
                     order.User.Email,
-                    $"Order #{order.Id} reserved — {settings.CompanyName}",
+                    $"Order #{order.Id} confirmed — {settings.CompanyName}",
                     html);
-                _logger.LogInformation("Order reserved email sent for order {OrderId}", orderId);
+                _logger.LogInformation("Order confirmation email sent for order {OrderId}", orderId);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to send reserved email for order {OrderId}", orderId);
+                _logger.LogError(ex, "Failed to send confirmation email for order {OrderId}", orderId);
             }
         }
 
@@ -83,7 +83,7 @@ namespace garge_api.Services
                 <html><body style="font-family:Arial,Helvetica,sans-serif;color:#1a1a1a;font-size:14px;">
                 <div style="max-width:560px;margin:0 auto;padding:24px;">
                   <h1 style="font-size:20px;margin:0 0 8px;">Thanks for your order, {{H(order.User?.FirstName)}}!</h1>
-                  <p style="color:#555;margin:0 0 16px;">Order <strong>#{{order.Id}}</strong> is reserved with Vipps. We'll capture payment when it ships.</p>
+                  <p style="color:#555;margin:0 0 16px;">We've received order <strong>#{{order.Id}}</strong> and will get it ready to ship.</p>
                   <table style="width:100%;border-collapse:collapse;margin:16px 0;">{{lines}}
                     <tr><td style="padding:8px;font-weight:700;">Total</td><td style="padding:8px;text-align:right;font-weight:700;">NOK {{Nok(order.TotalInOre)}}</td></tr>
                   </table>

--- a/garge-api.Tests/OrderEmailServiceTests.cs
+++ b/garge-api.Tests/OrderEmailServiceTests.cs
@@ -65,12 +65,12 @@ public class OrderEmailServiceTests
     }
 
     [Fact]
-    public async Task SendOrderReservedAsync_SendsEmailWithSubjectAndItemTotal()
+    public async Task SendOrderConfirmedAsync_SendsEmailWithSubjectAndItemTotal()
     {
         var (svc, db, email) = Create();
         var order = await SeedOrderAsync(db);
 
-        await svc.SendOrderReservedAsync(order.Id);
+        await svc.SendOrderConfirmedAsync(order.Id);
 
         email.Verify(e => e.SendEmailAsync(
             "buyer@example.com",
@@ -80,12 +80,12 @@ public class OrderEmailServiceTests
     }
 
     [Fact]
-    public async Task SendOrderReservedAsync_IncludesShippingAddress_WhenPresent()
+    public async Task SendOrderConfirmedAsync_IncludesShippingAddress_WhenPresent()
     {
         var (svc, db, email) = Create();
         var order = await SeedOrderAsync(db, shippingAddress: "Mårvegen 21a, 4347 Lye");
 
-        await svc.SendOrderReservedAsync(order.Id);
+        await svc.SendOrderConfirmedAsync(order.Id);
 
         email.Verify(e => e.SendEmailAsync(
             It.IsAny<string>(), It.IsAny<string>(),
@@ -94,12 +94,12 @@ public class OrderEmailServiceTests
     }
 
     [Fact]
-    public async Task SendOrderReservedAsync_OmitsShippingBlock_WhenNull()
+    public async Task SendOrderConfirmedAsync_OmitsShippingBlock_WhenNull()
     {
         var (svc, db, email) = Create();
         var order = await SeedOrderAsync(db, shippingAddress: null);
 
-        await svc.SendOrderReservedAsync(order.Id);
+        await svc.SendOrderConfirmedAsync(order.Id);
 
         email.Verify(e => e.SendEmailAsync(
             It.IsAny<string>(), It.IsAny<string>(),
@@ -108,12 +108,12 @@ public class OrderEmailServiceTests
     }
 
     [Fact]
-    public async Task SendOrderReservedAsync_DoesNotSend_WhenUserMissingEmail()
+    public async Task SendOrderConfirmedAsync_DoesNotSend_WhenUserMissingEmail()
     {
         var (svc, db, email) = Create();
         var order = await SeedOrderAsync(db, email: null);
 
-        await svc.SendOrderReservedAsync(order.Id);
+        await svc.SendOrderConfirmedAsync(order.Id);
 
         email.Verify(e => e.SendEmailAsync(
             It.IsAny<string>(), It.IsAny<string>(),
@@ -121,13 +121,13 @@ public class OrderEmailServiceTests
     }
 
     [Fact]
-    public async Task SendOrderReservedAsync_DoesNotSend_WhenOrderMissing()
+    public async Task SendOrderConfirmedAsync_DoesNotSend_WhenOrderMissing()
     {
         var (svc, db, email) = Create();
         await db.AppSettings.AddAsync(new AppSettings { Id = 1 });
         await db.SaveChangesAsync();
 
-        await svc.SendOrderReservedAsync(orderId: 99999);
+        await svc.SendOrderConfirmedAsync(orderId: 99999);
 
         email.Verify(e => e.SendEmailAsync(
             It.IsAny<string>(), It.IsAny<string>(),
@@ -135,7 +135,7 @@ public class OrderEmailServiceTests
     }
 
     [Fact]
-    public async Task SendOrderReservedAsync_SwallowsEmailServiceException()
+    public async Task SendOrderConfirmedAsync_SwallowsEmailServiceException()
     {
         var (svc, db, email) = Create();
         var order = await SeedOrderAsync(db);
@@ -144,6 +144,6 @@ public class OrderEmailServiceTests
                 It.IsAny<IReadOnlyList<EmailAttachment>?>()))
             .ThrowsAsync(new Exception("brevo down"));
 
-        await svc.SendOrderReservedAsync(order.Id);
+        await svc.SendOrderConfirmedAsync(order.Id);
     }
 }

--- a/garge-api.Tests/ShopControllerTests.cs
+++ b/garge-api.Tests/ShopControllerTests.cs
@@ -120,7 +120,7 @@ public class ShopControllerTests : ControllerTestBase
     }
 
     [Fact]
-    public async Task Webhook_AuthorizedEvent_SendsReservedEmail()
+    public async Task Webhook_AuthorizedEvent_SendsConfirmationEmail()
     {
         using var db = CreateDbContext();
         var order = new Order
@@ -132,7 +132,7 @@ public class ShopControllerTests : ControllerTestBase
         await db.SaveChangesAsync();
 
         var orderEmail = new Mock<IOrderEmailService>();
-        orderEmail.Setup(o => o.SendOrderReservedAsync(order.Id))
+        orderEmail.Setup(o => o.SendOrderConfirmedAsync(order.Id))
             .Returns(Task.CompletedTask).Verifiable();
 
         var payload = new
@@ -151,11 +151,11 @@ public class ShopControllerTests : ControllerTestBase
 
         await ctrl.Webhook();
 
-        orderEmail.Verify(o => o.SendOrderReservedAsync(order.Id), Times.Once);
+        orderEmail.Verify(o => o.SendOrderConfirmedAsync(order.Id), Times.Once);
     }
 
     [Fact]
-    public async Task Webhook_CapturedEvent_DoesNotSendReservedEmail()
+    public async Task Webhook_CapturedEvent_DoesNotSendConfirmationEmail()
     {
         using var db = CreateDbContext();
         var order = new Order
@@ -184,7 +184,7 @@ public class ShopControllerTests : ControllerTestBase
 
         await ctrl.Webhook();
 
-        orderEmail.Verify(o => o.SendOrderReservedAsync(It.IsAny<int>()), Times.Never);
+        orderEmail.Verify(o => o.SendOrderConfirmedAsync(It.IsAny<int>()), Times.Never);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- The post-AUTHORIZED email read like an internal log entry: subject `Order #N reserved`, body `Order #N is reserved with Vipps. We'll capture payment when it ships.` Customers don't speak in capture/reserve language.
- Rebrand as an order-confirmation email:
  - Subject: `Order #N confirmed — {CompanyName}`
  - Opening line: `We've received order #N and will get it ready to ship.`
  - Drop the Vipps capture mention from the body.
- Rename `IOrderEmailService.SendOrderReservedAsync` → `SendOrderConfirmedAsync` so the method name matches the user-facing language. All callers and tests updated.
- Align the push notification on the AUTHORIZED branch (`Order confirmed` / `Order #N confirmed. We'll get it ready to ship.`).

## Test plan
- [x] `dotnet test` — 136/136 pass (renamed `*OrderConfirmedAsync*` tests + assertion strings)
- [ ] After deploy: place a sensor order, complete in Vipps test app, confirm:
  - email subject reads `Order #N confirmed — Garge`
  - body says `We've received order #N and will get it ready to ship.`
  - push notification reads `Order confirmed` / `Order #N confirmed. We'll get it ready to ship.`

## Notes
- `OrderStatus.Reserved` enum value stays — it's the API/Vipps state, not user-facing.
- No template/styling changes beyond the two copy lines.
