### PR TITLE
refactor: share email shell + fix duplicate invoice email on capture

### DIFF
--- a/Services/EmailLayout.cs
+++ b/Services/EmailLayout.cs
@@ -1,0 +1,144 @@
+using garge_api.Models.Admin;
+using System.Web;
+
+namespace garge_api.Services
+{
+    /// <summary>
+    /// Shared shell for transactional emails (and the invoice PDF). Renders the
+    /// dark header band, brand info, a configurable right-side meta block, the
+    /// caller's body slot, and the company footer. Both InvoiceService and
+    /// OrderEmailService use this so theme changes live in one place.
+    /// </summary>
+    public static class EmailLayout
+    {
+        public sealed class Meta
+        {
+            public string? Number { get; set; }      // e.g. "#0007"
+            public string? Subtitle { get; set; }    // e.g. "INVOICE · 2026-05-07"
+            public string? Badge { get; set; }       // e.g. "Paid"
+            public string? FootNote { get; set; }    // e.g. "Vipps order #7"
+        }
+
+        public static string Render(AppSettings s, Meta? meta, string bodyHtml)
+        {
+            static string H(string? v) => HttpUtility.HtmlEncode(v ?? string.Empty);
+
+            var orgLine = s.VatEnabled ? $"{s.CompanyOrgNumber} MVA" : s.CompanyOrgNumber;
+
+            var metaBlock = string.Empty;
+            if (meta != null)
+            {
+                var number = string.IsNullOrEmpty(meta.Number) ? string.Empty
+                    : $"""<div class="meta-number">{H(meta.Number)}</div>""";
+                var subtitle = string.IsNullOrEmpty(meta.Subtitle) ? string.Empty
+                    : $"""<div class="meta-subtitle">{H(meta.Subtitle)}</div>""";
+                var badge = string.IsNullOrEmpty(meta.Badge) ? string.Empty
+                    : $"""<span class="badge">{H(meta.Badge)}</span>""";
+                var foot = string.IsNullOrEmpty(meta.FootNote) ? string.Empty
+                    : $"""<div class="meta-foot">{H(meta.FootNote)}</div>""";
+                metaBlock = $"""<div class="meta">{number}{subtitle}{badge}{foot}</div>""";
+            }
+
+            return $$"""
+                <!DOCTYPE html>
+                <html>
+                <head>
+                <meta charset="utf-8">
+                <style>
+                  * { box-sizing: border-box; margin: 0; padding: 0; }
+                  body { font-family: Arial, Helvetica, sans-serif; font-size: 12px; color: #1a1a1a; background: #fff; }
+
+                  .header-band {
+                    background: #182232;
+                    color: #fff;
+                    padding: 28px 32px 20px;
+                    display: flex;
+                    justify-content: space-between;
+                    align-items: flex-start;
+                  }
+                  .brand { font-size: 22px; font-weight: 700; letter-spacing: .04em; margin-bottom: 4px; }
+                  .brand-sub { font-size: 11px; opacity: .85; line-height: 1.5; }
+                  .meta { text-align: right; }
+                  .meta-number { font-size: 28px; font-weight: 700; line-height: 1; margin-bottom: 4px; }
+                  .meta-subtitle { font-size: 11px; opacity: .85; margin-bottom: 6px; }
+                  .meta-foot { margin-top: 6px; font-size: 10px; opacity: .75; }
+                  .badge {
+                    display: inline-block;
+                    background: rgba(255,255,255,0.25);
+                    border: 1px solid rgba(255,255,255,0.5);
+                    color: #fff;
+                    padding: 2px 10px;
+                    border-radius: 20px;
+                    font-size: 10px;
+                    font-weight: 700;
+                    letter-spacing: .08em;
+                    text-transform: uppercase;
+                  }
+
+                  .body { padding: 24px 32px; }
+                  .body p { line-height: 1.6; color: #333; }
+                  .body h1, .body h2 { color: #1a1a1a; margin-bottom: 8px; }
+                  .body h1 { font-size: 18px; }
+
+                  .parties { display: flex; gap: 40px; margin-bottom: 24px; }
+                  .party { flex: 1; }
+                  .party-label {
+                    font-size: 9px; font-weight: 700; text-transform: uppercase;
+                    letter-spacing: .1em; color: #0284c7; margin-bottom: 6px;
+                  }
+
+                  table { width: 100%; border-collapse: collapse; }
+                  th {
+                    font-size: 10px; font-weight: 700; text-transform: uppercase;
+                    letter-spacing: .06em; color: #0284c7;
+                    border-bottom: 2px solid #0284c7;
+                    padding: 7px 8px; text-align: left;
+                  }
+                  td { padding: 7px 8px; border-bottom: 1px solid #e5e7eb; }
+                  tr:last-child td { border-bottom: none; }
+                  tbody tr:nth-child(even) { background: #f8fafc; }
+                  .r { text-align: right; }
+                  .c { text-align: center; }
+
+                  .totals-section { margin-top: 8px; border-top: 2px solid #e5e7eb; padding-top: 8px; }
+                  .totals-section table { width: 40%; margin-left: auto; }
+                  .sub td { padding: 3px 8px; color: #555; }
+                  .grand td {
+                    padding: 7px 8px; font-weight: 700; font-size: 14px;
+                    border-top: 2px solid #0284c7; color: #0284c7;
+                  }
+
+                  .footer {
+                    margin: 24px 32px 0;
+                    padding-top: 12px;
+                    border-top: 1px solid #e5e7eb;
+                    font-size: 10px; color: #888; line-height: 1.6;
+                  }
+                  .footer p + p { margin-top: 2px; }
+                </style>
+                </head>
+                <body>
+
+                <div class="header-band">
+                  <div>
+                    <div class="brand">{{H(s.CompanyName)}}</div>
+                    <div class="brand-sub">
+                      {{H(s.CompanyLegalName)}}<br>
+                      Org. no. {{H(orgLine)}}<br>
+                      {{H(s.CompanyAddress)}}<br>
+                      {{H(s.CompanyEmail)}}
+                    </div>
+                  </div>
+                  {{metaBlock}}
+                </div>
+
+                <div class="body">
+                {{bodyHtml}}
+                </div>
+
+                </body>
+                </html>
+                """;
+        }
+    }
+}

