### PR TITLE
feat: subscription invoices + activation/charge-failed emails + admin list

### DIFF
--- a/Controllers/SubscriptionsController.cs
+++ b/Controllers/SubscriptionsController.cs
@@ -21,6 +21,8 @@ namespace garge_api.Controllers
     {
         private readonly ApplicationDbContext _context;
         private readonly IVippsService _vipps;
+        private readonly IInvoiceService _invoice;
+        private readonly ISubscriptionEmailService _subEmail;
         private readonly IAppSettingsCache _settingsCache;
         private readonly IWebhookSecretProtector _protector;
         private readonly IWebPushService _push;
@@ -31,6 +33,8 @@ namespace garge_api.Controllers
         public SubscriptionsController(
             ApplicationDbContext context,
             IVippsService vipps,
+            IInvoiceService invoice,
+            ISubscriptionEmailService subEmail,
             IAppSettingsCache settingsCache,
             IWebhookSecretProtector protector,
             IWebPushService push,
@@ -40,12 +44,90 @@ namespace garge_api.Controllers
         {
             _context = context;
             _vipps = vipps;
+            _invoice = invoice;
+            _subEmail = subEmail;
             _settingsCache = settingsCache;
             _protector = protector;
             _push = push;
             _appOpts = appOpts.Value;
             _mapper = mapper;
             _logger = logger;
+        }
+
+        /// <summary>Admin: list every subscription with the user's name + email, plus invoice count for the in-app subscriptions admin page.</summary>
+        [HttpGet("all")]
+        [Authorize(Policy = "Admin")]
+        public async Task<IActionResult> GetAllSubscriptions()
+        {
+            var rows = await _context.Subscriptions
+                .Include(s => s.User)
+                .Include(s => s.Product)
+                .OrderByDescending(s => s.CreatedAt)
+                .Select(s => new AdminSubscriptionResponseDto
+                {
+                    Id = s.Id,
+                    UserId = s.UserId,
+                    UserEmail = s.User != null ? s.User.Email ?? string.Empty : string.Empty,
+                    UserName = s.User != null ? (s.User.FirstName + " " + s.User.LastName).Trim() : string.Empty,
+                    ProductName = s.Product != null ? s.Product.Name : string.Empty,
+                    ProductType = s.Product != null ? s.Product.Type.ToString() : string.Empty,
+                    PriceInOre = s.Product != null ? s.Product.PriceInOre : 0,
+                    Interval = s.Product != null ? s.Product.Interval.ToString() : string.Empty,
+                    Status = s.Status.ToString(),
+                    IsTest = s.IsTest,
+                    StartDate = s.StartDate,
+                    NextChargeDate = s.NextChargeDate,
+                    InvoiceCount = _context.Invoices.Count(i => i.SubscriptionId == s.Id),
+                    CreatedAt = s.CreatedAt,
+                    UpdatedAt = s.UpdatedAt,
+                })
+                .ToListAsync();
+
+            return Ok(rows);
+        }
+
+        /// <summary>Lists invoice metadata for a subscription. Owner or admin only.</summary>
+        [HttpGet("{id:int}/invoices")]
+        public async Task<IActionResult> GetSubscriptionInvoices(int id)
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+            var isAdmin = User.IsInRole("Admin");
+
+            var subscription = await _context.Subscriptions
+                .FirstOrDefaultAsync(s => s.Id == id);
+            if (subscription == null) return NotFound();
+            if (!isAdmin && subscription.UserId != userId) return Forbid();
+
+            var invoices = await _context.Invoices
+                .Where(i => i.SubscriptionId == id)
+                .OrderByDescending(i => i.IssuedAt)
+                .Select(i => new
+                {
+                    i.Id,
+                    i.IssuedAt,
+                    i.AmountInOre,
+                    i.VippsChargeId,
+                })
+                .ToListAsync();
+
+            return Ok(invoices);
+        }
+
+        /// <summary>Downloads a single subscription invoice PDF. Owner or admin only.</summary>
+        [HttpGet("invoices/{invoiceId:int}/pdf")]
+        public async Task<IActionResult> GetSubscriptionInvoicePdf(int invoiceId)
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+            var isAdmin = User.IsInRole("Admin");
+
+            var invoice = await _context.Invoices
+                .Include(i => i.Subscription)
+                .FirstOrDefaultAsync(i => i.Id == invoiceId && i.SubscriptionId != null);
+            if (invoice == null) return NotFound("Subscription invoice not found.");
+            if (!isAdmin && invoice.Subscription?.UserId != userId) return Forbid();
+
+            return File(invoice.PdfData, "application/pdf",
+                $"invoice-{invoice.Id:D4}.pdf");
         }
 
         /// <summary>Returns the current user's subscriptions. Stopped/Expired hidden once next-charge date passed (grace period).</summary>
