### PR TITLE
style: invoice header to #182232 (Garge surface, not sky accent)

### DIFF
--- a/Services/InvoiceService.cs
+++ b/Services/InvoiceService.cs
@@ -169,7 +169,7 @@ namespace garge_api.Services
                   body { font-family: Arial, Helvetica, sans-serif; font-size: 12px; color: #1a1a1a; background: #fff; }
 
                   .header-band {
-                    background: #0284c7;
+                    background: #182232;
                     color: #fff;
                     padding: 28px 32px 20px;
                     display: flex;


### PR DESCRIPTION
Move invoice header band from sky-600 (`#0284c7`) to `#182232` — the dark navy slate that's actually the dominant surface tone in the Garge app. Sky-600 stays as the accent color for table heads, party labels, and totals row, preserving the visual link to the primary buttons in the dashboard.

Single CSS value change in the inline invoice template.

- [x] `dotnet test` — 148/148 pass.
- [ ] After deploy: regenerate an invoice, eyeball the PDF + email — header band should be deep navy, accent rows still sky.
