### PR TITLE
fix: webhook EF translation crash and PDF render timeout

### DIFF
--- a/Controllers/ShopController.cs
+++ b/Controllers/ShopController.cs
@@ -456,13 +456,12 @@ namespace garge_api.Controllers
             }
             else if (payload.Name == "CAPTURED" && order.Status == OrderStatus.Paid)
             {
-                var hasInvoice = await _context.Invoices.AnyAsync(i =>
-                    i.OrderId == order.Id && i.PdfData.Length > 0);
-                if (!hasInvoice)
-                {
-                    _logger.LogInformation("Order {OrderId} already Paid but no invoice — generating from webhook", order.Id);
-                    await TryGenerateInvoiceAsync(order.Id, "webhook recovery");
-                }
+                // Order already Paid (admin captured first, or this is a webhook
+                // redelivery). Service is idempotent: short-circuits on a complete
+                // existing invoice, otherwise renders. Empty placeholder rows from
+                // a prior failed render are cleaned up inside the service.
+                _logger.LogInformation("Webhook recovery check for order {OrderId}", order.Id);
+                await TryGenerateInvoiceAsync(order.Id, "webhook recovery");
             }
             else if (prevStatus != OrderStatus.Reserved && order.Status == OrderStatus.Reserved)
             {

--- a/Services/PuppeteerPdfRenderer.cs
+++ b/Services/PuppeteerPdfRenderer.cs
@@ -23,7 +23,7 @@ namespace garge_api.Services
             await using var page = await browser.NewPageAsync();
             await page.SetContentAsync(html, new NavigationOptions
             {
-                WaitUntil = [WaitUntilNavigation.Networkidle0]
+                WaitUntil = [WaitUntilNavigation.Load]
             });
 
             return await page.PdfDataAsync(new PdfOptions

--- a/garge-api.Tests/ShopControllerTests.cs
+++ b/garge-api.Tests/ShopControllerTests.cs
@@ -223,8 +223,11 @@ public class ShopControllerTests : ControllerTestBase
     }
 
     [Fact]
-    public async Task Webhook_CapturedEvent_ExistingInvoice_DoesNotGenerate()
+    public async Task Webhook_CapturedEvent_ExistingInvoice_DelegatesToIdempotentService()
     {
+        // Webhook now unconditionally calls GenerateAndStoreAsync when an order is
+        // already Paid; the service short-circuits when a complete invoice exists.
+        // Verify the controller delegates rather than duplicating the check.
         using var db = CreateDbContext();
         var order = new Order
         {
@@ -237,6 +240,7 @@ public class ShopControllerTests : ControllerTestBase
         await db.SaveChangesAsync();
 
         var invoice = new Mock<IInvoiceService>();
+        invoice.Setup(i => i.GenerateAndStoreAsync(order.Id, false)).ReturnsAsync(1);
 
         var payload = new
         {
@@ -254,7 +258,7 @@ public class ShopControllerTests : ControllerTestBase
 
         await ctrl.Webhook();
 
-        invoice.Verify(i => i.GenerateAndStoreAsync(It.IsAny<int>(), It.IsAny<bool>()), Times.Never);
+        invoice.Verify(i => i.GenerateAndStoreAsync(order.Id, false), Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Two regressions on the invoice path:

1. **Webhook 500** — the recovery check
   `Invoices.AnyAsync(i => i.OrderId == order.Id && i.PdfData.Length > 0)`
   couldn't be translated by Npgsql (`byte[].Length` over `bytea` ends up as `.Any()` in the LINQ tree and falls outside the provider's translation set). Every CAPTURED webhook returned 500.
   Fix: drop the client-side check. `InvoiceService` is already idempotent and cleans up empty placeholder rows on render failure, so the controller can call `GenerateAndStoreAsync` unconditionally and let the service decide whether to short-circuit. Simpler and avoids the EF translation gotcha.

2. **30 s render timeout** — Chrome installed and launched fine after PR #180, but `SetContentAsync` was waiting for `Networkidle0` (no network connections for 500 ms). The invoice template is inline HTML/CSS with no external resources, yet headless Chrome held the page open long enough for the 30 s nav timeout to fire on every render.
   Fix: switch the wait condition to `Load` — DOM + initial resources, which is all the self-contained template needs.

## Test plan
- [x] `dotnet test` — 148/148 pass.
- [x] Updated `Webhook_CapturedEvent_ExistingInvoice_DelegatesToIdempotentService` to assert the controller calls `GenerateAndStoreAsync(order.Id, false)` once and lets the service decide.
- [ ] After deploy: capture an order, watch logs for `Invoice {InvoiceId} generated for order {OrderId}` (no Networkidle0 timeout, no EF translation 500). Buyer receives invoice email with attached PDF.
- [ ] After deploy: `POST /api/shop/orders/8/invoice/regenerate` and `/9/invoice/regenerate` to recover the orders that were stuck since before the Chrome fix.

## Notes
- Stale empty `Invoice` rows for orders 8/9 will be cleaned by the service on the next regenerate call (PR #179 behavior).
- This finishes the chain: #178 (resilience) + #179 (empty-row cleanup) + #180 (real Chrome) + this (translation + render-wait).