@@ -304,12 +386,43 @@ namespace garge_api.Controllers
                 payload.AgreementId, payload.EventType);
 
             if (!wasActive && subscription.Status == SubscriptionStatus.Active)
+            {
+                try { await _subEmail.SendActivatedAsync(subscription.Id); }
+                catch (Exception ex) { _logger.LogError(ex, "Activation email failed for subscription {SubscriptionId}", subscription.Id); }
+
                 _ = SafePushAsync(subscription.UserId, "Subscription active",
                     "Your Garge subscription is confirmed.");
+            }
+
+            if (payload.EventType == VippsEvents.ChargeCaptured && !string.IsNullOrEmpty(payload.ChargeId))
+            {
+                var product = await _context.Products.FindAsync(subscription.ProductId);
+                if (product != null)
+                {
+                    try
+                    {
+                        await _invoice.GenerateForSubscriptionChargeAsync(
+                            subscription.Id,
+                            payload.ChargeId,
+                            product.PriceInOre,
+                            payload.Occurred ?? DateTime.UtcNow);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Subscription invoice generation failed for subscription {SubscriptionId} charge {ChargeId}",
+                            subscription.Id, payload.ChargeId);
+                    }
+                }
+            }
 
             if (payload.EventType is VippsEvents.ChargeFailed or VippsEvents.ChargeCreationFailed)
+            {
+                try { await _subEmail.SendChargeFailedAsync(subscription.Id); }
+                catch (Exception ex) { _logger.LogError(ex, "Charge-failed email failed for subscription {SubscriptionId}", subscription.Id); }
+
                 _ = SafePushAsync(subscription.UserId, "Payment failed",
                     "We couldn't charge your Garge subscription. Please update your payment method in Vipps.");
+            }
 
             return Ok();
         }

--- a/Dtos/Subscription/SubscriptionDtos.cs
+++ b/Dtos/Subscription/SubscriptionDtos.cs
@@ -40,6 +40,25 @@ namespace garge_api.Dtos.Subscription
         public string VippsAgreementId { get; set; } = string.Empty;
     }
 
