### PR TITLE
feat: filter admin stats by IsTest flag (live vs test toggle)

### DIFF
--- a/Controllers/AdminController.cs
+++ b/Controllers/AdminController.cs
@@ -237,9 +237,9 @@ namespace garge_api.Controllers
         [HttpGet("/api/admin/stats")]
         [SwaggerOperation(Summary = "Gets aggregate platform stats.")]
         [SwaggerResponse(200, "Stats retrieved successfully.", typeof(AdminStatsDto))]
-        public async Task<IActionResult> GetStats()
+        public async Task<IActionResult> GetStats([FromQuery] bool test = false)
         {
-            _logger.LogInformation("GetStats called by {@LogData}", new { User = User.Identity?.Name });
+            _logger.LogInformation("GetStats called by {@LogData}", new { User = User.Identity?.Name, Test = test });
 
             var now = DateTime.UtcNow;
             var today = now.Date;
@@ -252,31 +252,34 @@ namespace garge_api.Controllers
             var totalSwitches = await _context.Switches.CountAsync();
             var activeAutomations = await _context.AutomationRules.CountAsync(r => r.IsEnabled);
 
+            var orderQuery = _context.Orders.Where(o => o.IsTest == test);
+            var subQuery = _context.Subscriptions.Where(s => s.IsTest == test);
+
             var orders = new AdminOrderStatsDto
             {
-                Today = await _context.Orders.CountAsync(o => o.CreatedAt >= today),
-                ThisWeek = await _context.Orders.CountAsync(o => o.CreatedAt >= weekStart),
-                ThisMonth = await _context.Orders.CountAsync(o => o.CreatedAt >= monthStart),
-                PendingCapture = await _context.Orders.CountAsync(o => o.Status == OrderStatus.Reserved),
-                FailedOrCancelled = await _context.Orders.CountAsync(o =>
+                Today = await orderQuery.CountAsync(o => o.CreatedAt >= today),
+                ThisWeek = await orderQuery.CountAsync(o => o.CreatedAt >= weekStart),
+                ThisMonth = await orderQuery.CountAsync(o => o.CreatedAt >= monthStart),
+                PendingCapture = await orderQuery.CountAsync(o => o.Status == OrderStatus.Reserved),
+                FailedOrCancelled = await orderQuery.CountAsync(o =>
                     o.Status == OrderStatus.Failed || o.Status == OrderStatus.Cancelled),
-                TotalRevenueInOre = await _context.Orders
+                TotalRevenueInOre = await orderQuery
                     .Where(o => o.Status == OrderStatus.Paid)
                     .SumAsync(o => (long)o.TotalInOre),
-                MonthRevenueInOre = await _context.Orders
+                MonthRevenueInOre = await orderQuery
                     .Where(o => o.Status == OrderStatus.Paid && o.CreatedAt >= monthStart)
                     .SumAsync(o => (long)o.TotalInOre),
             };
 
             var subscriptions = new AdminSubscriptionStatsDto
             {
-                Active = await _context.Subscriptions.CountAsync(s => s.Status == SubscriptionStatus.Active),
-                PendingConfirm = await _context.Subscriptions.CountAsync(s => s.Status == SubscriptionStatus.Pending),
-                StoppedThisMonth = await _context.Subscriptions.CountAsync(s =>
+                Active = await subQuery.CountAsync(s => s.Status == SubscriptionStatus.Active),
+                PendingConfirm = await subQuery.CountAsync(s => s.Status == SubscriptionStatus.Pending),
+                StoppedThisMonth = await subQuery.CountAsync(s =>
                     s.Status == SubscriptionStatus.Stopped && s.UpdatedAt >= monthStart),
             };
 
-            var activeWithProduct = await _context.Subscriptions
+            var activeWithProduct = await subQuery
                 .Where(s => s.Status == SubscriptionStatus.Active)
                 .Include(s => s.Product)
                 .Where(s => s.Product != null)

--- a/garge-api.Tests/AdminControllerTests.cs
+++ b/garge-api.Tests/AdminControllerTests.cs
@@ -202,6 +202,54 @@ public class AdminControllerTests : ControllerTestBase
     }
 
     [Fact]
+    public async Task GetStats_DefaultExcludesTestData()
+    {
+        var db = CreateDbContext();
+        MockUserManager.Setup(m => m.Users).Returns(db.Users);
+
+        db.Orders.AddRange(
+            new Order { UserId = "u1", Status = OrderStatus.Paid, TotalInOre = 1000, CreatedAt = DateTime.UtcNow, IsTest = false },
+            new Order { UserId = "u1", Status = OrderStatus.Paid, TotalInOre = 9999, CreatedAt = DateTime.UtcNow, IsTest = true });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await CreateAdminController(db).GetStats();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var dto = Assert.IsType<AdminStatsDto>(ok.Value);
+        Assert.Equal(1, dto.Orders.Today);
+        Assert.Equal(1000L, dto.Orders.TotalRevenueInOre);
+    }
+
+    [Fact]
+    public async Task GetStats_TestTrue_OnlyReturnsTestData()
+    {
+        var db = CreateDbContext();
+        MockUserManager.Setup(m => m.Users).Returns(db.Users);
+
+        db.Orders.AddRange(
+            new Order { UserId = "u1", Status = OrderStatus.Paid, TotalInOre = 1000, CreatedAt = DateTime.UtcNow, IsTest = false },
+            new Order { UserId = "u1", Status = OrderStatus.Paid, TotalInOre = 9999, CreatedAt = DateTime.UtcNow, IsTest = true });
+
+        var product = new Product { Id = 1, Name = "P", PriceInOre = 5000, Interval = BillingInterval.Monthly, Type = ProductType.Primary, IsActive = true };
+        db.Products.Add(product);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        db.Subscriptions.AddRange(
+            new Subscription { UserId = "u1", ProductId = 1, VippsAgreementId = "live", Status = SubscriptionStatus.Active, IsTest = false },
+            new Subscription { UserId = "u2", ProductId = 1, VippsAgreementId = "test", Status = SubscriptionStatus.Active, IsTest = true });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await CreateAdminController(db).GetStats(test: true);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var dto = Assert.IsType<AdminStatsDto>(ok.Value);
+        Assert.Equal(1, dto.Orders.Today);
+        Assert.Equal(9999L, dto.Orders.TotalRevenueInOre);
+        Assert.Equal(1, dto.Subscriptions.Active);
+        Assert.Equal(5000L, dto.Subscriptions.MonthlyRecurringInOre);
+    }
+
+    [Fact]
     public async Task GetStats_StoppedThisMonth_OnlyCountsCurrentMonth()
     {
         var db = CreateDbContext();


### PR DESCRIPTION
## Summary
`/api/admin/stats` was counting `Order` and `Subscription` rows regardless of their `IsTest` flag, so Vipps test-mode purchases inflated the live revenue + counts whenever `VippsTestMode` was on dev or staging.

Add a `?test` query param (default `false`). Filter both `Orders` and `Subscriptions` queries by `IsTest == test`. Frontend will pair this with a Live / Test toggle on `/admin`.

User / sensor / switch / automation counts unchanged — they have no `IsTest` concept.

## Test plan
- [x] `dotnet test` — 153/153 pass.
- [x] New tests: `GetStats_DefaultExcludesTestData`, `GetStats_TestTrue_OnlyReturnsTestData`.
- [ ] After deploy: `curl .../api/admin/stats` → live numbers; `curl .../api/admin/stats?test=true` → test-mode numbers.

## Notes
- Frontend toggle PR follows on `garge-app`.
- Default behavior is "live", which is the safer default for production reads.
