### PR TITLE
fix: open own scope in WebPushService instead of capturing request DbContext

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -77,7 +77,7 @@ namespace garge_api
             builder.Services.AddSingleton<PostgresNotificationService>();
             builder.Services.AddHostedService<garge_api.Services.RefreshTokenCleanupService>();
             builder.Services.AddHttpClient("webpush");
-            builder.Services.AddScoped<IWebPushService, WebPushService>();
+            builder.Services.AddSingleton<IWebPushService, WebPushService>();
             builder.Services.AddHostedService<SensorOfflineCheckService>();
             builder.Services.AddScoped<IEmailService, EmailService>();
             builder.Services.AddEndpointsApiExplorer();

--- a/Services/WebPushService.cs
+++ b/Services/WebPushService.cs
@@ -16,7 +16,7 @@ namespace garge_api.Services
     }
 
     public class WebPushService(
-        ApplicationDbContext db,
+        IServiceScopeFactory scopeFactory,
         IHttpClientFactory httpClientFactory,
         IConfiguration configuration,
         ILogger<WebPushService> logger) : IWebPushService
@@ -32,6 +32,9 @@ namespace garge_api.Services
                 logger.LogWarning("VAPID keys not configured — push skipped");
                 return false;
             }
+
+            using var scope = scopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
             var subscriptions = await db.PushSubscriptions
                 .Where(s => s.UserId == userId)

--- a/garge-api.Tests/WebPushServiceTests.cs
+++ b/garge-api.Tests/WebPushServiceTests.cs
@@ -2,6 +2,7 @@ using garge_api.Models;
 using garge_api.Models.Push;
 using garge_api.Services;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Moq.Protected;
@@ -21,6 +22,19 @@ public class WebPushServiceTests : ControllerTestBase
                 ["Vapid:Subject"] = "https://garge.no"
             })
             .Build();
+
+    private static IServiceScopeFactory MakeScopeFactory(ApplicationDbContext db)
+    {
+        var serviceProvider = new Mock<IServiceProvider>();
+        serviceProvider.Setup(sp => sp.GetService(typeof(ApplicationDbContext))).Returns(db);
+
+        var scope = new Mock<IServiceScope>();
+        scope.SetupGet(s => s.ServiceProvider).Returns(serviceProvider.Object);
+
+        var scopeFactory = new Mock<IServiceScopeFactory>();
+        scopeFactory.Setup(f => f.CreateScope()).Returns(scope.Object);
+        return scopeFactory.Object;
+    }
 
     private static Mock<IHttpClientFactory> MakeFactory(HttpStatusCode responseCode = HttpStatusCode.Created)
     {
@@ -53,11 +67,37 @@ public class WebPushServiceTests : ControllerTestBase
     }
 
     [Fact]
+    public async Task SendAsync_OpensFreshScopePerCall()
+    {
+        var db = CreateDbContext();
+        var (publicKey, privateKey) = GenerateVapidKeyPair();
+
+        var serviceProvider = new Mock<IServiceProvider>();
+        serviceProvider.Setup(sp => sp.GetService(typeof(ApplicationDbContext))).Returns(db);
+
+        var scope = new Mock<IServiceScope>();
+        scope.SetupGet(s => s.ServiceProvider).Returns(serviceProvider.Object);
+
+        var scopeFactory = new Mock<IServiceScopeFactory>();
+        scopeFactory.Setup(f => f.CreateScope()).Returns(scope.Object);
+
+        var factory = MakeFactory(HttpStatusCode.Created);
+        var svc = new WebPushService(scopeFactory.Object, factory.Object,
+            MakeConfig(publicKey, privateKey),
+            NullLogger<WebPushService>.Instance);
+
+        await svc.SendAsync("u-1", "title", "body", TestContext.Current.CancellationToken);
+        await svc.SendAsync("u-2", "title", "body", TestContext.Current.CancellationToken);
+
+        scopeFactory.Verify(f => f.CreateScope(), Times.Exactly(2));
+    }
+
+    [Fact]
     public async Task SendAsync_VapidKeysNotConfigured_SkipsWithoutError()
     {
         var db = CreateDbContext();
         var factory = MakeFactory();
-        var svc = new WebPushService(db, factory.Object, MakeConfig(), NullLogger<WebPushService>.Instance);
+        var svc = new WebPushService(MakeScopeFactory(db), factory.Object, MakeConfig(), NullLogger<WebPushService>.Instance);
 
         // Should not throw, and should not attempt any HTTP call
         await svc.SendAsync("u1", "title", "body", TestContext.Current.CancellationToken);
@@ -70,7 +110,7 @@ public class WebPushServiceTests : ControllerTestBase
     {
         var db = CreateDbContext();
         var factory = MakeFactory();
-        var svc = new WebPushService(db, factory.Object,
+        var svc = new WebPushService(MakeScopeFactory(db), factory.Object,
             MakeConfig("fake-pub-key", "fake-priv-key"),
             NullLogger<WebPushService>.Instance);
 
@@ -97,7 +137,7 @@ public class WebPushServiceTests : ControllerTestBase
         await db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var factory = MakeFactoryThrowing(HttpStatusCode.Gone);
-        var svc = new WebPushService(db, factory.Object,
+        var svc = new WebPushService(MakeScopeFactory(db), factory.Object,
             MakeConfig(publicKey, privateKey),
             NullLogger<WebPushService>.Instance);
 
@@ -122,7 +162,7 @@ public class WebPushServiceTests : ControllerTestBase
         await db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var factory = MakeFactoryThrowing(HttpStatusCode.NotFound);
-        var svc = new WebPushService(db, factory.Object,
+        var svc = new WebPushService(MakeScopeFactory(db), factory.Object,
             MakeConfig(publicKey, privateKey),
             NullLogger<WebPushService>.Instance);
 


### PR DESCRIPTION
## Summary
- `_ = SafePushAsync(...)` fires push notifications without awaiting in `ShopController` (3 sites) and `SubscriptionsController` (2 sites). After the controller returned, ASP.NET disposed the request scope, taking the `ApplicationDbContext` that `WebPushService` had captured in its constructor with it. The pending `PushSubscriptions` query then crashed with `NotSupportedException` + `ObjectDisposedException` — a Kestrel-level unhandled exception that cluttered admin capture logs and dropped every push.
- `WebPushService` now takes `IServiceScopeFactory` instead of a scoped `ApplicationDbContext` and opens a fresh scope per `SendAsync` call. Registration changes from `AddScoped` to `AddSingleton` (no scoped state remains).
- Added a regression test that asserts `CreateScope` is invoked per `SendAsync`.

## Test plan
- [x] `dotnet test` — 137/137 pass.
- [ ] After deploy: capture an order in `/admin/orders`, confirm:
  - admin capture endpoint returns 200 with no `NotSupportedException` / `ObjectDisposedException` / `Push send failed` entry afterwards
  - push is delivered to subscribed devices
  - same for AUTHORIZED webhook flow (order confirmed push) and for subscription `recurring.charge-captured.v1` / `recurring.charge-failed.v1` paths

## Notes
- Does **not** investigate the missing invoice email reported alongside this — invoice generation is awaited and would log `"Invoice generation failed for order {OrderId}"` if it threw. Separate follow-up.
- The unrelated `libasound2` → `libasound2t64` Dockerfile fix (PR #175) still needs to land for the next image rebuild.