+    public class AdminSubscriptionResponseDto
+    {
+        public int Id { get; set; }
+        public string UserId { get; set; } = string.Empty;
+        public string UserEmail { get; set; } = string.Empty;
+        public string UserName { get; set; } = string.Empty;
+        public string ProductName { get; set; } = string.Empty;
+        public string ProductType { get; set; } = string.Empty;
+        public int PriceInOre { get; set; }
+        public string Interval { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
+        public bool IsTest { get; set; }
+        public DateTime? StartDate { get; set; }
+        public DateTime? NextChargeDate { get; set; }
+        public int InvoiceCount { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+    }
+
     public class VippsAgreementWebhookDto
     {
         public string AgreementId { get; set; } = string.Empty;
@@ -47,5 +66,10 @@ namespace garge_api.Dtos.Subscription
         public string EventType { get; set; } = string.Empty;
         public DateTime? Occurred { get; set; }
         public string? Msn { get; set; }
+
+        // Set on recurring.charge-* events. Used as the idempotency key when
+        // generating subscription invoices so a redelivered webhook can't
+        // produce two invoices for the same charge.
+        public string? ChargeId { get; set; }
     }
 }

--- a/Migrations/20260507201522_InvoiceForOrderOrSubscription.Designer.cs
+++ b/Migrations/20260507201522_InvoiceForOrderOrSubscription.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260507201522_InvoiceForOrderOrSubscription")]
+    partial class InvoiceForOrderOrSubscription
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260507201522_InvoiceForOrderOrSubscription.cs
+++ b/Migrations/20260507201522_InvoiceForOrderOrSubscription.cs
@@ -1,0 +1,121 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class InvoiceForOrderOrSubscription : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Invoices_OrderId",
+                table: "Invoices");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "OrderId",
+                table: "Invoices",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AddColumn<int>(
+                name: "AmountInOre",
+                table: "Invoices",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "SubscriptionId",
+                table: "Invoices",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "VippsChargeId",
+                table: "Invoices",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Invoices_OrderId",
+                table: "Invoices",
+                column: "OrderId",
+                unique: true,
+                filter: "\"OrderId\" IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Invoices_SubscriptionId",
+                table: "Invoices",
+                column: "SubscriptionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Invoices_VippsChargeId",
+                table: "Invoices",
+                column: "VippsChargeId",
+                unique: true,
+                filter: "\"VippsChargeId\" IS NOT NULL");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Invoices_Subscriptions_SubscriptionId",
+                table: "Invoices",
+                column: "SubscriptionId",
+                principalTable: "Subscriptions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Invoices_Subscriptions_SubscriptionId",
+                table: "Invoices");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Invoices_OrderId",
+                table: "Invoices");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Invoices_SubscriptionId",
+                table: "Invoices");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Invoices_VippsChargeId",
+                table: "Invoices");
+
+            migrationBuilder.DropColumn(
+                name: "AmountInOre",
+                table: "Invoices");
+
+            migrationBuilder.DropColumn(
+                name: "SubscriptionId",
+                table: "Invoices");
+
+            migrationBuilder.DropColumn(
+                name: "VippsChargeId",
+                table: "Invoices");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "OrderId",
+                table: "Invoices",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Invoices_OrderId",
+                table: "Invoices",
+                column: "OrderId",
+                unique: true);
+        }
+    }
+}

--- a/Models/ApplicationDbContext.cs
+++ b/Models/ApplicationDbContext.cs
@@ -294,9 +294,25 @@ namespace garge_api.Models
                 .HasForeignKey<Invoice>(i => i.OrderId)
                 .OnDelete(DeleteBehavior.Cascade);
 
+            // Filtered unique index: one invoice per order when set; multiple rows
+            // with NULL OrderId are allowed (subscription invoices).
             modelBuilder.Entity<Invoice>()
                 .HasIndex(i => i.OrderId)
-                .IsUnique();
+                .IsUnique()
+                .HasFilter("\"OrderId\" IS NOT NULL");
+
+            modelBuilder.Entity<Invoice>()
+                .HasOne(i => i.Subscription)
+                .WithMany()
+                .HasForeignKey(i => i.SubscriptionId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // Unique-when-present index so webhook redelivery can't produce duplicate
+            // invoices for the same Vipps charge.
+            modelBuilder.Entity<Invoice>()
+                .HasIndex(i => i.VippsChargeId)
+                .IsUnique()
+                .HasFilter("\"VippsChargeId\" IS NOT NULL");
 
             modelBuilder.Entity<ProcessedWebhookEvent>()
                 .HasIndex(p => new { p.Source, p.Id });

--- a/Models/Shop/Invoice.cs
+++ b/Models/Shop/Invoice.cs
@@ -9,11 +9,27 @@ namespace garge_api.Models.Shop
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int Id { get; set; }
 
-        [Required]
-        public int OrderId { get; set; }
+        // Exactly one of OrderId / SubscriptionId is set. Order = one-off shop purchase,
+        // Subscription = a single recurring charge against a Vipps agreement.
+        public int? OrderId { get; set; }
 
         [ForeignKey(nameof(OrderId))]
         public Order? Order { get; set; }
+
+        public int? SubscriptionId { get; set; }
+
+        [ForeignKey(nameof(SubscriptionId))]
+        public Subscription.Subscription? Subscription { get; set; }
+
+        // Vipps charge id for the subscription path. Lets us guard against webhook
+        // redelivery so a single charge never produces two invoices.
+        [MaxLength(200)]
+        public string? VippsChargeId { get; set; }
+
+        // Snapshot of the amount charged in øre. For order invoices we pull this from the
+        // Order; for subscription charges we capture it at invoice time so future product
+        // price changes don't rewrite history.
+        public int AmountInOre { get; set; }
 
         public DateTime IssuedAt { get; set; } = DateTime.UtcNow;
 

--- a/Program.cs
+++ b/Program.cs
@@ -142,6 +142,7 @@ namespace garge_api
             builder.Services.AddSingleton<IPdfRenderer, PuppeteerPdfRenderer>();
             builder.Services.AddScoped<IInvoiceService, InvoiceService>();
             builder.Services.AddScoped<IOrderEmailService, OrderEmailService>();
+            builder.Services.AddScoped<ISubscriptionEmailService, SubscriptionEmailService>();
             builder.Services.AddHttpClient<IVippsService, VippsService>();
             builder.Services.AddHostedService<VippsWebhookRegistrationService>();
             builder.Services.AddHostedService<ProcessedWebhookEventCleanupService>();

--- a/Services/IInvoiceService.cs
+++ b/Services/IInvoiceService.cs
@@ -9,5 +9,14 @@ namespace garge_api.Services
         /// reusing the same invoice row.
         /// </summary>
         Task<int> GenerateAndStoreAsync(int orderId, bool force = false);
+
+        /// <summary>
+        /// Generate the invoice for a single recurring charge against a Vipps subscription
+        /// agreement and email the buyer. Idempotent on <paramref name="vippsChargeId"/>:
+        /// webhook redelivery for the same charge returns the existing invoice id without
+        /// inserting a duplicate row or re-emailing.
+        /// </summary>
+        Task<int> GenerateForSubscriptionChargeAsync(
+            int subscriptionId, string vippsChargeId, int amountInOre, DateTime occurredAt);
     }
 }

