### PR TITLE
fix: switch VippsConfirmationUrl to unbounded text

### DIFF
--- a/Migrations/20260507194536_VippsConfirmationUrlToText.Designer.cs
+++ b/Migrations/20260507194536_VippsConfirmationUrlToText.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260507194536_VippsConfirmationUrlToText")]
+    partial class VippsConfirmationUrlToText
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260507194536_VippsConfirmationUrlToText.cs
+++ b/Migrations/20260507194536_VippsConfirmationUrlToText.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class VippsConfirmationUrlToText : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "VippsConfirmationUrl",
+                table: "Subscriptions",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(2000)",
+                oldMaxLength: 2000,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "VippsConfirmationUrl",
+                table: "Subscriptions",
+                type: "character varying(2000)",
+                maxLength: 2000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+        }
+    }
+}

--- a/Models/Subscription/Subscription.cs
+++ b/Models/Subscription/Subscription.cs
@@ -33,7 +33,7 @@ namespace garge_api.Models.Subscription
         [MaxLength(200)]
         public required string VippsAgreementId { get; set; }
 
-        [MaxLength(2000)]
+        [Column(TypeName = "text")]
         public string? VippsConfirmationUrl { get; set; }
 
         [Required]


### PR DESCRIPTION
## Summary
`POST /api/subscriptions/initiate` failed with `22001: value too long for type character varying(500)` on dev — even though `Subscription.VippsConfirmationUrl` was bumped to `MaxLength(2000)` back in PR #174 via the `IncreaseVippsConfirmationUrlLength` migration. Root cause: that migration was **never applied** to the dev database (the app does not auto-migrate at startup), and Vipps confirmation URLs keep getting longer as new signed-token formats roll out.

Drop the length cap entirely. The column becomes PostgreSQL `text`, the entity uses `[Column(TypeName = "text")]`. New migration alters from `varchar(2000)` → `text`. Operators applying both still-pending migrations end up with an unbounded column either way; PG's `ALTER COLUMN TYPE` chains fine through `varchar(500) → varchar(2000) → text`.

## Test plan
- [x] `dotnet test` — 151/151 pass.
- [ ] Run `dotnet ef database update` against dev (or `kubectl exec` into a maintenance pod) to apply both pending migrations.
- [ ] After deploy: place a subscription on `dev.garge.no/shop`, expect 200 + redirect to Vipps confirm URL. No 22001 error.
- [ ] Verify column type:
  ```sql
  SELECT data_type, character_maximum_length
  FROM information_schema.columns
  WHERE table_name = 'Subscriptions' AND column_name = 'VippsConfirmationUrl';
  ```
  Expected: `text`, `null`.

## Quick unblock for dev (before this merges)
```sql
ALTER TABLE "Subscriptions"
  ALTER COLUMN "VippsConfirmationUrl" TYPE text;
```
Idempotent — if column is already wider, this is a no-op.

## Notes
- No data loss: existing values fit unchanged in `text`.
- The earlier `IncreaseVippsConfirmationUrlLength` migration is still in the migration history; the new migration is additive.
