### PR TITLE
refactor: drop the 'Not VAT registered' invoice footnote

### DIFF
--- a/Services/InvoiceService.cs
+++ b/Services/InvoiceService.cs
@@ -149,10 +149,6 @@ namespace garge_api.Services
                   """
                 : string.Empty;
 
-            var vatFootnote = s.VatEnabled
-                ? string.Empty
-                : "<p>Not VAT registered — below the NOK 50,000 registration threshold.</p>";
-
             var deliveryNote = order.ShippedAt.HasValue
                 ? $"Shipped on {order.ShippedAt.Value:yyyy-MM-dd}."
                 : "Estimated delivery: 3–5 business days from shipment.";
@@ -300,7 +296,6 @@ namespace garge_api.Services
                 <div class="footer">
                   <p>Payment received via Vipps.</p>
                   <p>Delivery address: {{H(order.ShippingAddress)}} — {{deliveryNote}}</p>
-                  {{vatFootnote}}
                 </div>
 
                 </body>


### PR DESCRIPTION
## Summary
Drop the awkward `Not VAT registered — below the NOK 50,000 registration threshold.` footnote from the invoice template. Norwegian `bokføringsforskriften §5-1-1` doesn't require a non-registered seller to declare non-registration on the invoice; omitting the VAT lines is itself the signal. The footnote read like an apology and added clutter.

The other VAT-conditional branches in `BuildInvoiceHtml` (org-line MVA suffix, VAT columns, subtotal rows) are unchanged and still render when `AppSettings.VatEnabled` is flipped on.

## Test plan
- [x] `dotnet test` — 148/148 pass.
- [ ] After deploy: capture an order with `VatEnabled = false` (current state). Footer reads only `Payment received via Vipps.` and the delivery line. No VAT footnote.
- [ ] Optional: flip `VatEnabled = true` in a test DB and confirm the VAT columns + subtotals still render.