--- a/Services/ISubscriptionEmailService.cs
+++ b/Services/ISubscriptionEmailService.cs
@@ -1,0 +1,8 @@
+namespace garge_api.Services
+{
+    public interface ISubscriptionEmailService
+    {
+        Task SendActivatedAsync(int subscriptionId);
+        Task SendChargeFailedAsync(int subscriptionId);
+    }
+}

--- a/Services/InvoiceService.cs
+++ b/Services/InvoiceService.cs
@@ -2,7 +2,9 @@ using garge_api.Helpers;
 using garge_api.Models;
 using garge_api.Models.Admin;
 using garge_api.Models.Shop;
+using garge_api.Models.Subscription;
 using Microsoft.EntityFrameworkCore;
+using System.Globalization;
 using System.Text;
 using System.Web;
 
@@ -103,6 +105,154 @@ namespace garge_api.Services
 
             _logger.LogInformation("Invoice {InvoiceId} generated for order {OrderId}", invoice.Id, orderId);
             return invoice.Id;
+        }
+
+        public async Task<int> GenerateForSubscriptionChargeAsync(
+            int subscriptionId, string vippsChargeId, int amountInOre, DateTime occurredAt)
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+            var existing = await db.Invoices.FirstOrDefaultAsync(i => i.VippsChargeId == vippsChargeId);
+            if (existing != null)
+            {
+                _logger.LogInformation("Invoice {InvoiceId} already exists for charge {ChargeId} — skip",
+                    existing.Id, vippsChargeId);
+                return existing.Id;
+            }
+
+            var subscription = await db.Subscriptions
+                .Include(s => s.User)
+                .Include(s => s.Product)
+                .FirstOrDefaultAsync(s => s.Id == subscriptionId)
+                ?? throw new InvalidOperationException($"Subscription {subscriptionId} not found");
+
+            var settings = await db.AppSettings.FindAsync(1) ?? new AppSettings();
+
+            var invoice = new Invoice
+            {
+                SubscriptionId = subscription.Id,
+                VippsChargeId = vippsChargeId,
+                AmountInOre = amountInOre,
+                IssuedAt = occurredAt,
+                PdfData = []
+            };
+            db.Invoices.Add(invoice);
+            await db.SaveChangesAsync();
+
+            var html = BuildSubscriptionInvoiceHtml(subscription, settings, invoice.Id, occurredAt, amountInOre);
+            try
+            {
+                invoice.PdfData = await _pdfRenderer.RenderAsync(html);
+                await db.SaveChangesAsync();
+            }
+            catch
+            {
+                db.Invoices.Remove(invoice);
+                await db.SaveChangesAsync();
+                throw;
+            }
+
+            try
+            {
+                var buyerEmail = subscription.User?.Email;
+                if (!string.IsNullOrEmpty(buyerEmail))
+                {
+                    var attachment = new EmailAttachment
+                    {
+                        FileName = $"invoice-{invoice.Id:D4}.pdf",
+                        Content = invoice.PdfData,
+                        ContentType = "application/pdf"
+                    };
+                    await _emailService.SendEmailAsync(
+                        buyerEmail,
+                        $"Invoice #{invoice.Id:D4} — {settings.CompanyName}",
+                        html,
+                        [attachment]);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to email invoice {InvoiceId} for subscription {SubscriptionId} charge {ChargeId}",
+                    invoice.Id, subscriptionId, vippsChargeId);
+            }
+
+            _logger.LogInformation("Invoice {InvoiceId} generated for subscription {SubscriptionId} charge {ChargeId}",
+                invoice.Id, subscriptionId, vippsChargeId);
+            return invoice.Id;
+        }
+
+        private static string BuildSubscriptionInvoiceHtml(
+            Subscription subscription, AppSettings s, int invoiceId, DateTime issuedAt, int amountInOre)
+        {
+            static string Nok(int ore) => MoneyFormat.Nok(ore);
+            static string H(string? v) => HttpUtility.HtmlEncode(v ?? string.Empty);
+
+            var product = subscription.Product;
+            var productName = product?.Name ?? "Subscription";
+            var period = product?.Interval == BillingInterval.Yearly ? "year" : "month";
+            var buyerName = subscription.User != null
+                ? $"{subscription.User.FirstName} {subscription.User.LastName}"
+                : "—";
+
+            var body = $$"""
+                <div class="parties">
+                  <div class="party">
+                    <div class="party-label">From</div>
+                    <p>
+                      <strong>{{H(s.CompanyLegalName)}}</strong><br>
+                      {{H(s.CompanyAddress)}}<br>
+                      {{H(s.CompanyEmail)}}
+                    </p>
+                  </div>
+                  <div class="party">
+                    <div class="party-label">Bill to</div>
+                    <p>
+                      <strong>{{H(buyerName)}}</strong><br>
+                      {{H(subscription.User?.Email)}}
+                    </p>
+                  </div>
+                </div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Description</th>
+                      <th class="r">Amount</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>{{H(productName)}} — recurring charge ({{period}})</td>
+                      <td class="r">NOK {{Nok(amountInOre)}}</td>
+                    </tr>
+                  </tbody>
+                </table>
+
+                <div class="totals-section">
+                  <table>
+                    <tbody>
+                      <tr class="grand">
+                        <td>Total</td>
+                        <td class="r">NOK {{Nok(amountInOre)}}</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+
+                <div class="footer">
+                  <p>Charged via Vipps recurring agreement.</p>
+                  <p>Charge date: {{issuedAt.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}}.</p>
+                </div>
+                """;
+
+            return EmailLayout.Render(s, new EmailLayout.Meta
+            {
+                Number = $"#{invoiceId:D4}",
+                Subtitle = $"INVOICE  ·  {issuedAt:yyyy-MM-dd}",
+                Badge = "Paid",
+                FootNote = $"Vipps agreement {subscription.VippsAgreementId}"
+            }, body);
         }
 
         private static string BuildInvoiceHtml(Order order, AppSettings s, int invoiceId, DateTime issuedAt)

