### PR TITLE
fix: recover from invoice render failures by cleaning up empty rows

### DIFF
--- a/Controllers/ShopController.cs
+++ b/Controllers/ShopController.cs
@@ -456,7 +456,8 @@ namespace garge_api.Controllers
             }
             else if (payload.Name == "CAPTURED" && order.Status == OrderStatus.Paid)
             {
-                var hasInvoice = await _context.Invoices.AnyAsync(i => i.OrderId == order.Id);
+                var hasInvoice = await _context.Invoices.AnyAsync(i =>
+                    i.OrderId == order.Id && i.PdfData.Length > 0);
                 if (!hasInvoice)
                 {
                     _logger.LogInformation("Order {OrderId} already Paid but no invoice — generating from webhook", order.Id);

--- a/Program.cs
+++ b/Program.cs
@@ -139,6 +139,7 @@ namespace garge_api
                 .SetApplicationName("garge-api");
             builder.Services.AddSingleton<IWebhookSecretProtector, WebhookSecretProtector>();
             builder.Services.AddSingleton<IAppSettingsCache, AppSettingsCache>();
+            builder.Services.AddSingleton<IPdfRenderer, PuppeteerPdfRenderer>();
             builder.Services.AddScoped<IInvoiceService, InvoiceService>();
             builder.Services.AddScoped<IOrderEmailService, OrderEmailService>();
             builder.Services.AddHttpClient<IVippsService, VippsService>();

--- a/Services/IPdfRenderer.cs
+++ b/Services/IPdfRenderer.cs
@@ -1,0 +1,7 @@
+namespace garge_api.Services
+{
+    public interface IPdfRenderer
+    {
+        Task<byte[]> RenderAsync(string html);
+    }
+}

--- a/Services/InvoiceService.cs
+++ b/Services/InvoiceService.cs
@@ -3,8 +3,6 @@ using garge_api.Models;
 using garge_api.Models.Admin;
 using garge_api.Models.Shop;
 using Microsoft.EntityFrameworkCore;
-using PuppeteerSharp;
-using PuppeteerSharp.Media;
 using System.Text;
 using System.Web;
 
@@ -14,15 +12,18 @@ namespace garge_api.Services
     {
         private readonly IServiceScopeFactory _scopeFactory;
         private readonly IEmailService _emailService;
+        private readonly IPdfRenderer _pdfRenderer;
         private readonly ILogger<InvoiceService> _logger;
 
         public InvoiceService(
             IServiceScopeFactory scopeFactory,
             IEmailService emailService,
+            IPdfRenderer pdfRenderer,
             ILogger<InvoiceService> logger)
         {
             _scopeFactory = scopeFactory;
             _emailService = emailService;
+            _pdfRenderer = pdfRenderer;
             _logger = logger;
         }
 
@@ -40,12 +41,13 @@ namespace garge_api.Services
             var settings = await db.AppSettings.FindAsync(1) ?? new AppSettings();
 
             var invoice = await db.Invoices.FirstOrDefaultAsync(i => i.OrderId == orderId);
-            if (invoice != null && !force)
+            if (invoice != null && invoice.PdfData.Length > 0 && !force)
             {
                 _logger.LogInformation("Invoice {InvoiceId} already exists for order {OrderId} — skip", invoice.Id, orderId);
                 return invoice.Id;
             }
 
+            var wasNewRow = invoice == null;
             if (invoice == null)
             {
                 invoice = new Invoice { OrderId = orderId, IssuedAt = DateTime.UtcNow, PdfData = [] };
@@ -58,8 +60,23 @@ namespace garge_api.Services
             }
 
             var html = BuildInvoiceHtml(order, settings, invoice.Id, invoice.IssuedAt);
-            invoice.PdfData = await RenderPdfAsync(html);
-            await db.SaveChangesAsync();
+            try
+            {
+                invoice.PdfData = await _pdfRenderer.RenderAsync(html);
+                await db.SaveChangesAsync();
+            }
+            catch
+            {
+                // Keep DB clean: drop the row we just added so retry isn't blocked by an
+                // empty-PDF placeholder. For force-regenerate over an existing complete
+                // invoice we leave the prior row + bytes alone.
+                if (wasNewRow || invoice.PdfData.Length == 0)
+                {
+                    db.Invoices.Remove(invoice);
+                    await db.SaveChangesAsync();
+                }
+                throw;
+            }
 
             try
             {
@@ -86,35 +103,6 @@ namespace garge_api.Services
 
             _logger.LogInformation("Invoice {InvoiceId} generated for order {OrderId}", invoice.Id, orderId);
             return invoice.Id;
-        }
-
-        private static async Task<byte[]> RenderPdfAsync(string html)
-        {
-            var execPath = Environment.GetEnvironmentVariable("PUPPETEER_EXECUTABLE_PATH");
-            if (string.IsNullOrEmpty(execPath))
-            {
-                var browserFetcher = new BrowserFetcher();
-                await browserFetcher.DownloadAsync();
-            }
-
-            await using var browser = await Puppeteer.LaunchAsync(new LaunchOptions
-            {
-                Headless = true,
-                ExecutablePath = execPath,
-                Args = ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage"]
-            });
-            await using var page = await browser.NewPageAsync();
-            await page.SetContentAsync(html, new NavigationOptions
-            {
-                WaitUntil = [WaitUntilNavigation.Networkidle0]
-            });
-
-            return await page.PdfDataAsync(new PdfOptions
-            {
-                Format = PaperFormat.A4,
-                PrintBackground = true,
-                MarginOptions = new MarginOptions { Top = "0", Bottom = "15mm", Left = "0", Right = "0" }
-            });
         }
 
         private static string BuildInvoiceHtml(Order order, AppSettings s, int invoiceId, DateTime issuedAt)

--- a/Services/PuppeteerPdfRenderer.cs
+++ b/Services/PuppeteerPdfRenderer.cs
@@ -1,0 +1,37 @@
+using PuppeteerSharp;
+using PuppeteerSharp.Media;
+
+namespace garge_api.Services
+{
+    public class PuppeteerPdfRenderer : IPdfRenderer
+    {
+        public async Task<byte[]> RenderAsync(string html)
+        {
+            var execPath = Environment.GetEnvironmentVariable("PUPPETEER_EXECUTABLE_PATH");
+            if (string.IsNullOrEmpty(execPath))
+            {
+                var browserFetcher = new BrowserFetcher();
+                await browserFetcher.DownloadAsync();
+            }
+
+            await using var browser = await Puppeteer.LaunchAsync(new LaunchOptions
+            {
+                Headless = true,
+                ExecutablePath = execPath,
+                Args = ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage"]
+            });
+            await using var page = await browser.NewPageAsync();
+            await page.SetContentAsync(html, new NavigationOptions
+            {
+                WaitUntil = [WaitUntilNavigation.Networkidle0]
+            });
+
+            return await page.PdfDataAsync(new PdfOptions
+            {
+                Format = PaperFormat.A4,
+                PrintBackground = true,
+                MarginOptions = new MarginOptions { Top = "0", Bottom = "15mm", Left = "0", Right = "0" }
+            });
+        }
+    }
+}

--- a/garge-api.Tests/InvoiceServiceTests.cs
+++ b/garge-api.Tests/InvoiceServiceTests.cs
@@ -12,7 +12,8 @@ namespace garge_api.Tests;
 
 public class InvoiceServiceTests
 {
-    private static (InvoiceService svc, ApplicationDbContext db, Mock<IEmailService> email) Create()
+    private static (InvoiceService svc, ApplicationDbContext db, Mock<IEmailService> email, Mock<IPdfRenderer> pdf) Create(
+        Mock<IPdfRenderer>? pdfRenderer = null)
     {
         var db = new ApplicationDbContext(
             new DbContextOptionsBuilder<ApplicationDbContext>()
@@ -28,9 +29,15 @@ public class InvoiceServiceTests
         scopeFactory.Setup(f => f.CreateScope()).Returns(scope.Object);
 
         var email = new Mock<IEmailService>();
-        var svc = new InvoiceService(scopeFactory.Object, email.Object,
+        var pdf = pdfRenderer ?? new Mock<IPdfRenderer>();
+        if (pdfRenderer == null)
+        {
+            pdf.Setup(p => p.RenderAsync(It.IsAny<string>())).ReturnsAsync(new byte[] { 1, 2, 3 });
+        }
+
+        var svc = new InvoiceService(scopeFactory.Object, email.Object, pdf.Object,
             NullLogger<InvoiceService>.Instance);
-        return (svc, db, email);
+        return (svc, db, email, pdf);
     }
 
     private static async Task<Order> SeedPaidOrderAsync(ApplicationDbContext db)
@@ -47,13 +54,22 @@ public class InvoiceServiceTests
         };
         await db.Orders.AddAsync(order);
         await db.SaveChangesAsync();
+
+        var item = new ShopItem { Id = 1, Name = "Garge Sensor", PriceInOre = 50000, IsActive = true };
+        await db.ShopItems.AddAsync(item);
+        await db.OrderItems.AddAsync(new OrderItem
+        {
+            OrderId = order.Id, ShopItemId = 1, Quantity = 1,
+            PriceAtPurchaseInOre = 50000, UnitPriceExclVatInOre = 50000, VatPercentage = 0
+        });
+        await db.SaveChangesAsync();
         return order;
     }
 
     [Fact]
-    public async Task GenerateAndStoreAsync_ExistingInvoiceWithoutForce_ShortCircuits()
+    public async Task GenerateAndStoreAsync_ExistingNonEmptyInvoiceWithoutForce_ShortCircuits()
     {
-        var (svc, db, email) = Create();
+        var (svc, db, email, pdf) = Create();
         var order = await SeedPaidOrderAsync(db);
         var existing = new Invoice { OrderId = order.Id, IssuedAt = DateTime.UtcNow.AddMinutes(-5), PdfData = [9, 9, 9] };
         db.Invoices.Add(existing);
@@ -62,21 +78,109 @@ public class InvoiceServiceTests
         var returnedId = await svc.GenerateAndStoreAsync(order.Id);
 
         Assert.Equal(existing.Id, returnedId);
-
-        // No second invoice row
         Assert.Single(db.Invoices);
-        // PDF bytes preserved (no re-render)
         Assert.Equal(new byte[] { 9, 9, 9 }, db.Invoices.Single().PdfData);
-        // No email sent on the no-op path
+        email.Verify(e => e.SendEmailAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<IReadOnlyList<EmailAttachment>?>()), Times.Never);
+        pdf.Verify(p => p.RenderAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GenerateAndStoreAsync_NoExistingInvoice_RendersAndEmails()
+    {
+        var (svc, db, email, pdf) = Create();
+        var order = await SeedPaidOrderAsync(db);
+
+        var id = await svc.GenerateAndStoreAsync(order.Id);
+
+        var saved = await db.Invoices.SingleAsync();
+        Assert.Equal(id, saved.Id);
+        Assert.Equal(new byte[] { 1, 2, 3 }, saved.PdfData);
+        pdf.Verify(p => p.RenderAsync(It.IsAny<string>()), Times.Once);
+        email.Verify(e => e.SendEmailAsync(
+            "buyer@example.com",
+            It.Is<string>(s => s.Contains($"#{id:D4}")),
+            It.IsAny<string>(),
+            It.Is<IReadOnlyList<EmailAttachment>?>(a => a != null && a.Count == 1)), Times.Once);
+    }
+
+    [Fact]
+    public async Task GenerateAndStoreAsync_RenderThrows_RemovesNewRow()
+    {
+        var pdf = new Mock<IPdfRenderer>();
+        pdf.Setup(p => p.RenderAsync(It.IsAny<string>())).ThrowsAsync(new Exception("chromium gone"));
+        var (svc, db, email, _) = Create(pdf);
+        var order = await SeedPaidOrderAsync(db);
+
+        await Assert.ThrowsAsync<Exception>(() => svc.GenerateAndStoreAsync(order.Id));
+
+        Assert.Empty(db.Invoices);
         email.Verify(e => e.SendEmailAsync(
             It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
             It.IsAny<IReadOnlyList<EmailAttachment>?>()), Times.Never);
     }
 
     [Fact]
+    public async Task GenerateAndStoreAsync_OrphanEmptyRow_RetriesAndCleansUpOnFailure()
+    {
+        var pdf = new Mock<IPdfRenderer>();
+        pdf.Setup(p => p.RenderAsync(It.IsAny<string>())).ThrowsAsync(new Exception("chromium gone"));
+        var (svc, db, _, _) = Create(pdf);
+        var order = await SeedPaidOrderAsync(db);
+        db.Invoices.Add(new Invoice { OrderId = order.Id, IssuedAt = DateTime.UtcNow.AddHours(-1), PdfData = [] });
+        await db.SaveChangesAsync();
+
+        await Assert.ThrowsAsync<Exception>(() => svc.GenerateAndStoreAsync(order.Id));
+
+        // Empty orphan row was treated as not-generated, render attempted, render
+        // failed, and the still-empty row was cleaned up so the next retry isn't
+        // blocked.
+        Assert.Empty(db.Invoices);
+        pdf.Verify(p => p.RenderAsync(It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GenerateAndStoreAsync_OrphanEmptyRow_ThenRenderSucceeds_FillsRow()
+    {
+        var (svc, db, _, pdf) = Create();
+        var order = await SeedPaidOrderAsync(db);
+        var orphan = new Invoice { OrderId = order.Id, IssuedAt = DateTime.UtcNow.AddHours(-1), PdfData = [] };
+        db.Invoices.Add(orphan);
+        await db.SaveChangesAsync();
+
+        var id = await svc.GenerateAndStoreAsync(order.Id);
+
+        Assert.Equal(orphan.Id, id);
+        var saved = await db.Invoices.SingleAsync();
+        Assert.Equal(new byte[] { 1, 2, 3 }, saved.PdfData);
+        pdf.Verify(p => p.RenderAsync(It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GenerateAndStoreAsync_ForceRegenerateOnExistingInvoice_KeepsRowOnRenderFail()
+    {
+        var pdf = new Mock<IPdfRenderer>();
+        pdf.Setup(p => p.RenderAsync(It.IsAny<string>())).ThrowsAsync(new Exception("chromium gone"));
+        var (svc, db, _, _) = Create(pdf);
+        var order = await SeedPaidOrderAsync(db);
+        var existing = new Invoice { OrderId = order.Id, IssuedAt = DateTime.UtcNow.AddDays(-1), PdfData = [9, 9, 9] };
+        db.Invoices.Add(existing);
+        await db.SaveChangesAsync();
+
+        await Assert.ThrowsAsync<Exception>(() => svc.GenerateAndStoreAsync(order.Id, force: true));
+
+        // Force regenerate over a complete invoice must NOT throw away the existing
+        // PDF bytes when the new render fails.
+        var saved = await db.Invoices.SingleAsync();
+        Assert.Equal(existing.Id, saved.Id);
+        Assert.Equal(new byte[] { 9, 9, 9 }, saved.PdfData);
+    }
+
+    [Fact]
     public async Task GenerateAndStoreAsync_OrderMissing_Throws()
     {
-        var (svc, _, _) = Create();
+        var (svc, _, _, _) = Create();
 
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => svc.GenerateAndStoreAsync(orderId: 99999));


### PR DESCRIPTION
## Summary
Order #9 reproduced the same Chromium-missing crash as #8, but this time the resilience PR (#178) didn't help — the webhook saw an `Invoice` row already exists and short-circuited, even though `PdfData` was empty. `InvoiceService` saves a placeholder row *before* rendering (to obtain the sequential id used in the PDF); when render throws, that empty row is left behind and blocks every subsequent retry.

This PR closes the gap:

- **`InvoiceService`** — idempotent short-circuit now requires `PdfData.Length > 0`, so empty placeholder rows are treated as "not generated yet" and re-rendered. The render call is wrapped in try/catch: on failure, the just-inserted (or still-empty orphan) row is removed before rethrowing, so the next attempt starts clean. Force-regenerate over a *complete* invoice keeps the prior PDF bytes when the new render throws.
- **`ShopController`** webhook recovery — `i.PdfData.Length > 0` instead of `AnyAsync`, same defensive intent.
- **`IPdfRenderer`** — extracted so the service is unit-testable without Chromium. The default `PuppeteerPdfRenderer` is the existing implementation.

## Test plan
- [x] `dotnet test` — 148/148 pass.
- [x] New `InvoiceServiceTests` cover: short-circuit on complete row, render+email happy path, render-fail removes new row, orphan empty row triggers retry, orphan + render fail still cleans up, force-regenerate keeps old bytes on render fail, missing-order throws.
- [ ] After deploy: hit `POST /api/shop/orders/8/invoice/regenerate` and `POST /api/shop/orders/9/invoice/regenerate` as admin. Expect both to recover (Chromium presence required — separate Dockerfile concern).
- [ ] Place a fresh test order, AUTHORIZE, capture, confirm single invoice email + single `Invoices` row.

## Notes
- This PR alone does **not** fix the root Chromium-missing problem in the pod image — that's a deployment / Dockerfile issue tracked separately. Without Chromium, regenerate calls will still throw, but the row will now be cleaned up and the next retry can succeed once Chromium is back.
- Order 9 currently has a stuck empty `Invoice` row in dev DB (and 8 likely too). After this PR lands, calling the regenerate endpoint on each will treat the row as not-generated and try again. With Chromium present, it'll succeed.
