### PR TITLE
feat: add order + subscription stats to /api/admin/stats

### DIFF
--- a/Controllers/AdminController.cs
+++ b/Controllers/AdminController.cs
@@ -1,4 +1,6 @@
 using garge_api.Models;
+using garge_api.Models.Shop;
+using garge_api.Models.Subscription;
 using garge_api.Dtos.Admin;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
@@ -239,12 +241,58 @@ namespace garge_api.Controllers
         {
             _logger.LogInformation("GetStats called by {@LogData}", new { User = User.Identity?.Name });
 
+            var now = DateTime.UtcNow;
+            var today = now.Date;
+            var monthStart = new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+            // Monday-start ISO week.
+            var weekStart = today.AddDays(-(((int)today.DayOfWeek + 6) % 7));
+
+            var totalUsers = await _userManager.Users.CountAsync();
+            var totalSensors = await _context.Sensors.CountAsync();
+            var totalSwitches = await _context.Switches.CountAsync();
+            var activeAutomations = await _context.AutomationRules.CountAsync(r => r.IsEnabled);
+
+            var orders = new AdminOrderStatsDto
+            {
+                Today = await _context.Orders.CountAsync(o => o.CreatedAt >= today),
+                ThisWeek = await _context.Orders.CountAsync(o => o.CreatedAt >= weekStart),
+                ThisMonth = await _context.Orders.CountAsync(o => o.CreatedAt >= monthStart),
+                PendingCapture = await _context.Orders.CountAsync(o => o.Status == OrderStatus.Reserved),
+                FailedOrCancelled = await _context.Orders.CountAsync(o =>
+                    o.Status == OrderStatus.Failed || o.Status == OrderStatus.Cancelled),
+                TotalRevenueInOre = await _context.Orders
+                    .Where(o => o.Status == OrderStatus.Paid)
+                    .SumAsync(o => (long)o.TotalInOre),
+                MonthRevenueInOre = await _context.Orders
+                    .Where(o => o.Status == OrderStatus.Paid && o.CreatedAt >= monthStart)
+                    .SumAsync(o => (long)o.TotalInOre),
+            };
+
+            var subscriptions = new AdminSubscriptionStatsDto
+            {
+                Active = await _context.Subscriptions.CountAsync(s => s.Status == SubscriptionStatus.Active),
+                PendingConfirm = await _context.Subscriptions.CountAsync(s => s.Status == SubscriptionStatus.Pending),
+                StoppedThisMonth = await _context.Subscriptions.CountAsync(s =>
+                    s.Status == SubscriptionStatus.Stopped && s.UpdatedAt >= monthStart),
+            };
+
+            var activeWithProduct = await _context.Subscriptions
+                .Where(s => s.Status == SubscriptionStatus.Active)
+                .Include(s => s.Product)
+                .Where(s => s.Product != null)
+                .Select(s => new { s.Product!.PriceInOre, s.Product.Interval })
+                .ToListAsync();
+            subscriptions.MonthlyRecurringInOre = activeWithProduct.Sum(p =>
+                p.Interval == BillingInterval.Yearly ? (long)(p.PriceInOre / 12) : (long)p.PriceInOre);
+
             var stats = new AdminStatsDto
             {
-                TotalUsers = await _userManager.Users.CountAsync(),
-                TotalSensors = await _context.Sensors.CountAsync(),
-                TotalSwitches = await _context.Switches.CountAsync(),
-                ActiveAutomations = await _context.AutomationRules.CountAsync(r => r.IsEnabled),
+                TotalUsers = totalUsers,
+                TotalSensors = totalSensors,
+                TotalSwitches = totalSwitches,
+                ActiveAutomations = activeAutomations,
+                Orders = orders,
+                Subscriptions = subscriptions,
             };
             return Ok(stats);
         }

--- a/Dtos/Admin/AdminStatsDto.cs
+++ b/Dtos/Admin/AdminStatsDto.cs
@@ -6,5 +6,27 @@ namespace garge_api.Dtos.Admin
         public int TotalSensors { get; set; }
         public int TotalSwitches { get; set; }
         public int ActiveAutomations { get; set; }