--- a/Services/SubscriptionEmailService.cs
+++ b/Services/SubscriptionEmailService.cs
@@ -1,0 +1,107 @@
+using garge_api.Helpers;
+using garge_api.Models;
+using garge_api.Models.Admin;
+using garge_api.Models.Subscription;
+using Microsoft.EntityFrameworkCore;
+using System.Web;
+
+namespace garge_api.Services
+{
+    public class SubscriptionEmailService : ISubscriptionEmailService
+    {
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly IEmailService _emailService;
+        private readonly ILogger<SubscriptionEmailService> _logger;
+
+        public SubscriptionEmailService(
+            IServiceScopeFactory scopeFactory,
+            IEmailService emailService,
+            ILogger<SubscriptionEmailService> logger)
+        {
+            _scopeFactory = scopeFactory;
+            _emailService = emailService;
+            _logger = logger;
+        }
+
+        public Task SendActivatedAsync(int subscriptionId) =>
+            SendAsync(subscriptionId, kind: "activated",
+                subjectFormat: "Subscription confirmed — {0}",
+                buildBody: (sub, s) =>
+                {
+                    var productName = sub.Product?.Name ?? "Garge subscription";
+                    var period = sub.Product?.Interval == BillingInterval.Yearly ? "yearly" : "monthly";
+                    var price = sub.Product != null ? MoneyFormat.Nok(sub.Product.PriceInOre) : null;
+                    var nextChargeLine = sub.NextChargeDate.HasValue
+                        ? $"<p>Next charge: <strong>{sub.NextChargeDate.Value:yyyy-MM-dd}</strong>.</p>"
+                        : string.Empty;
+
+                    return $$"""
+                        <h1>Welcome aboard, {{H(sub.User?.FirstName)}}!</h1>
+                        <p>Your <strong>{{H(productName)}}</strong> {{period}} subscription is active. Vipps will charge {{(price != null ? $"NOK {price}" : "the agreed amount")}} per {{(period == "yearly" ? "year" : "month")}}.</p>
+                        {{nextChargeLine}}
+                        <p>Receipts for every charge land here as PDF invoices.</p>
+                        """;
+                });
+
+        public Task SendChargeFailedAsync(int subscriptionId) =>
+            SendAsync(subscriptionId, kind: "charge-failed",
+                subjectFormat: "Action needed: subscription payment failed — {0}",
+                buildBody: (sub, s) =>
+                {
+                    var productName = sub.Product?.Name ?? "Garge subscription";
+                    return $$"""
+                        <h1>We couldn't charge your subscription</h1>
+                        <p>Hi {{H(sub.User?.FirstName)}}, the latest charge for <strong>{{H(productName)}}</strong> failed. Vipps will retry, but please update your payment method in the Vipps app to avoid the agreement being stopped.</p>
+                        <p>If you've already fixed it, you can ignore this email.</p>
+                        """;
+                });
+
+        private async Task SendAsync(
+            int subscriptionId,
+            string kind,
+            string subjectFormat,
+            Func<Subscription, AppSettings, string> buildBody)
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+            var subscription = await db.Subscriptions
+                .Include(s => s.User)
+                .Include(s => s.Product)
+                .FirstOrDefaultAsync(s => s.Id == subscriptionId);
+
+            if (subscription?.User?.Email == null)
+            {
+                _logger.LogWarning("Subscription {SubscriptionId} missing user/email — {Kind} email skipped",
+                    subscriptionId, kind);
+                return;
+            }
+
+            var settings = await db.AppSettings.FindAsync(1) ?? new AppSettings();
+
+            var body = buildBody(subscription, settings);
+            var html = EmailLayout.Render(settings, new EmailLayout.Meta
+            {
+                Number = $"#{subscription.Id}",
+                Subtitle = $"SUBSCRIPTION  ·  {DateTime.UtcNow:yyyy-MM-dd}",
+            }, body);
+
+            try
+            {
+                await _emailService.SendEmailAsync(
+                    subscription.User.Email,
+                    string.Format(subjectFormat, settings.CompanyName),
+                    html);
+                _logger.LogInformation("Subscription {Kind} email sent for subscription {SubscriptionId}",
+                    kind, subscriptionId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to send subscription {Kind} email for subscription {SubscriptionId}",
+                    kind, subscriptionId);
+            }
+        }
+
+        private static string H(string? v) => HttpUtility.HtmlEncode(v ?? string.Empty);
+    }
+}

