### PR TITLE
fix: install google-chrome-stable instead of the chromium snap stub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,14 @@ WORKDIR /app
 EXPOSE 7297
 
 USER root
+# The aspnet:10.0 base image is Ubuntu 24.04, where the `chromium` apt package is
+# only a transitional snap stub that does not work in a container. Install Google
+# Chrome stable from Google's apt repo instead — it ships a real binary at a
+# stable path that PuppeteerSharp can launch.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        chromium \
+        wget \
+        gnupg \
+        ca-certificates \
         fonts-liberation \
         fonts-noto-color-emoji \
         libnss3 \
@@ -16,10 +22,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libxss1 \
         libgbm1 \
         libasound2t64 \
-        ca-certificates \
+    && wget -qO- https://dl.google.com/linux/linux_signing_key.pub \
+        | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg \
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
+        > /etc/apt/sources.list.d/google-chrome.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends google-chrome-stable \
     && rm -rf /var/lib/apt/lists/*
 
-ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable
 ENV PUPPETEER_SKIP_DOWNLOAD=true
 
 # This stage is used to build the service project


### PR DESCRIPTION
## Summary
Pod diagnostic confirmed the base image is Ubuntu 24.04, and on Ubuntu 24.04 the `chromium` apt package is only a transitional stub that points at the chromium snap (`chromium-browser` -> `chromium snap`). Snap doesn't work in containers, so `/usr/bin/chromium` was never a real binary — PuppeteerSharp's `Process.Start("/usr/bin/chromium")` threw `No such file or directory` on every invoice render, leaving orders #8 and #9 with empty placeholder Invoice rows and no email.

Switch the Dockerfile to install `google-chrome-stable` from Google's apt repo. Real binary at `/usr/bin/google-chrome-stable`, well-tested in containers. Update `PUPPETEER_EXECUTABLE_PATH` to match.

```text
=== os-release ===
PRETTY_NAME="Ubuntu 24.04.4 LTS"
=== dpkg chromium ===
ii  chromium-browser  2:1snap1-0ubuntu2  amd64  Transitional package - chromium-browser -> chromium snap
=== which ===
/usr/bin/chromium-browser  (stub, not executable)
```

## Test plan
- [ ] CI rebuilds the image and the apt step prints `Setting up google-chrome-stable`.
- [ ] After deploy: `kubectl -n garge-dev exec <pod> -- /usr/bin/google-chrome-stable --version` prints a version string.
- [ ] After deploy: `POST /api/shop/orders/8/invoice/regenerate` and `POST /api/shop/orders/9/invoice/regenerate` as admin → expect `200 { invoiceId: ... }` and the buyer receives the invoice email with PDF attached. (Requires PR #179 — empty-row recovery — to be in the same release; otherwise the existing empty placeholder rows in dev DB will short-circuit.)
- [ ] Place a fresh test order, AUTHORIZE in Vipps test, capture from `/admin/orders` → invoice email arrives, single Invoices row populated.

## Notes
- This fix lives in the runtime stage of the multi-stage Dockerfile, so the build/publish stages aren't slowed down.
- Pairs naturally with PR #179 (`fix/invoice-empty-row-recovery`) — that PR makes the service tolerate empty placeholder rows that the broken Chromium install left behind, and this PR makes the render itself succeed.