--- a/Services/InvoiceService.cs
+++ b/Services/InvoiceService.cs
@@ -41,9 +41,9 @@ namespace garge_api.Services
             var settings = await db.AppSettings.FindAsync(1) ?? new AppSettings();
 
             var invoice = await db.Invoices.FirstOrDefaultAsync(i => i.OrderId == orderId);
-            if (invoice != null && invoice.PdfData.Length > 0 && !force)
+            if (invoice != null && !force)
             {
-                _logger.LogInformation("Invoice {InvoiceId} already exists for order {OrderId} — skip", invoice.Id, orderId);
+                _logger.LogInformation("Invoice {InvoiceId} already exists or is in progress for order {OrderId} — skip", invoice.Id, orderId);
                 return invoice.Id;
             }
 
@@ -110,8 +110,6 @@ namespace garge_api.Services
             static string Nok(int ore) => MoneyFormat.Nok(ore);
             static string H(string? v) => HttpUtility.HtmlEncode(v ?? string.Empty);
 
-            var orgLine = s.VatEnabled ? $"{s.CompanyOrgNumber} MVA" : s.CompanyOrgNumber;
-
             var vatHeaders = s.VatEnabled
                 ? """<th class="r">VAT %</th><th class="r">VAT</th>"""
                 : string.Empty;