+
+        public AdminOrderStatsDto Orders { get; set; } = new();
+        public AdminSubscriptionStatsDto Subscriptions { get; set; } = new();
+    }
+
+    public class AdminOrderStatsDto
+    {
+        public int Today { get; set; }
+        public int ThisWeek { get; set; }
+        public int ThisMonth { get; set; }
+        public int PendingCapture { get; set; }
+        public int FailedOrCancelled { get; set; }
+        public long TotalRevenueInOre { get; set; }
+        public long MonthRevenueInOre { get; set; }
+    }
+
+    public class AdminSubscriptionStatsDto
+    {
+        public int Active { get; set; }
+        public int PendingConfirm { get; set; }
+        public int StoppedThisMonth { get; set; }
+        public long MonthlyRecurringInOre { get; set; }
     }
 }

--- a/garge-api.Tests/AdminControllerTests.cs
+++ b/garge-api.Tests/AdminControllerTests.cs
@@ -3,6 +3,8 @@ using garge_api.Controllers;
 using garge_api.Dtos.Admin;
 using garge_api.Models;
 using garge_api.Models.Admin;
+using garge_api.Models.Shop;
+using garge_api.Models.Subscription;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -141,5 +143,85 @@ public class AdminControllerTests : ControllerTestBase
         Assert.Equal("934 531 035", settings.CompanyOrgNumber);
         Assert.Equal("hello@garge.no", settings.CompanyEmail);
         Assert.Equal("must-not-disappear", settings.VippsShopWebhookSecret);
+    }
+
+    [Fact]
+    public async Task GetStats_PopulatesOrderStats()
+    {
+        var db = CreateDbContext();
+        MockUserManager.Setup(m => m.Users).Returns(db.Users);
+
+        var monthStart = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        db.Orders.AddRange(
+            new Order { UserId = "u1", Status = OrderStatus.Paid, TotalInOre = 50000, CreatedAt = DateTime.UtcNow },
+            new Order { UserId = "u1", Status = OrderStatus.Paid, TotalInOre = 30000, CreatedAt = DateTime.UtcNow },
+            new Order { UserId = "u1", Status = OrderStatus.Paid, TotalInOre = 12000, CreatedAt = monthStart.AddMonths(-2) },
+            new Order { UserId = "u1", Status = OrderStatus.Reserved, TotalInOre = 9900, CreatedAt = DateTime.UtcNow },
+            new Order { UserId = "u1", Status = OrderStatus.Failed, TotalInOre = 0, CreatedAt = DateTime.UtcNow },
+            new Order { UserId = "u1", Status = OrderStatus.Cancelled, TotalInOre = 0, CreatedAt = DateTime.UtcNow });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await CreateAdminController(db).GetStats();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var dto = Assert.IsType<AdminStatsDto>(ok.Value);
+        Assert.Equal(5, dto.Orders.Today);                 // 5 created today (paid x2, reserved, failed, cancelled)
+        Assert.Equal(1, dto.Orders.PendingCapture);
+        Assert.Equal(2, dto.Orders.FailedOrCancelled);
+        Assert.Equal(92000L, dto.Orders.TotalRevenueInOre); // 50000 + 30000 + 12000
+        Assert.Equal(80000L, dto.Orders.MonthRevenueInOre); // 50000 + 30000 (12000 was 2 months ago)
+    }
+
+    [Fact]
+    public async Task GetStats_PopulatesSubscriptionStats_AndComputesMrr()
+    {
+        var db = CreateDbContext();
+        MockUserManager.Setup(m => m.Users).Returns(db.Users);
+
+        var monthly = new Product { Id = 1, Name = "Garge Basic", PriceInOre = 29900, Interval = BillingInterval.Monthly, Type = ProductType.Primary, IsActive = true };
+        var yearly = new Product { Id = 2, Name = "Garge Yearly", PriceInOre = 299000, Interval = BillingInterval.Yearly, Type = ProductType.Primary, IsActive = true };
+        db.Products.AddRange(monthly, yearly);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        db.Subscriptions.AddRange(
+            new Subscription { UserId = "u1", ProductId = monthly.Id, VippsAgreementId = "agr-1", Status = SubscriptionStatus.Active },
+            new Subscription { UserId = "u2", ProductId = monthly.Id, VippsAgreementId = "agr-2", Status = SubscriptionStatus.Active },
+            new Subscription { UserId = "u3", ProductId = yearly.Id, VippsAgreementId = "agr-3", Status = SubscriptionStatus.Active },
+            new Subscription { UserId = "u4", ProductId = monthly.Id, VippsAgreementId = "agr-4", Status = SubscriptionStatus.Pending });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await CreateAdminController(db).GetStats();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var dto = Assert.IsType<AdminStatsDto>(ok.Value);
+        Assert.Equal(3, dto.Subscriptions.Active);
+        Assert.Equal(1, dto.Subscriptions.PendingConfirm);
+        // 2 * 29900 (monthly) + 299000 / 12 (yearly normalized) = 59800 + 24916 = 84716
+        Assert.Equal(29900L * 2 + 299000L / 12, dto.Subscriptions.MonthlyRecurringInOre);
+    }
+
+    [Fact]
+    public async Task GetStats_StoppedThisMonth_OnlyCountsCurrentMonth()
+    {
+        var db = CreateDbContext();
+        MockUserManager.Setup(m => m.Users).Returns(db.Users);
+
+        var monthStart = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var product = new Product { Id = 1, Name = "X", PriceInOre = 10000, Interval = BillingInterval.Monthly, Type = ProductType.Primary, IsActive = true };
+        db.Products.Add(product);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        db.Subscriptions.AddRange(
+            new Subscription { UserId = "u1", ProductId = 1, VippsAgreementId = "agr-old", Status = SubscriptionStatus.Stopped, UpdatedAt = monthStart.AddMonths(-1) },
+            new Subscription { UserId = "u2", ProductId = 1, VippsAgreementId = "agr-new", Status = SubscriptionStatus.Stopped, UpdatedAt = DateTime.UtcNow });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await CreateAdminController(db).GetStats();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var dto = Assert.IsType<AdminStatsDto>(ok.Value);
+        Assert.Equal(1, dto.Subscriptions.StoppedThisMonth);
     }
 }