--- a/garge-api.Tests/InvoiceServiceTests.cs
+++ b/garge-api.Tests/InvoiceServiceTests.cs
@@ -193,4 +193,89 @@ public class InvoiceServiceTests
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => svc.GenerateAndStoreAsync(orderId: 99999));
     }
+
+    private static async Task<garge_api.Models.Subscription.Subscription> SeedSubscriptionAsync(ApplicationDbContext db)
+    {
+        await db.AppSettings.AddAsync(new AppSettings { Id = 1, CompanyName = "Garge" });
+        await db.Users.AddAsync(new User
+        {
+            Id = "user-sub", Email = "buyer@example.com", UserName = "buyer@example.com",
+            FirstName = "Sondre", LastName = "Sjølyst"
+        });
+        var product = new garge_api.Models.Subscription.Product
+        {
+            Id = 9, Name = "Garge Basic", PriceInOre = 29900,
+            Interval = garge_api.Models.Subscription.BillingInterval.Monthly,
+            Type = garge_api.Models.Subscription.ProductType.Primary,
+            IsActive = true,
+        };
+        await db.Products.AddAsync(product);
+        var subscription = new garge_api.Models.Subscription.Subscription
+        {
+            UserId = "user-sub",
+            ProductId = product.Id,
+            VippsAgreementId = "agr-test",
+            Status = garge_api.Models.Subscription.SubscriptionStatus.Active,
+        };
+        await db.Subscriptions.AddAsync(subscription);
+        await db.SaveChangesAsync();
+        return subscription;
+    }
+
+    [Fact]
+    public async Task GenerateForSubscriptionChargeAsync_HappyPath_RendersAndEmails()
+    {
+        var (svc, db, email, pdf) = Create();
+        var subscription = await SeedSubscriptionAsync(db);
+
+        var id = await svc.GenerateForSubscriptionChargeAsync(
+            subscription.Id, "charge-1", amountInOre: 29900, occurredAt: DateTime.UtcNow);
+
+        var saved = await db.Invoices.SingleAsync();
+        Assert.Equal(id, saved.Id);
+        Assert.Equal(subscription.Id, saved.SubscriptionId);
+        Assert.Equal("charge-1", saved.VippsChargeId);
+        Assert.Equal(29900, saved.AmountInOre);
+        Assert.Null(saved.OrderId);
+        Assert.Equal(new byte[] { 1, 2, 3 }, saved.PdfData);
+        pdf.Verify(p => p.RenderAsync(It.IsAny<string>()), Times.Once);
+        email.Verify(e => e.SendEmailAsync(
+            "buyer@example.com",
+            It.Is<string>(s => s.Contains($"#{id:D4}")),
+            It.IsAny<string>(),
+            It.Is<IReadOnlyList<EmailAttachment>?>(a => a != null && a.Count == 1)), Times.Once);
+    }
+
+    [Fact]
+    public async Task GenerateForSubscriptionChargeAsync_DuplicateChargeId_ShortCircuits()
+    {
+        var (svc, db, email, pdf) = Create();
+        var subscription = await SeedSubscriptionAsync(db);
+
+        var first = await svc.GenerateForSubscriptionChargeAsync(
+            subscription.Id, "charge-dup", 29900, DateTime.UtcNow);
+        var second = await svc.GenerateForSubscriptionChargeAsync(
+            subscription.Id, "charge-dup", 29900, DateTime.UtcNow);
+
+        Assert.Equal(first, second);
+        Assert.Single(db.Invoices);
+        pdf.Verify(p => p.RenderAsync(It.IsAny<string>()), Times.Once);
+        email.Verify(e => e.SendEmailAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<IReadOnlyList<EmailAttachment>?>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GenerateForSubscriptionChargeAsync_RenderFails_RemovesPlaceholderRow()
+    {
+        var pdf = new Mock<IPdfRenderer>();
+        pdf.Setup(p => p.RenderAsync(It.IsAny<string>())).ThrowsAsync(new Exception("chromium gone"));
+        var (svc, db, _, _) = Create(pdf);
+        var subscription = await SeedSubscriptionAsync(db);
+
+        await Assert.ThrowsAsync<Exception>(() =>
+            svc.GenerateForSubscriptionChargeAsync(subscription.Id, "charge-fail", 29900, DateTime.UtcNow));
+
+        Assert.Empty(db.Invoices);
+    }
 }

--- a/garge-api.Tests/SubscriptionsControllerTests.cs
+++ b/garge-api.Tests/SubscriptionsControllerTests.cs
@@ -54,7 +54,8 @@ public class SubscriptionsControllerTests : ControllerTestBase
 
     private SubscriptionsController CreateController(
         ApplicationDbContext db, string userId = "user-1",
-        Mock<IVippsService>? vipps = null, AppSettings? settings = null)
+        Mock<IVippsService>? vipps = null, AppSettings? settings = null,
+        IInvoiceService? invoice = null, ISubscriptionEmailService? subEmail = null)
     {
         var push = new Mock<IWebPushService>();
         push.Setup(p => p.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -62,6 +63,8 @@ public class SubscriptionsControllerTests : ControllerTestBase
 
         var ctrl = new SubscriptionsController(
             db, (vipps ?? MockVipps()).Object,
+            invoice ?? new Mock<IInvoiceService>().Object,
+            subEmail ?? new Mock<ISubscriptionEmailService>().Object,
             MockSettingsCache(settings).Object,
             MockProtector().Object,
             push.Object,


### PR DESCRIPTION
## Summary
Subscriptions now generate a real PDF invoice + email for every recurring charge, send an activation email when the agreement first turns Active, and warn the buyer when a charge fails. Backed by a new admin-only listing endpoint that the upcoming `/admin/subscriptions` frontend page will consume.

Norwegian `bokføringsforskriften §5-1-1` requires a `salgsdokument` per sale — including every recurring charge. Same sequential invoice Id sequence is reused so accounting sees one book of invoices.

### Schema
- `Invoice.OrderId` becomes nullable.
- New `Invoice.SubscriptionId` (FK), `Invoice.VippsChargeId` (idempotency key), `Invoice.AmountInOre` (charge amount snapshot).
- Filtered unique index keeps the existing "one invoice per order" guarantee, allows many invoices per subscription.
- Filtered unique index on `VippsChargeId` blocks duplicate invoices when Vipps redelivers a `recurring.charge-captured.v1` webhook.
- Migration: `20260507201522_InvoiceForOrderOrSubscription`.

### Services
- `IInvoiceService.GenerateForSubscriptionChargeAsync(subscriptionId, chargeId, amountInOre, occurredAt)` — idempotent on `chargeId`. Renders a sub-specific HTML body via the shared `EmailLayout` shell, attaches the PDF, emails the buyer.
- `ISubscriptionEmailService.SendActivatedAsync(id)` — first-charge welcome email.
- `ISubscriptionEmailService.SendChargeFailedAsync(id)` — heads-up about a failed charge.

### Webhook wiring (`SubscriptionsController.Webhook`)
- `recurring.agreement-activated.v1` (or any transition into `Active`) → activation email + push.
- `recurring.charge-captured.v1` → invoice generation (using `payload.ChargeId` for idempotency, `Product.PriceInOre` as the amount).
- `recurring.charge-failed.v1` / `charge-creation-failed.v1` → warning email + push.

### Admin endpoints
- `GET /api/subscriptions/all` (Admin policy) — list every sub with user info, product, status, invoice count.
- `GET /api/subscriptions/{id}/invoices` — list invoices for a sub (owner or admin).
- `GET /api/subscriptions/invoices/{invoiceId}/pdf` — download a single subscription invoice (owner or admin).

## Test plan
- [x] `dotnet test` — 156/156 pass.
- [x] New tests cover: subscription invoice happy path, duplicate-charge idempotency, render-fail cleanup.
- [ ] Run `dotnet ef database update` against dev (the app does not auto-migrate).
- [ ] After deploy: subscribe to a Vipps test plan, confirm the activation email arrives. Wait for Vipps to fire `recurring.charge-captured.v1` (or trigger via portal) — confirm an invoice email arrives with the PDF attached and a single Invoice row exists for that charge.
- [ ] Hit `GET /api/subscriptions/all` with the admin JWT — expect rows.

## Notes
- Frontend `/admin/subscriptions` page is a follow-up PR on `garge-app`.
- Default amount uses `Product.PriceInOre` snapshot — if Vipps ever sends a pro-rated amount different from the product price, we'd want to call the Vipps charge API to read the real amount. Out of scope here.