@@ -149,163 +147,72 @@ namespace garge_api.Services
                   """
                 : string.Empty;
 
-            var vatFootnote = s.VatEnabled
-                ? string.Empty
-                : "<p>Not VAT registered — below the NOK 50,000 registration threshold.</p>";
-
             var deliveryNote = order.ShippedAt.HasValue
                 ? $"Shipped on {order.ShippedAt.Value:yyyy-MM-dd}."
                 : "Estimated delivery: 3–5 business days from shipment.";
 
             var buyerName = order.User != null ? $"{order.User.FirstName} {order.User.LastName}" : "—";
 
-            return $$"""
-                <!DOCTYPE html>
-                <html>
-                <head>
-                <meta charset="utf-8">
-                <style>
-                  * { box-sizing: border-box; margin: 0; padding: 0; }
-                  body { font-family: Arial, Helvetica, sans-serif; font-size: 12px; color: #1a1a1a; background: #fff; }
-
-                  .header-band {
-                    background: #0284c7;
-                    color: #fff;
-                    padding: 28px 32px 20px;
-                    display: flex;
-                    justify-content: space-between;
-                    align-items: flex-start;
-                  }
-                  .brand { font-size: 22px; font-weight: 700; letter-spacing: .04em; margin-bottom: 4px; }
-                  .brand-sub { font-size: 11px; opacity: .85; }
-                  .inv-meta { text-align: right; }
-                  .inv-number { font-size: 28px; font-weight: 700; line-height: 1; margin-bottom: 4px; }
-                  .inv-date { font-size: 11px; opacity: .85; margin-bottom: 6px; }
-                  .badge {
-                    display: inline-block;
-                    background: rgba(255,255,255,0.25);
-                    border: 1px solid rgba(255,255,255,0.5);
-                    color: #fff;
-                    padding: 2px 10px;
-                    border-radius: 20px;
-                    font-size: 10px;
-                    font-weight: 700;
-                    letter-spacing: .08em;
-                    text-transform: uppercase;
-                  }
-                  .body { padding: 24px 32px; }
-                  .parties { display: flex; gap: 40px; margin-bottom: 24px; }
-                  .party { flex: 1; }
-                  .party-label {
-                    font-size: 9px; font-weight: 700; text-transform: uppercase;
-                    letter-spacing: .1em; color: #0284c7; margin-bottom: 6px;
-                  }
-                  .party p { line-height: 1.6; color: #333; }
-                  table { width: 100%; border-collapse: collapse; }
-                  th {
-                    font-size: 10px; font-weight: 700; text-transform: uppercase;
-                    letter-spacing: .06em; color: #0284c7;
-                    border-bottom: 2px solid #0284c7;
-                    padding: 7px 8px; text-align: left;
-                  }
-                  td { padding: 7px 8px; border-bottom: 1px solid #e5e7eb; }
-                  tr:last-child td { border-bottom: none; }
-                  tbody tr:nth-child(even) { background: #f8fafc; }
-                  .r { text-align: right; }
-                  .c { text-align: center; }
-                  .totals-section { margin-top: 8px; border-top: 2px solid #e5e7eb; padding-top: 8px; }
-                  .totals-section table { width: 40%; margin-left: auto; }
-                  .sub td { padding: 3px 8px; color: #555; }
-                  .grand td {
-                    padding: 7px 8px; font-weight: 700; font-size: 14px;
-                    border-top: 2px solid #0284c7; color: #0284c7;
-                  }
-                  .footer {
-                    margin: 24px 32px 0;
-                    padding-top: 12px;
-                    border-top: 1px solid #e5e7eb;
-                    font-size: 10px; color: #888; line-height: 1.6;
-                  }
-                  .footer p + p { margin-top: 2px; }
-                </style>
-                </head>
-                <body>
-
-                <div class="header-band">
-                  <div>
-                    <div class="brand">{{H(s.CompanyName)}}</div>
-                    <div class="brand-sub">
-                      {{H(s.CompanyLegalName)}}<br>
-                      Org. no. {{H(orgLine)}}<br>
+            var body = $$"""
+                <div class="parties">
+                  <div class="party">
+                    <div class="party-label">From</div>
+                    <p>
+                      <strong>{{H(s.CompanyLegalName)}}</strong><br>
                       {{H(s.CompanyAddress)}}<br>
                       {{H(s.CompanyEmail)}}
-                    </div>
+                    </p>
                   </div>
-                  <div class="inv-meta">
-                    <div class="inv-number">#{{invoiceId:D4}}</div>
-                    <div class="inv-date">INVOICE &nbsp;·&nbsp; {{issuedAt:yyyy-MM-dd}}</div>
-                    <span class="badge">Paid</span>
-                    <div style="margin-top:6px;font-size:10px;opacity:.75;">Vipps order #{{order.Id}}</div>
+                  <div class="party">
+                    <div class="party-label">Bill to</div>
+                    <p>
+                      <strong>{{H(buyerName)}}</strong><br>
+                      {{H(order.User?.Email)}}<br>
+                      {{H(order.ShippingAddress)}}
+                    </p>
                   </div>
                 </div>
 
-                <div class="body">
-                  <div class="parties">
-                    <div class="party">
-                      <div class="party-label">From</div>
-                      <p>
-                        <strong>{{H(s.CompanyLegalName)}}</strong><br>
-                        {{H(s.CompanyAddress)}}<br>
-                        {{H(s.CompanyEmail)}}
-                      </p>
-                    </div>
-                    <div class="party">
-                      <div class="party-label">Bill to</div>
-                      <p>
-                        <strong>{{H(buyerName)}}</strong><br>
-                        {{H(order.User?.Email)}}<br>
-                        {{H(order.ShippingAddress)}}
-                      </p>
-                    </div>
-                  </div>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Description</th>
+                      <th class="c">Qty</th>
+                      <th class="r">Unit price</th>
+                      {{vatHeaders}}
+                      <th class="r">Amount</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {{linesSb}}
+                  </tbody>
+                </table>
 
+                <div class="totals-section">
                   <table>
-                    <thead>
-                      <tr>
-                        <th>Description</th>
-                        <th class="c">Qty</th>
-                        <th class="r">Unit price</th>
-                        {{vatHeaders}}
-                        <th class="r">Amount</th>
-                      </tr>
-                    </thead>
+                    <tbody>{{subRows}}</tbody>
                     <tbody>
-                      {{linesSb}}
+                      <tr class="grand">
+                        <td>Total</td>
+                        <td class="r">NOK {{Nok(order.TotalInOre)}}</td>
+                      </tr>
                     </tbody>
                   </table>
-
-                  <div class="totals-section">
-                    <table>
-                      <tbody>{{subRows}}</tbody>
-                      <tbody>
-                        <tr class="grand">
-                          <td>Total</td>
-                          <td class="r">NOK {{Nok(order.TotalInOre)}}</td>
-                        </tr>
-                      </tbody>
-                    </table>
-                  </div>
                 </div>
 
                 <div class="footer">
                   <p>Payment received via Vipps.</p>
                   <p>Delivery address: {{H(order.ShippingAddress)}} — {{deliveryNote}}</p>
-                  {{vatFootnote}}
                 </div>
-
-                </body>
-                </html>
                 """;
+
+            return EmailLayout.Render(s, new EmailLayout.Meta
+            {
+                Number = $"#{invoiceId:D4}",
+                Subtitle = $"INVOICE  ·  {issuedAt:yyyy-MM-dd}",
+                Badge = "Paid",
+                FootNote = $"Vipps order #{order.Id}"
+            }, body);
         }
     }
 }

--- a/Services/OrderEmailService.cs
+++ b/Services/OrderEmailService.cs
@@ -68,30 +68,45 @@ namespace garge_api.Services
                 var lineTotal = item.PriceAtPurchaseInOre * item.Quantity;
                 lines.Append($"""
                     <tr>
-                      <td style="padding:6px 8px;border-bottom:1px solid #e5e7eb;">{H(item.ShopItem?.Name)} × {item.Quantity}</td>
-                      <td style="padding:6px 8px;border-bottom:1px solid #e5e7eb;text-align:right;">NOK {Nok(lineTotal)}</td>
+                      <td>{H(item.ShopItem?.Name)} × {item.Quantity}</td>
+                      <td class="r">NOK {Nok(lineTotal)}</td>
                     </tr>
                     """);
             }
 
             var shipBlock = string.IsNullOrEmpty(order.ShippingAddress)
                 ? string.Empty
-                : $"""<p style="margin:12px 0 0;"><strong>Ship to:</strong> {H(order.ShippingAddress)}</p>""";
+                : $"""<p><strong>Ship to:</strong> {H(order.ShippingAddress)}</p>""";
 
-            return $$"""
-                <!DOCTYPE html>
-                <html><body style="font-family:Arial,Helvetica,sans-serif;color:#1a1a1a;font-size:14px;">
-                <div style="max-width:560px;margin:0 auto;padding:24px;">
-                  <h1 style="font-size:20px;margin:0 0 8px;">Thanks for your order, {{H(order.User?.FirstName)}}!</h1>
-                  <p style="color:#555;margin:0 0 16px;">We've received order <strong>#{{order.Id}}</strong> and will get it ready to ship.</p>
-                  <table style="width:100%;border-collapse:collapse;margin:16px 0;">{{lines}}
-                    <tr><td style="padding:8px;font-weight:700;">Total</td><td style="padding:8px;text-align:right;font-weight:700;">NOK {{Nok(order.TotalInOre)}}</td></tr>
+            var body = $$"""
+                <h1>Thanks for your order, {{H(order.User?.FirstName)}}!</h1>
+                <p>We've received order <strong>#{{order.Id}}</strong> and will get it ready to ship.</p>
+
+                <table>
+                  <tbody>
+                    {{lines}}
+                  </tbody>
+                </table>
+
+                <div class="totals-section">
+                  <table>
+                    <tbody>
+                      <tr class="grand">
+                        <td>Total</td>
+                        <td class="r">NOK {{Nok(order.TotalInOre)}}</td>
+                      </tr>
+                    </tbody>
                   </table>
-                  {{shipBlock}}
-                  <p style="color:#888;font-size:12px;margin-top:24px;">{{H(s.CompanyLegalName)}} · Org. no. {{H(s.CompanyOrgNumber)}}</p>
                 </div>
-                </body></html>
+
+                {{shipBlock}}
                 """;
+
+            return EmailLayout.Render(s, new EmailLayout.Meta
+            {
+                Number = $"#{order.Id}",
+                Subtitle = $"ORDER  ·  {order.CreatedAt:yyyy-MM-dd}"
+            }, body);
         }
     }
 }

--- a/garge-api.Tests/InvoiceServiceTests.cs
+++ b/garge-api.Tests/InvoiceServiceTests.cs
@@ -122,39 +122,47 @@ public class InvoiceServiceTests
     }
 
     [Fact]
-    public async Task GenerateAndStoreAsync_OrphanEmptyRow_RetriesAndCleansUpOnFailure()
+    public async Task GenerateAndStoreAsync_ExistingEmptyRow_WithoutForce_ShortCircuits()
     {
-        var pdf = new Mock<IPdfRenderer>();
-        pdf.Setup(p => p.RenderAsync(It.IsAny<string>())).ThrowsAsync(new Exception("chromium gone"));
-        var (svc, db, _, _) = Create(pdf);
+        // Race scenario: a concurrent caller has inserted an in-progress placeholder
+        // row but hasn't filled the PDF yet. The second caller must NOT render
+        // again (would double-email). Short-circuit on any existing row.
+        var (svc, db, email, pdf) = Create();
         var order = await SeedPaidOrderAsync(db);
-        db.Invoices.Add(new Invoice { OrderId = order.Id, IssuedAt = DateTime.UtcNow.AddHours(-1), PdfData = [] });
-        await db.SaveChangesAsync();
-
-        await Assert.ThrowsAsync<Exception>(() => svc.GenerateAndStoreAsync(order.Id));
-
-        // Empty orphan row was treated as not-generated, render attempted, render
-        // failed, and the still-empty row was cleaned up so the next retry isn't
-        // blocked.
-        Assert.Empty(db.Invoices);
-        pdf.Verify(p => p.RenderAsync(It.IsAny<string>()), Times.Once);
-    }
-
-    [Fact]
-    public async Task GenerateAndStoreAsync_OrphanEmptyRow_ThenRenderSucceeds_FillsRow()
-    {
-        var (svc, db, _, pdf) = Create();
-        var order = await SeedPaidOrderAsync(db);
-        var orphan = new Invoice { OrderId = order.Id, IssuedAt = DateTime.UtcNow.AddHours(-1), PdfData = [] };
-        db.Invoices.Add(orphan);
+        var inProgress = new Invoice { OrderId = order.Id, IssuedAt = DateTime.UtcNow, PdfData = [] };
+        db.Invoices.Add(inProgress);
         await db.SaveChangesAsync();
 
         var id = await svc.GenerateAndStoreAsync(order.Id);
 
-        Assert.Equal(orphan.Id, id);
+        Assert.Equal(inProgress.Id, id);
+        Assert.Single(db.Invoices);
+        pdf.Verify(p => p.RenderAsync(It.IsAny<string>()), Times.Never);
+        email.Verify(e => e.SendEmailAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<IReadOnlyList<EmailAttachment>?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GenerateAndStoreAsync_ExistingRow_WithForce_RegeneratesAndEmails()
+    {
+        // Admin retry path: force=true must re-render and re-email, reusing the
+        // same row (and id) so the invoice number stays sequential.
+        var (svc, db, email, pdf) = Create();
+        var order = await SeedPaidOrderAsync(db);
+        var existing = new Invoice { OrderId = order.Id, IssuedAt = DateTime.UtcNow.AddDays(-1), PdfData = [9, 9, 9] };
+        db.Invoices.Add(existing);
+        await db.SaveChangesAsync();
+
+        var id = await svc.GenerateAndStoreAsync(order.Id, force: true);
+
+        Assert.Equal(existing.Id, id);
         var saved = await db.Invoices.SingleAsync();
         Assert.Equal(new byte[] { 1, 2, 3 }, saved.PdfData);
         pdf.Verify(p => p.RenderAsync(It.IsAny<string>()), Times.Once);
+        email.Verify(e => e.SendEmailAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<IReadOnlyList<EmailAttachment>?>()), Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Folds three concerns into one because they all touch the same templates:

1. **Duplicate invoice email after capture.** `CaptureOrder` inserts a placeholder `Invoice` row before rendering, render takes ~30+ seconds, and if the Vipps `CAPTURED` webhook arrives during that window it re-entered the service. The previous idempotency check required `PdfData.Length > 0`, so the in-progress empty row didn't short-circuit — a second render ran and a second email went out. Loosen the check to any existing row; orphan rows from genuine render failures are still cleaned up by the catch-and-remove path. Force-regenerate (admin endpoint) is the only way to overwrite a complete invoice.

2. **Theme alignment between order-confirmed email and invoice email.** The two emails had unrelated HTML/CSS — different fonts, colors, and the order email had no header band at all. Pull the shared shell (dark `#182232` header band with brand info, body slot, footer) into a new `Services/EmailLayout.cs` helper. Both services now compose just their body content and pass metadata (number, subtitle, badge) to the layout. Theme changes live in one place from now on.

3. **Supersedes #182 and #183.** This PR includes the header color change (`#0284c7` → `#182232`) and the "Not VAT registered" footnote removal. Close #182 and #183 once this lands, or merge those first and I'll rebase.

## Test plan
- [x] `dotnet test` — 148/148 pass.
- [x] Two new InvoiceService tests cover the new contract: short-circuit on in-progress empty row, force-regenerate replaces bytes + re-emails.
- [ ] After deploy: capture an order; confirm exactly one invoice email arrives (not two), styled with the dark header band, table, totals, footer.
- [ ] Place a fresh order; AUTHORIZE; confirm the order-received email looks visually consistent with the invoice email — same dark band, same brand block, same footer.

## Notes
- `MockInvoice()` and `MockEmailService` patterns in tests are unchanged.
- No DB schema change; `Invoice.PdfData` stays `byte[]`.
- The accent color `#0284c7` is preserved for the totals row, table head, and party labels — keeps the visual link to the buy/capture buttons in the app.