### PR DESCRIPTION
## Summary
Extend `GET /api/admin/stats` so the `/admin` landing page can show commerce metrics alongside the existing user / sensor / switch / automation counts. Adds two nested blocks to `AdminStatsDto`:

- **Orders**: `today`, `thisWeek`, `thisMonth` counts; `pendingCapture` (`OrderStatus.Reserved`); `failedOrCancelled`; `totalRevenueInOre` and `monthRevenueInOre` (sums of `TotalInOre` where `Status = Paid`).
- **Subscriptions**: `active`, `pendingConfirm`, `stoppedThisMonth`, `monthlyRecurringInOre` (yearly products contribute `price / 12`, monthly contribute `price`).

Time windows are UTC-based (`UtcNow.Date` today, Monday-start ISO week, first-of-month). Norway TZ (Europe/Oslo) drift is ≤ 1 h off the admin's calendar — acceptable for v1; will revisit if month-end discrepancies show up.

## Test plan
- [x] `dotnet test` — 151/151 pass.
- [x] New tests: `GetStats_PopulatesOrderStats`, `GetStats_PopulatesSubscriptionStats_AndComputesMrr`, `GetStats_StoppedThisMonth_OnlyCountsCurrentMonth`.
- [ ] After deploy: `curl https://garge-api-dev.prod.tumogroup.com/api/admin/stats -H "Authorization: Bearer <admin-jwt>"` should return the new `orders` + `subscriptions` blocks. Numbers cross-check with `SELECT COUNT(*) FROM "Orders" WHERE "Status" = 1;` (Paid) and the Subscriptions table.

## Notes
- Frontend PR follows on `garge-app` to render the new blocks.
- No DB schema change. No new migrations.
