### PR TITLE
feat: Vipps recurring charges, invoice compliance, admin refund

### DIFF
--- a/Controllers/ShopController.cs
+++ b/Controllers/ShopController.cs
@@ -297,6 +297,27 @@ namespace garge_api.Controllers
                 $"invoice-{invoice.Id:D4}.pdf");
         }
 
+        [HttpPost("orders/{id}/refund")]
+        [Authorize(Policy = "Admin")]
+        public async Task<IActionResult> RefundOrder(int id)
+        {
+            var order = await _context.Orders.FindAsync(id);
+            if (order == null) return NotFound();
+            if (order.Status != OrderStatus.Paid)
+                return BadRequest("Order is not in Paid state.");
+            if (string.IsNullOrEmpty(order.VippsOrderId))
+                return BadRequest("No Vipps reference found.");
+
+            await _vipps.RefundPaymentAsync(order.VippsOrderId, order.TotalInOre, $"refund-{order.Id}");
+
+            order.Status = OrderStatus.Refunded;
+            order.UpdatedAt = DateTime.UtcNow;
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("Order {OrderId} refunded by admin", id);
+            return Ok();
+        }
+
         [HttpPost("orders/{id}/cancel")]
         [Authorize(Policy = "Admin")]
         public async Task<IActionResult> CancelOrder(int id)

--- a/Controllers/SubscriptionsController.cs
+++ b/Controllers/SubscriptionsController.cs
@@ -414,25 +414,6 @@ namespace garge_api.Controllers
                         _logger.LogError(ex, "Subscription invoice generation failed for subscription {SubscriptionId} charge {ChargeId}",
                             subscription.Id, payload.ChargeId);
                     }
-
-                    if (subscription.NextChargeDate.HasValue && subscription.Status == SubscriptionStatus.Active)
-                    {
-                        var due = subscription.NextChargeDate.Value;
-                        try
-                        {
-                            await _vipps.CreateChargeAsync(
-                                subscription.VippsAgreementId,
-                                product.PriceInOre,
-                                due,
-                                product.Name,
-                                idempotencyKey: $"charge-{subscription.Id}-{due.Ticks}");
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogError(ex, "Scheduling next charge failed for subscription {SubscriptionId} dueDate {DueDate}",
-                                subscription.Id, due);
-                        }
-                    }
                 }
             }
 

--- a/Controllers/SubscriptionsController.cs
+++ b/Controllers/SubscriptionsController.cs
@@ -357,6 +357,8 @@ namespace garge_api.Controllers
                     subscription.Status = SubscriptionStatus.Active;
                     if (subscription.StartDate == null)
                         subscription.StartDate = payload.Occurred ?? DateTime.UtcNow;
+                    if (string.IsNullOrEmpty(subscription.BillingAddress))
+                        await TryPopulateBillingAddressAsync(subscription, payload.AgreementId);
                     break;
                 case VippsEvents.AgreementStopped:
                 case VippsEvents.AgreementRejected:
@@ -412,6 +414,25 @@ namespace garge_api.Controllers
                         _logger.LogError(ex, "Subscription invoice generation failed for subscription {SubscriptionId} charge {ChargeId}",
                             subscription.Id, payload.ChargeId);
                     }
+
+                    if (subscription.NextChargeDate.HasValue && subscription.Status == SubscriptionStatus.Active)
+                    {
+                        var due = subscription.NextChargeDate.Value;
+                        try
+                        {
+                            await _vipps.CreateChargeAsync(
+                                subscription.VippsAgreementId,
+                                product.PriceInOre,
+                                due,
+                                product.Name,
+                                idempotencyKey: $"charge-{subscription.Id}-{due.Ticks}");
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, "Scheduling next charge failed for subscription {SubscriptionId} dueDate {DueDate}",
+                                subscription.Id, due);
+                        }
+                    }
                 }
             }
 
@@ -431,6 +452,24 @@ namespace garge_api.Controllers
         {
             try { await _push.SendAsync(userId, title, body); }
             catch (Exception ex) { _logger.LogWarning(ex, "Push send failed for user {UserId}", userId); }
+        }
+
+        private async Task TryPopulateBillingAddressAsync(Subscription subscription, string agreementId)
+        {
+            try
+            {
+                var details = await _vipps.GetAgreementAsync(agreementId);
+                if (string.IsNullOrEmpty(details?.Sub)) return;
+
+                var info = await _vipps.GetUserInfoAsync(details.Sub);
+                var formatted = VippsAddressFormatter.Format(info?.Address);
+                if (!string.IsNullOrEmpty(formatted))
+                    subscription.BillingAddress = formatted;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to fetch Vipps user info for subscription {SubscriptionId}", subscription.Id);
+            }
         }
     }
 }

--- a/Controllers/VippsWebhookControllerBase.cs
+++ b/Controllers/VippsWebhookControllerBase.cs
@@ -24,21 +24,34 @@ namespace garge_api.Controllers
             return body;
         }
 
-        protected async Task<bool> TryRecordEventAsync(
+        protected static async Task<bool> TryRecordEventAsync(
             ApplicationDbContext db, string source, string eventId)
         {
             if (string.IsNullOrEmpty(eventId)) return true;
 
-            var exists = await db.ProcessedWebhookEvents
-                .AnyAsync(e => e.Source == source && e.Id == eventId);
-            if (exists) return false;
-
-            db.ProcessedWebhookEvents.Add(new ProcessedWebhookEvent
+            var entity = new ProcessedWebhookEvent
             {
                 Id = eventId,
                 Source = source
-            });
-            return true;
+            };
+
+            try
+            {
+                db.ProcessedWebhookEvents.Add(entity);
+                await db.SaveChangesAsync();
+                return true;
+            }
+            catch (Exception ex) when (ex is DbUpdateException || ex is InvalidOperationException)
+            {
+                var entry = db.Entry(entity);
+                if (entry.State != EntityState.Detached) entry.State = EntityState.Detached;
+
+                var raceLost = await db.ProcessedWebhookEvents
+                    .AsNoTracking()
+                    .AnyAsync(e => e.Id == eventId);
+                if (raceLost) return false;
+                throw;
+            }
         }
     }
 }

--- a/Migrations/20260508161155_AddSubscriptionBillingAddress.Designer.cs
+++ b/Migrations/20260508161155_AddSubscriptionBillingAddress.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260508161155_AddSubscriptionBillingAddress")]
+    partial class AddSubscriptionBillingAddress
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260508161155_AddSubscriptionBillingAddress.cs
+++ b/Migrations/20260508161155_AddSubscriptionBillingAddress.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSubscriptionBillingAddress : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "BillingAddress",
+                table: "Subscriptions",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "BillingAddress",
+                table: "Subscriptions");
+        }
+    }
+}

--- a/Models/Subscription/Subscription.cs
+++ b/Models/Subscription/Subscription.cs
@@ -48,6 +48,9 @@ namespace garge_api.Models.Subscription
         [MaxLength(45)]
         public string? ConsentIp { get; set; }
 
+        [MaxLength(500)]
+        public string? BillingAddress { get; set; }
+
         public bool IsTest { get; set; }
 
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;

--- a/Program.cs
+++ b/Program.cs
@@ -146,6 +146,7 @@ namespace garge_api
             builder.Services.AddHttpClient<IVippsService, VippsService>();
             builder.Services.AddHostedService<VippsWebhookRegistrationService>();
             builder.Services.AddHostedService<ProcessedWebhookEventCleanupService>();
+            builder.Services.AddHostedService<SubscriptionChargeSchedulerService>();
 
             var allowedOrigins = builder.Configuration
                 .GetSection("Cors:AllowedOrigins")

--- a/Services/EmailLayout.cs
+++ b/Services/EmailLayout.cs
@@ -19,6 +19,41 @@ namespace garge_api.Services
             public string? FootNote { get; set; }    // e.g. "Vipps order #7"
         }
 
+        public sealed class Party
+        {
+            public string Label { get; set; } = string.Empty;
+            public string Name { get; set; } = string.Empty;
+            public List<string> Lines { get; set; } = new();
+        }
+
+        public static string RenderParties(Party from, Party to)
+        {
+            static string H(string? v) => HttpUtility.HtmlEncode(v ?? string.Empty);
+            static string LinesHtml(IEnumerable<string> lines) =>
+                string.Join("<br>", lines.Where(l => !string.IsNullOrEmpty(l)).Select(H));
+
+            return $$"""
+                <table role="presentation" class="parties" cellpadding="0" cellspacing="0" border="0">
+                  <tr>
+                    <td>
+                      <div class="party-label">{{H(from.Label)}}</div>
+                      <p>
+                        <strong>{{H(from.Name)}}</strong><br>
+                        {{LinesHtml(from.Lines)}}
+                      </p>
+                    </td>
+                    <td class="r">
+                      <div class="party-label">{{H(to.Label)}}</div>
+                      <p>
+                        <strong>{{H(to.Name)}}</strong><br>
+                        {{LinesHtml(to.Lines)}}
+                      </p>
+                    </td>
+                  </tr>
+                </table>
+                """;
+        }
+
         public static string Render(AppSettings s, Meta? meta, string bodyHtml)
         {
             static string H(string? v) => HttpUtility.HtmlEncode(v ?? string.Empty);
@@ -36,7 +71,7 @@ namespace garge_api.Services
                     : $"""<span class="badge">{H(meta.Badge)}</span>""";
                 var foot = string.IsNullOrEmpty(meta.FootNote) ? string.Empty
                     : $"""<div class="meta-foot">{H(meta.FootNote)}</div>""";
-                metaBlock = $"""<div class="meta">{number}{subtitle}{badge}{foot}</div>""";
+                metaBlock = $"{number}{subtitle}{badge}{foot}";
             }
 
             return $$"""
@@ -52,13 +87,12 @@ namespace garge_api.Services
                     background: #182232;
                     color: #fff;
                     padding: 28px 32px 20px;
-                    display: flex;
-                    justify-content: space-between;
-                    align-items: flex-start;
                   }
+                  .header-band table { width: 100%; }
+                  .header-band td { padding: 0; border: none; background: transparent; vertical-align: top; }
+                  .header-band td.r { text-align: right; }
                   .brand { font-size: 22px; font-weight: 700; letter-spacing: .04em; margin-bottom: 4px; }
                   .brand-sub { font-size: 11px; opacity: .85; line-height: 1.5; }
-                  .meta { text-align: right; }
                   .meta-number { font-size: 28px; font-weight: 700; line-height: 1; margin-bottom: 4px; }
                   .meta-subtitle { font-size: 11px; opacity: .85; margin-bottom: 6px; }
                   .meta-foot { margin-top: 6px; font-size: 10px; opacity: .75; }
@@ -80,8 +114,9 @@ namespace garge_api.Services
                   .body h1, .body h2 { color: #1a1a1a; margin-bottom: 8px; }
                   .body h1 { font-size: 18px; }
 
-                  .parties { display: flex; gap: 40px; margin-bottom: 24px; }
-                  .party { flex: 1; }
+                  table.parties { width: 100%; margin-bottom: 24px; border-collapse: separate; border-spacing: 0; }
+                  table.parties td { width: 50%; padding: 0 20px 0 0; vertical-align: top; border: none; background: transparent; }
+                  table.parties td.r { padding: 0 0 0 20px; text-align: right; }
                   .party-label {
                     font-size: 9px; font-weight: 700; text-transform: uppercase;
                     letter-spacing: .1em; color: #0284c7; margin-bottom: 6px;
@@ -120,16 +155,22 @@ namespace garge_api.Services
                 <body>
 
                 <div class="header-band">
-                  <div>
-                    <div class="brand">{{H(s.CompanyName)}}</div>
-                    <div class="brand-sub">
-                      {{H(s.CompanyLegalName)}}<br>
-                      Org. no. {{H(orgLine)}}<br>
-                      {{H(s.CompanyAddress)}}<br>
-                      {{H(s.CompanyEmail)}}
-                    </div>
-                  </div>
-                  {{metaBlock}}
+                  <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                    <tr>
+                      <td>
+                        <div class="brand">{{H(s.CompanyName)}}</div>
+                        <div class="brand-sub">
+                          {{H(s.CompanyLegalName)}}<br>
+                          Org. no. {{H(orgLine)}}<br>
+                          {{H(s.CompanyAddress)}}<br>
+                          {{H(s.CompanyEmail)}}
+                        </div>
+                      </td>
+                      <td class="r">
+                        {{metaBlock}}
+                      </td>
+                    </tr>
+                  </table>
                 </div>
 
                 <div class="body">

--- a/Services/IVippsService.cs
+++ b/Services/IVippsService.cs
@@ -20,6 +20,11 @@ namespace garge_api.Services
         public string VippsConfirmationUrl { get; set; } = string.Empty;
     }
 
+    public class VippsCreateChargeResponse
+    {
+        public string ChargeId { get; set; } = string.Empty;
+    }
+
     public class VippsAgreementResponse
     {
         public string Id { get; set; } = string.Empty;
@@ -27,6 +32,7 @@ namespace garge_api.Services
         public string ProductName { get; set; } = string.Empty;
         public DateTime? Start { get; set; }
         public DateTime? Stop { get; set; }
+        public string? Sub { get; set; }
     }
 
     public class VippsCreatePaymentResponse
@@ -80,6 +86,10 @@ namespace garge_api.Services
         Task<VippsAgreementResponse> GetAgreementAsync(string agreementId);
         Task CancelAgreementAsync(string agreementId, string idempotencyKey);
 
+        Task<VippsCreateChargeResponse> CreateChargeAsync(
+            string agreementId, int amountInOre, DateTime dueDate,
+            string description, string idempotencyKey);
+
         Task<VippsCreatePaymentResponse> CreatePaymentAsync(
             Order order, List<VippsOrderLine> receiptLines, string redirectUrl,
             string phoneNumber, string idempotencyKey);
@@ -87,6 +97,7 @@ namespace garge_api.Services
         Task<VippsUserInfo?> GetUserInfoAsync(string sub);
         Task CapturePaymentAsync(string reference, int amountInOre, string idempotencyKey);
         Task CancelPaymentAsync(string reference, string idempotencyKey);
+        Task RefundPaymentAsync(string reference, int amountInOre, string idempotencyKey);
 
         Task<(string WebhookId, string Secret)> RegisterWebhookAsync(string url, string[] events);
         WebhookVerifyResult VerifyWebhookSignature(HttpRequest request, string rawBody, string secret);

--- a/Services/InvoiceService.cs
+++ b/Services/InvoiceService.cs
@@ -195,24 +195,30 @@ namespace garge_api.Services
                 ? $"{subscription.User.FirstName} {subscription.User.LastName}"
                 : "—";
 
+            int net = amountInOre, vatAmount = 0;
+            if (s.VatEnabled)
+            {
+                net = (int)Math.Round(amountInOre / 1.25);
+                vatAmount = amountInOre - net;
+            }
+            var subRows = BuildVatSubRows(s.VatEnabled, net, vatAmount);
+
+            var partiesHtml = EmailLayout.RenderParties(
+                from: new EmailLayout.Party
+                {
+                    Label = "From",
+                    Name = s.CompanyLegalName,
+                    Lines = { s.CompanyAddress, s.CompanyEmail }
+                },
+                to: new EmailLayout.Party
+                {
+                    Label = "Bill to",
+                    Name = buyerName,
+                    Lines = { subscription.User?.Email ?? string.Empty, subscription.BillingAddress ?? string.Empty }
+                });
+
             var body = $$"""
-                <div class="parties">
-                  <div class="party">
-                    <div class="party-label">From</div>
-                    <p>
-                      <strong>{{H(s.CompanyLegalName)}}</strong><br>
-                      {{H(s.CompanyAddress)}}<br>
-                      {{H(s.CompanyEmail)}}
-                    </p>
-                  </div>
-                  <div class="party">
-                    <div class="party-label">Bill to</div>
-                    <p>
-                      <strong>{{H(buyerName)}}</strong><br>
-                      {{H(subscription.User?.Email)}}
-                    </p>
-                  </div>
-                </div>
+                {{partiesHtml}}
 
                 <table>
                   <thead>
@@ -231,6 +237,7 @@ namespace garge_api.Services
 
                 <div class="totals-section">
                   <table>
+                    <tbody>{{subRows}}</tbody>
                     <tbody>
                       <tr class="grand">
                         <td>Total</td>
@@ -290,12 +297,7 @@ namespace garge_api.Services
                     """);
             }
 
-            var subRows = s.VatEnabled
-                ? $"""
-                    <tr class="sub"><td class="r">Subtotal excl. VAT</td><td class="r">NOK {Nok(totalExcl)}</td></tr>
-                    <tr class="sub"><td class="r">VAT</td><td class="r">NOK {Nok(totalVat)}</td></tr>
-                  """
-                : string.Empty;
+            var subRows = BuildVatSubRows(s.VatEnabled, totalExcl, totalVat);
 
             var deliveryNote = order.ShippedAt.HasValue
                 ? $"Shipped on {order.ShippedAt.Value:yyyy-MM-dd}."
@@ -303,25 +305,22 @@ namespace garge_api.Services
 
             var buyerName = order.User != null ? $"{order.User.FirstName} {order.User.LastName}" : "—";
 
+            var partiesHtml = EmailLayout.RenderParties(
+                from: new EmailLayout.Party
+                {
+                    Label = "From",
+                    Name = s.CompanyLegalName,
+                    Lines = { s.CompanyAddress, s.CompanyEmail }
+                },
+                to: new EmailLayout.Party
+                {
+                    Label = "Bill to",
+                    Name = buyerName,
+                    Lines = { order.User?.Email ?? string.Empty, order.ShippingAddress ?? string.Empty }
+                });
+
             var body = $$"""
-                <div class="parties">
-                  <div class="party">
-                    <div class="party-label">From</div>
-                    <p>
-                      <strong>{{H(s.CompanyLegalName)}}</strong><br>
-                      {{H(s.CompanyAddress)}}<br>
-                      {{H(s.CompanyEmail)}}
-                    </p>
-                  </div>
-                  <div class="party">
-                    <div class="party-label">Bill to</div>
-                    <p>
-                      <strong>{{H(buyerName)}}</strong><br>
-                      {{H(order.User?.Email)}}<br>
-                      {{H(order.ShippingAddress)}}
-                    </p>
-                  </div>
-                </div>
+                {{partiesHtml}}
 
                 <table>
                   <thead>
@@ -351,7 +350,7 @@ namespace garge_api.Services
                 </div>
 
                 <div class="footer">
-                  <p>Payment received via Vipps.</p>
+                  <p>Paid via Vipps.</p>
                   <p>Delivery address: {{H(order.ShippingAddress)}} — {{deliveryNote}}</p>
                 </div>
                 """;
@@ -363,6 +362,15 @@ namespace garge_api.Services
                 Badge = "Paid",
                 FootNote = $"Vipps order #{order.Id}"
             }, body);
+        }
+
+        private static string BuildVatSubRows(bool vatEnabled, int netInOre, int vatInOre)
+        {
+            if (!vatEnabled) return string.Empty;
+            return $"""
+                    <tr class="sub"><td class="r">Subtotal excl. VAT</td><td class="r">NOK {MoneyFormat.Nok(netInOre)}</td></tr>
+                    <tr class="sub"><td class="r">VAT 25%</td><td class="r">NOK {MoneyFormat.Nok(vatInOre)}</td></tr>
+                """;
         }
     }
 }

--- a/Services/SubscriptionChargeSchedulerService.cs
+++ b/Services/SubscriptionChargeSchedulerService.cs
@@ -1,0 +1,84 @@
+using garge_api.Models;
+using garge_api.Models.Subscription;
+using Microsoft.EntityFrameworkCore;
+
+namespace garge_api.Services
+{
+    public class SubscriptionChargeSchedulerService : BackgroundService
+    {
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly ILogger<SubscriptionChargeSchedulerService> _logger;
+        private static readonly TimeSpan Interval = TimeSpan.FromDays(1);
+        private static readonly TimeSpan Lookahead = TimeSpan.FromDays(7);
+
+        public SubscriptionChargeSchedulerService(
+            IServiceScopeFactory scopeFactory,
+            ILogger<SubscriptionChargeSchedulerService> logger)
+        {
+            _scopeFactory = scopeFactory;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                await ScheduleDueChargesAsync(stoppingToken);
+                await Task.Delay(Interval, stoppingToken);
+            }
+        }
+
+        internal async Task ScheduleDueChargesAsync(CancellationToken stoppingToken)
+        {
+            try
+            {
+                using var scope = _scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                var vipps = scope.ServiceProvider.GetRequiredService<IVippsService>();
+                var settingsCache = scope.ServiceProvider.GetRequiredService<IAppSettingsCache>();
+
+                var settings = await settingsCache.GetAsync();
+                var testMode = settings.VippsTestMode;
+                var cutoff = DateTime.UtcNow + Lookahead;
+
+                var due = await db.Subscriptions
+                    .Include(s => s.Product)
+                    .Where(s => s.Status == SubscriptionStatus.Active
+                                && s.IsTest == testMode
+                                && s.NextChargeDate != null
+                                && s.NextChargeDate <= cutoff
+                                && s.Product != null)
+                    .ToListAsync(stoppingToken);
+
+                foreach (var sub in due)
+                {
+                    if (sub.Product == null || !sub.NextChargeDate.HasValue) continue;
+
+                    var dueDate = sub.NextChargeDate.Value;
+                    try
+                    {
+                        await vipps.CreateChargeAsync(
+                            sub.VippsAgreementId,
+                            sub.Product.PriceInOre,
+                            dueDate,
+                            sub.Product.Name,
+                            idempotencyKey: $"charge-{sub.Id}-{dueDate.Ticks}");
+
+                        _logger.LogInformation("ChargeScheduler: posted charge for subscription {SubId} due {DueDate}",
+                            sub.Id, dueDate);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "ChargeScheduler: failed to post charge for subscription {SubId} due {DueDate}",
+                            sub.Id, dueDate);
+                    }
+                }
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "ChargeScheduler: unexpected error during sweep.");
+            }
+        }
+    }
+}

--- a/Services/SubscriptionEmailService.cs
+++ b/Services/SubscriptionEmailService.cs
@@ -26,35 +26,81 @@ namespace garge_api.Services
         public Task SendActivatedAsync(int subscriptionId) =>
             SendAsync(subscriptionId, kind: "activated",
                 subjectFormat: "Subscription confirmed — {0}",
-                buildBody: (sub, s) =>
-                {
-                    var productName = sub.Product?.Name ?? "Garge subscription";
-                    var period = sub.Product?.Interval == BillingInterval.Yearly ? "yearly" : "monthly";
-                    var price = sub.Product != null ? MoneyFormat.Nok(sub.Product.PriceInOre) : null;
-                    var nextChargeLine = sub.NextChargeDate.HasValue
-                        ? $"<p>Next charge: <strong>{sub.NextChargeDate.Value:yyyy-MM-dd}</strong>.</p>"
-                        : string.Empty;
-
-                    return $$"""
-                        <h1>Welcome aboard, {{H(sub.User?.FirstName)}}!</h1>
-                        <p>Your <strong>{{H(productName)}}</strong> {{period}} subscription is active. Vipps will charge {{(price != null ? $"NOK {price}" : "the agreed amount")}} per {{(period == "yearly" ? "year" : "month")}}.</p>
-                        {{nextChargeLine}}
-                        <p>Receipts for every charge land here as PDF invoices.</p>
-                        """;
-                });
+                buildBody: (sub, s) => BuildSubscriptionEmailBody(
+                    sub, s,
+                    headline: $"Welcome aboard, {H(sub.User?.FirstName)}!",
+                    intro: "Your subscription is now active.",
+                    footerNote: BuildActivatedFooter(sub)));
 
         public Task SendChargeFailedAsync(int subscriptionId) =>
             SendAsync(subscriptionId, kind: "charge-failed",
                 subjectFormat: "Action needed: subscription payment failed — {0}",
-                buildBody: (sub, s) =>
+                buildBody: (sub, s) => BuildSubscriptionEmailBody(
+                    sub, s,
+                    headline: "We couldn't charge your subscription",
+                    intro: $"Hi {H(sub.User?.FirstName)}, the latest charge failed. We'll retry automatically — update your payment method in the Vipps app to avoid the agreement being stopped.",
+                    footerNote: "If you've already fixed it, you can ignore this email."));
+
+        private static string BuildActivatedFooter(Subscription sub)
+        {
+            var parts = new List<string>();
+            if (sub.NextChargeDate.HasValue)
+                parts.Add($"Next charge on {sub.NextChargeDate.Value:yyyy-MM-dd}.");
+            parts.Add("Cancel anytime under Billing.");
+            if (sub.ConsentAcceptedAt.HasValue)
+                parts.Add($"You waived your 14-day right of withdrawal at signup on {sub.ConsentAcceptedAt.Value:yyyy-MM-dd}, so service is delivered immediately.");
+            return string.Join(" ", parts);
+        }
+
+        private static string BuildSubscriptionEmailBody(
+            Subscription sub, AppSettings s, string headline, string intro, string footerNote)
+        {
+            var productName = sub.Product?.Name ?? "Garge subscription";
+            var period = sub.Product?.Interval == BillingInterval.Yearly ? "year" : "month";
+            var price = sub.Product != null ? MoneyFormat.Nok(sub.Product.PriceInOre) : null;
+            var buyerName = ((sub.User?.FirstName ?? string.Empty) + " " + (sub.User?.LastName ?? string.Empty)).Trim();
+            var amountCell = price != null ? $"NOK {price} / {period}" : "—";
+
+            var partiesHtml = EmailLayout.RenderParties(
+                from: new EmailLayout.Party
                 {
-                    var productName = sub.Product?.Name ?? "Garge subscription";
-                    return $$"""
-                        <h1>We couldn't charge your subscription</h1>
-                        <p>Hi {{H(sub.User?.FirstName)}}, the latest charge for <strong>{{H(productName)}}</strong> failed. Vipps will retry, but please update your payment method in the Vipps app to avoid the agreement being stopped.</p>
-                        <p>If you've already fixed it, you can ignore this email.</p>
-                        """;
+                    Label = "From",
+                    Name = s.CompanyLegalName,
+                    Lines = { s.CompanyAddress, s.CompanyEmail }
+                },
+                to: new EmailLayout.Party
+                {
+                    Label = "Subscriber",
+                    Name = buyerName,
+                    Lines = { sub.User?.Email ?? string.Empty, sub.BillingAddress ?? string.Empty }
                 });
+
+            return $$"""
+                <h1>{{headline}}</h1>
+                <p>{{H(intro)}}</p>
+
+                {{partiesHtml}}
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Subscription</th>
+                      <th class="r">Amount</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>{{H(productName)}} — {{period}}ly</td>
+                      <td class="r">{{H(amountCell)}}</td>
+                    </tr>
+                  </tbody>
+                </table>
+
+                <div class="footer">
+                  <p>{{H(footerNote)}}</p>
+                </div>
+                """;
+        }
 
         private async Task SendAsync(
             int subscriptionId,

--- a/Services/VippsService.cs
+++ b/Services/VippsService.cs
@@ -149,11 +149,18 @@ namespace garge_api.Services
                     unit = product.Interval == BillingInterval.Monthly ? "MONTH" : "YEAR",
                     count = 1
                 },
+                initialCharge = new
+                {
+                    amount = effectivePriceInOre,
+                    description = product.Name,
+                    transactionType = "DIRECT_CAPTURE"
+                },
                 merchantRedirectUrl = redirectUrl,
                 merchantAgreementUrl = $"{_appOpts.FrontendBaseUrl}/terms",
                 productName = product.Name,
                 productDescription = product.Description ?? string.Empty,
-                phoneNumber
+                phoneNumber,
+                scope = "name address email phoneNumber"
             };
 
             var request = new HttpRequestMessage(HttpMethod.Post, $"{e.BaseUrl}/recurring/v3/agreements");
@@ -163,6 +170,38 @@ namespace garge_api.Services
             var response = await _http.SendAsync(request);
             var json = await ReadAsStringAndEnsureSuccessAsync(response, "create-agreement");
             return JsonSerializer.Deserialize<VippsCreateAgreementResponse>(json, _jsonOpts)!;
+        }
+
+        public async Task<VippsCreateChargeResponse> CreateChargeAsync(
+            string agreementId, int amountInOre, DateTime dueDate,
+            string description, string idempotencyKey)
+        {
+            var e = await GetEffectiveAsync();
+
+            var minDue = DateTime.UtcNow.Date.AddDays(2);
+            if (dueDate.Date < minDue) dueDate = minDue;
+
+            var orderId = idempotencyKey.Length <= 50 ? idempotencyKey : idempotencyKey[..50];
+
+            var body = new
+            {
+                amount = amountInOre,
+                transactionType = "DIRECT_CAPTURE",
+                type = "RECURRING",
+                description,
+                due = dueDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                retryDays = 5,
+                orderId
+            };
+
+            var request = new HttpRequestMessage(HttpMethod.Post,
+                $"{e.BaseUrl}/recurring/v3/agreements/{agreementId}/charges");
+            AddCommonHeaders(request, e, idempotencyKey);
+            request.Content = BuildJsonContent(body);
+
+            var response = await _http.SendAsync(request);
+            var json = await ReadAsStringAndEnsureSuccessAsync(response, "create-charge");
+            return JsonSerializer.Deserialize<VippsCreateChargeResponse>(json, _jsonOpts)!;
         }
 
         public async Task<VippsAgreementResponse> GetAgreementAsync(string agreementId)
@@ -355,6 +394,18 @@ namespace garge_api.Services
             request.Content = BuildJsonContent(new { });
             var response = await _http.SendAsync(request);
             await ReadAsStringAndEnsureSuccessAsync(response, "cancel-payment");
+        }
+
+        public async Task RefundPaymentAsync(string reference, int amountInOre, string idempotencyKey)
+        {
+            var e = await GetEffectiveAsync();
+            var body = new { modificationAmount = new { value = amountInOre, currency = "NOK" } };
+            var request = new HttpRequestMessage(HttpMethod.Post,
+                $"{e.BaseUrl}/epayment/v1/payments/{reference}/refund");
+            AddCommonHeaders(request, e, idempotencyKey);
+            request.Content = BuildJsonContent(body);
+            var response = await _http.SendAsync(request);
+            await ReadAsStringAndEnsureSuccessAsync(response, "refund-payment");
         }
 
         public async Task<(string WebhookId, string Secret)> RegisterWebhookAsync(string url, string[] events)

--- a/garge-api.Tests/ShopControllerTests.cs
+++ b/garge-api.Tests/ShopControllerTests.cs
@@ -617,6 +617,106 @@ public class ShopControllerTests : ControllerTestBase
         Assert.Equal(1, reloaded.StockCount);
     }
 
+    [Fact]
+    public async Task RefundOrder_PaidOrder_CallsVippsAndSetsStatusToRefunded()
+    {
+        using var db = CreateDbContext();
+        var order = new Order
+        {
+            UserId = "user-1", VippsOrderId = "garge-order-000007",
+            TotalInOre = 12500, Status = OrderStatus.Paid
+        };
+        await db.Orders.AddAsync(order);
+        await db.SaveChangesAsync();
+
+        var vipps = MockVipps();
+        vipps.Setup(v => v.RefundPaymentAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
+            .Returns(Task.CompletedTask);
+
+        var ctrl = CreateController(db, vipps: vipps);
+        var result = await ctrl.RefundOrder(order.Id);
+
+        Assert.IsType<OkResult>(result);
+        vipps.Verify(v => v.RefundPaymentAsync("garge-order-000007", 12500, $"refund-{order.Id}"), Times.Once);
+        var updated = await db.Orders.FindAsync(order.Id);
+        Assert.Equal(OrderStatus.Refunded, updated!.Status);
+    }
+
+    [Fact]
+    public async Task RefundOrder_NonPaidOrder_Returns400AndDoesNotCallVipps()
+    {
+        using var db = CreateDbContext();
+        var order = new Order
+        {
+            UserId = "user-1", VippsOrderId = "garge-order-000008",
+            TotalInOre = 5000, Status = OrderStatus.Reserved
+        };
+        await db.Orders.AddAsync(order);
+        await db.SaveChangesAsync();
+
+        var vipps = MockVipps();
+        var ctrl = CreateController(db, vipps: vipps);
+        var result = await ctrl.RefundOrder(order.Id);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        vipps.Verify(v => v.RefundPaymentAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+        var updated = await db.Orders.FindAsync(order.Id);
+        Assert.Equal(OrderStatus.Reserved, updated!.Status);
+    }
+
+    [Fact]
+    public async Task RefundOrder_PaidOrderMissingVippsOrderId_Returns400()
+    {
+        using var db = CreateDbContext();
+        var order = new Order
+        {
+            UserId = "user-1", VippsOrderId = null,
+            TotalInOre = 5000, Status = OrderStatus.Paid
+        };
+        await db.Orders.AddAsync(order);
+        await db.SaveChangesAsync();
+
+        var vipps = MockVipps();
+        var ctrl = CreateController(db, vipps: vipps);
+        var result = await ctrl.RefundOrder(order.Id);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        vipps.Verify(v => v.RefundPaymentAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RefundOrder_UnknownOrder_Returns404()
+    {
+        using var db = CreateDbContext();
+        var ctrl = CreateController(db);
+        var result = await ctrl.RefundOrder(9999);
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task RefundOrder_VippsThrows_StatusStaysPaid()
+    {
+        using var db = CreateDbContext();
+        var order = new Order
+        {
+            UserId = "user-1", VippsOrderId = "garge-order-000009",
+            TotalInOre = 7700, Status = OrderStatus.Paid
+        };
+        await db.Orders.AddAsync(order);
+        await db.SaveChangesAsync();
+
+        var vipps = MockVipps();
+        vipps.Setup(v => v.RefundPaymentAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
+            .ThrowsAsync(new HttpRequestException("Vipps unavailable"));
+
+        var ctrl = CreateController(db, vipps: vipps);
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => ctrl.RefundOrder(order.Id));
+
+        var updated = await db.Orders.FindAsync(order.Id);
+        Assert.Equal(OrderStatus.Paid, updated!.Status);
+    }
+
     private static void SetupValidWebhookRequest(ShopController ctrl, string body) =>
         SetupWebhookRequest(ctrl, body, valid: true);
 

--- a/garge-api.Tests/SubscriptionChargeSchedulerServiceTests.cs
+++ b/garge-api.Tests/SubscriptionChargeSchedulerServiceTests.cs
@@ -1,0 +1,211 @@
+using garge_api.Models;
+using garge_api.Models.Admin;
+using garge_api.Models.Subscription;
+using garge_api.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace garge_api.Tests;
+
+public class SubscriptionChargeSchedulerServiceTests
+{
+    private static (SubscriptionChargeSchedulerService svc, Mock<IVippsService> vipps, ApplicationDbContext db)
+        BuildHarness(bool testMode = false)
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var services = new ServiceCollection();
+        services.AddDbContext<ApplicationDbContext>(o =>
+            o.UseInMemoryDatabase(dbName)
+             .ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning)));
+
+        var vipps = new Mock<IVippsService>();
+        services.AddSingleton(vipps.Object);
+
+        var settings = new Mock<IAppSettingsCache>();
+        settings.Setup(s => s.GetAsync()).ReturnsAsync(new AppSettings { Id = 1, VippsTestMode = testMode });
+        services.AddSingleton(settings.Object);
+
+        var provider = services.BuildServiceProvider();
+        var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+        var svc = new SubscriptionChargeSchedulerService(scopeFactory,
+            NullLogger<SubscriptionChargeSchedulerService>.Instance);
+        var db = provider.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        return (svc, vipps, db);
+    }
+
+    private static Product MakePrimaryProduct(int id = 1) => new()
+    {
+        Id = id, Name = "Garge Basic", PriceInOre = 29900,
+        Interval = BillingInterval.Monthly, Type = ProductType.Primary, IsActive = true
+    };
+
+    [Fact]
+    public async Task Scheduler_ActiveSubDueWithinLookahead_PostsChargeWithIdempotencyKey()
+    {
+        var (svc, vipps, db) = BuildHarness();
+        var dueDate = DateTime.UtcNow.AddDays(3);
+        await db.Products.AddAsync(MakePrimaryProduct());
+        var sub = new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr_due", Status = SubscriptionStatus.Active,
+            NextChargeDate = dueDate
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        await svc.ScheduleDueChargesAsync(CancellationToken.None);
+
+        vipps.Verify(v => v.CreateChargeAsync(
+            "agr_due", 29900, dueDate, "Garge Basic",
+            $"charge-{sub.Id}-{dueDate.Ticks}"), Times.Once);
+    }
+
+    [Fact]
+    public async Task Scheduler_ActiveSubBeyondLookahead_NotCharged()
+    {
+        var (svc, vipps, db) = BuildHarness();
+        await db.Products.AddAsync(MakePrimaryProduct());
+        var sub = new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr_far", Status = SubscriptionStatus.Active,
+            NextChargeDate = DateTime.UtcNow.AddDays(20)
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        await svc.ScheduleDueChargesAsync(CancellationToken.None);
+
+        vipps.Verify(v => v.CreateChargeAsync(
+            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<DateTime>(),
+            It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData(SubscriptionStatus.Pending)]
+    [InlineData(SubscriptionStatus.Stopped)]
+    [InlineData(SubscriptionStatus.Expired)]
+    public async Task Scheduler_NonActiveStatuses_Skipped(SubscriptionStatus status)
+    {
+        var (svc, vipps, db) = BuildHarness();
+        await db.Products.AddAsync(MakePrimaryProduct());
+        var sub = new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr_inactive", Status = status,
+            NextChargeDate = DateTime.UtcNow.AddDays(1)
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        await svc.ScheduleDueChargesAsync(CancellationToken.None);
+
+        vipps.Verify(v => v.CreateChargeAsync(
+            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<DateTime>(),
+            It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Scheduler_TestSubInLiveMode_NotCharged()
+    {
+        var (svc, vipps, db) = BuildHarness(testMode: false);
+        await db.Products.AddAsync(MakePrimaryProduct());
+        var sub = new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr_test", Status = SubscriptionStatus.Active,
+            NextChargeDate = DateTime.UtcNow.AddDays(1),
+            IsTest = true
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        await svc.ScheduleDueChargesAsync(CancellationToken.None);
+
+        vipps.Verify(v => v.CreateChargeAsync(
+            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<DateTime>(),
+            It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Scheduler_LiveSubInTestMode_NotCharged()
+    {
+        var (svc, vipps, db) = BuildHarness(testMode: true);
+        await db.Products.AddAsync(MakePrimaryProduct());
+        var sub = new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr_live", Status = SubscriptionStatus.Active,
+            NextChargeDate = DateTime.UtcNow.AddDays(1),
+            IsTest = false
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        await svc.ScheduleDueChargesAsync(CancellationToken.None);
+
+        vipps.Verify(v => v.CreateChargeAsync(
+            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<DateTime>(),
+            It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Scheduler_OneSubThrows_OthersStillProcessed()
+    {
+        var (svc, vipps, db) = BuildHarness();
+        await db.Products.AddAsync(MakePrimaryProduct());
+        var sub1 = new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr_a", Status = SubscriptionStatus.Active,
+            NextChargeDate = DateTime.UtcNow.AddDays(1)
+        };
+        var sub2 = new Subscription
+        {
+            UserId = "user-2", ProductId = 1,
+            VippsAgreementId = "agr_b", Status = SubscriptionStatus.Active,
+            NextChargeDate = DateTime.UtcNow.AddDays(2)
+        };
+        await db.Subscriptions.AddRangeAsync(sub1, sub2);
+        await db.SaveChangesAsync();
+
+        vipps.Setup(v => v.CreateChargeAsync("agr_a", It.IsAny<int>(), It.IsAny<DateTime>(),
+                It.IsAny<string>(), It.IsAny<string>()))
+            .ThrowsAsync(new HttpRequestException("Vipps boom"));
+        vipps.Setup(v => v.CreateChargeAsync("agr_b", It.IsAny<int>(), It.IsAny<DateTime>(),
+                It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new VippsCreateChargeResponse { ChargeId = "chg_b" });
+
+        await svc.ScheduleDueChargesAsync(CancellationToken.None);
+
+        vipps.Verify(v => v.CreateChargeAsync("agr_a", It.IsAny<int>(), It.IsAny<DateTime>(),
+            It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        vipps.Verify(v => v.CreateChargeAsync("agr_b", It.IsAny<int>(), It.IsAny<DateTime>(),
+            It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Scheduler_NextChargeDateNull_Skipped()
+    {
+        var (svc, vipps, db) = BuildHarness();
+        await db.Products.AddAsync(MakePrimaryProduct());
+        var sub = new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr_null", Status = SubscriptionStatus.Active,
+            NextChargeDate = null
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        await svc.ScheduleDueChargesAsync(CancellationToken.None);
+
+        vipps.Verify(v => v.CreateChargeAsync(
+            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<DateTime>(),
+            It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+}

--- a/garge-api.Tests/SubscriptionsControllerTests.cs
+++ b/garge-api.Tests/SubscriptionsControllerTests.cs
@@ -131,6 +131,40 @@ public class SubscriptionsControllerTests : ControllerTestBase
     }
 
     [Fact]
+    public async Task Webhook_ConcurrentDuplicates_OnlyOneRecorded()
+    {
+        using var db = CreateDbContext();
+        var sub = new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr_race", Status = SubscriptionStatus.Pending
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        var payload = new VippsAgreementWebhookDto
+        {
+            AgreementId = "agr_race",
+            EventId = "evt-race",
+            EventType = "recurring.agreement-activated.v1",
+            Occurred = DateTime.UtcNow
+        };
+        var body = JsonSerializer.Serialize(payload);
+
+        var settings = new AppSettings { Id = 1, VippsSubscriptionWebhookSecret = "secret" };
+        var ctrl1 = CreateController(db, settings: settings);
+        var ctrl2 = CreateController(db, settings: settings);
+        SetupValidWebhookRequest(ctrl1, body);
+        SetupValidWebhookRequest(ctrl2, body);
+
+        var t1 = ctrl1.Webhook();
+        var t2 = ctrl2.Webhook();
+        await Task.WhenAll(t1, t2);
+
+        Assert.Equal(1, await db.ProcessedWebhookEvents.CountAsync(e => e.Id == "evt-race"));
+    }
+
+    [Fact]
     public async Task Webhook_DuplicateEvent_SkipsSecondProcessing()
     {
         using var db = CreateDbContext();
@@ -370,7 +404,7 @@ public class SubscriptionsControllerTests : ControllerTestBase
     }
 
     [Fact]
-    public async Task Webhook_ChargeCaptured_PostsNextChargeWithIdempotencyKey()
+    public async Task Webhook_ChargeCaptured_DoesNotCallCreateChargeAsync_SchedulerIsSoleSource()
     {
         using var db = CreateDbContext();
         var occurred = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -378,109 +412,20 @@ public class SubscriptionsControllerTests : ControllerTestBase
         var sub = new Subscription
         {
             UserId = "user-1", ProductId = 1,
-            VippsAgreementId = "agr_next", Status = SubscriptionStatus.Active
+            VippsAgreementId = "agr_no_post", Status = SubscriptionStatus.Active
         };
         await db.Subscriptions.AddAsync(sub);
         await db.SaveChangesAsync();
 
+        var vipps = MockVipps();
+
         var payload = new
         {
-            agreementId = "agr_next",
-            eventId = "evt-next",
+            agreementId = "agr_no_post",
+            eventId = "evt-no-post",
             eventType = "recurring.charge-captured.v1",
-            chargeId = "chg_1",
+            chargeId = "chg_p",
             occurred
-        };
-        var body = JsonSerializer.Serialize(payload);
-
-        var vipps = MockVipps();
-        vipps.Setup(v => v.CreateChargeAsync(
-                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<DateTime>(),
-                It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(new VippsCreateChargeResponse { ChargeId = "chg_2" });
-
-        var expectedDue = occurred.AddMonths(1);
-
-        var ctrl = CreateController(db,
-            settings: new AppSettings { Id = 1, VippsSubscriptionWebhookSecret = "secret" },
-            vipps: vipps);
-        SetupValidWebhookRequest(ctrl, body);
-        await ctrl.Webhook();
-
-        vipps.Verify(v => v.CreateChargeAsync(
-            "agr_next",
-            29900,
-            expectedDue,
-            It.IsAny<string>(),
-            $"charge-{sub.Id}-{expectedDue.Ticks}"),
-            Times.Once);
-    }
-
-    [Fact]
-    public async Task Webhook_ChargeCaptured_CreateChargeThrows_StillReturnsOk()
-    {
-        using var db = CreateDbContext();
-        var occurred = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc);
-        await db.Products.AddAsync(MakePrimaryProduct());
-        var sub = new Subscription
-        {
-            UserId = "user-1", ProductId = 1,
-            VippsAgreementId = "agr_throw", Status = SubscriptionStatus.Active
-        };
-        await db.Subscriptions.AddAsync(sub);
-        await db.SaveChangesAsync();
-
-        var vipps = MockVipps();
-        vipps.Setup(v => v.CreateChargeAsync(
-                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<DateTime>(),
-                It.IsAny<string>(), It.IsAny<string>()))
-            .ThrowsAsync(new HttpRequestException("Vipps unavailable"));
-
-        var invoice = new Mock<IInvoiceService>();
-        invoice.Setup(i => i.GenerateForSubscriptionChargeAsync(
-                It.IsAny<int>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<DateTime>()))
-            .ReturnsAsync(7);
-
-        var payload = new
-        {
-            agreementId = "agr_throw",
-            eventId = "evt-throw",
-            eventType = "recurring.charge-captured.v1",
-            chargeId = "chg_t",
-            occurred
-        };
-        var ctrl = CreateController(db,
-            settings: new AppSettings { Id = 1, VippsSubscriptionWebhookSecret = "secret" },
-            vipps: vipps, invoice: invoice.Object);
-        SetupValidWebhookRequest(ctrl, JsonSerializer.Serialize(payload));
-        var result = await ctrl.Webhook();
-
-        Assert.IsType<OkResult>(result);
-        invoice.Verify(i => i.GenerateForSubscriptionChargeAsync(
-            sub.Id, "chg_t", 29900, occurred), Times.Once);
-    }
-
-    [Fact]
-    public async Task Webhook_ChargeCaptured_NullOccurred_DoesNotCallCreateCharge()
-    {
-        using var db = CreateDbContext();
-        await db.Products.AddAsync(MakePrimaryProduct());
-        var sub = new Subscription
-        {
-            UserId = "user-1", ProductId = 1,
-            VippsAgreementId = "agr_noocc", Status = SubscriptionStatus.Active
-        };
-        await db.Subscriptions.AddAsync(sub);
-        await db.SaveChangesAsync();
-
-        var vipps = MockVipps();
-
-        var payload = new
-        {
-            agreementId = "agr_noocc",
-            eventId = "evt-noocc",
-            eventType = "recurring.charge-captured.v1",
-            chargeId = "chg_n"
         };
         var ctrl = CreateController(db,
             settings: new AppSettings { Id = 1, VippsSubscriptionWebhookSecret = "secret" },
@@ -492,11 +437,40 @@ public class SubscriptionsControllerTests : ControllerTestBase
             It.IsAny<string>(), It.IsAny<int>(), It.IsAny<DateTime>(),
             It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         var updated = await db.Subscriptions.FirstAsync();
+        Assert.Equal(occurred.AddMonths(1), updated.NextChargeDate);
+    }
+
+    [Fact]
+    public async Task Webhook_ChargeCaptured_NullOccurred_LeavesNextChargeDateNull()
+    {
+        using var db = CreateDbContext();
+        await db.Products.AddAsync(MakePrimaryProduct());
+        var sub = new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr_noocc", Status = SubscriptionStatus.Active
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        var payload = new
+        {
+            agreementId = "agr_noocc",
+            eventId = "evt-noocc",
+            eventType = "recurring.charge-captured.v1",
+            chargeId = "chg_n"
+        };
+        var ctrl = CreateController(db,
+            settings: new AppSettings { Id = 1, VippsSubscriptionWebhookSecret = "secret" });
+        SetupValidWebhookRequest(ctrl, JsonSerializer.Serialize(payload));
+        await ctrl.Webhook();
+
+        var updated = await db.Subscriptions.FirstAsync();
         Assert.Null(updated.NextChargeDate);
     }
 
     [Fact]
-    public async Task Webhook_ChargeCaptured_YearlyProduct_DueDateIsPlusOneYear()
+    public async Task Webhook_ChargeCaptured_YearlyProduct_NextChargeDateIsPlusOneYear()
     {
         using var db = CreateDbContext();
         var occurred = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -513,12 +487,6 @@ public class SubscriptionsControllerTests : ControllerTestBase
         await db.Subscriptions.AddAsync(sub);
         await db.SaveChangesAsync();
 
-        var vipps = MockVipps();
-        vipps.Setup(v => v.CreateChargeAsync(
-                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<DateTime>(),
-                It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(new VippsCreateChargeResponse { ChargeId = "chg_yr2" });
-
         var payload = new
         {
             agreementId = "agr_yr",
@@ -528,15 +496,12 @@ public class SubscriptionsControllerTests : ControllerTestBase
             occurred
         };
         var ctrl = CreateController(db,
-            settings: new AppSettings { Id = 1, VippsSubscriptionWebhookSecret = "secret" },
-            vipps: vipps);
+            settings: new AppSettings { Id = 1, VippsSubscriptionWebhookSecret = "secret" });
         SetupValidWebhookRequest(ctrl, JsonSerializer.Serialize(payload));
         await ctrl.Webhook();
 
-        var expectedDue = occurred.AddYears(1);
-        vipps.Verify(v => v.CreateChargeAsync(
-            "agr_yr", 99900, expectedDue, It.IsAny<string>(),
-            $"charge-{sub.Id}-{expectedDue.Ticks}"), Times.Once);
+        var updated = await db.Subscriptions.FirstAsync();
+        Assert.Equal(occurred.AddYears(1), updated.NextChargeDate);
     }
 
     private static void SetupValidWebhookRequest(SubscriptionsController ctrl, string body) =>

--- a/garge-api.Tests/SubscriptionsControllerTests.cs
+++ b/garge-api.Tests/SubscriptionsControllerTests.cs
@@ -195,6 +195,150 @@ public class SubscriptionsControllerTests : ControllerTestBase
     }
 
     [Fact]
+    public async Task Webhook_Activated_VippsReturnsAddress_PopulatesBillingAddress()
+    {
+        using var db = CreateDbContext();
+        var sub = new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr_addr1", Status = SubscriptionStatus.Pending
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        var vipps = MockVipps();
+        vipps.Setup(v => v.GetAgreementAsync("agr_addr1"))
+            .ReturnsAsync(new VippsAgreementResponse { Id = "agr_addr1", Sub = "sub-x" });
+        vipps.Setup(v => v.GetUserInfoAsync("sub-x"))
+            .ReturnsAsync(new VippsUserInfo
+            {
+                Address = new VippsAddress { Formatted = "Mårvegen 21a, 4347 Lye, Norway" }
+            });
+
+        var payload = new
+        {
+            agreementId = "agr_addr1",
+            eventId = "evt-addr1",
+            eventType = "recurring.agreement-activated.v1",
+            occurred = DateTime.UtcNow
+        };
+        var ctrl = CreateController(db,
+            settings: new AppSettings { Id = 1, VippsSubscriptionWebhookSecret = "secret" },
+            vipps: vipps);
+        SetupValidWebhookRequest(ctrl, JsonSerializer.Serialize(payload));
+        await ctrl.Webhook();
+
+        var updated = await db.Subscriptions.FirstAsync();
+        Assert.Equal("Mårvegen 21a, 4347 Lye, Norway", updated.BillingAddress);
+        Assert.Equal(SubscriptionStatus.Active, updated.Status);
+    }
+
+    [Fact]
+    public async Task Webhook_Activated_NoSubReturned_LeavesBillingAddressNull()
+    {
+        using var db = CreateDbContext();
+        var sub = new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr_addr2", Status = SubscriptionStatus.Pending
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        var vipps = MockVipps();
+        vipps.Setup(v => v.GetAgreementAsync("agr_addr2"))
+            .ReturnsAsync(new VippsAgreementResponse { Id = "agr_addr2", Sub = null });
+
+        var payload = new
+        {
+            agreementId = "agr_addr2",
+            eventId = "evt-addr2",
+            eventType = "recurring.agreement-activated.v1",
+            occurred = DateTime.UtcNow
+        };
+        var ctrl = CreateController(db,
+            settings: new AppSettings { Id = 1, VippsSubscriptionWebhookSecret = "secret" },
+            vipps: vipps);
+        SetupValidWebhookRequest(ctrl, JsonSerializer.Serialize(payload));
+        await ctrl.Webhook();
+
+        var updated = await db.Subscriptions.FirstAsync();
+        Assert.Null(updated.BillingAddress);
+        Assert.Equal(SubscriptionStatus.Active, updated.Status);
+        vipps.Verify(v => v.GetUserInfoAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Webhook_Activated_GetUserInfoThrows_Swallowed_StatusStillActive()
+    {
+        using var db = CreateDbContext();
+        var sub = new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr_addr3", Status = SubscriptionStatus.Pending
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        var vipps = MockVipps();
+        vipps.Setup(v => v.GetAgreementAsync("agr_addr3"))
+            .ReturnsAsync(new VippsAgreementResponse { Id = "agr_addr3", Sub = "sub-y" });
+        vipps.Setup(v => v.GetUserInfoAsync("sub-y"))
+            .ThrowsAsync(new HttpRequestException("Vipps userinfo down"));
+
+        var payload = new
+        {
+            agreementId = "agr_addr3",
+            eventId = "evt-addr3",
+            eventType = "recurring.agreement-activated.v1",
+            occurred = DateTime.UtcNow
+        };
+        var ctrl = CreateController(db,
+            settings: new AppSettings { Id = 1, VippsSubscriptionWebhookSecret = "secret" },
+            vipps: vipps);
+        SetupValidWebhookRequest(ctrl, JsonSerializer.Serialize(payload));
+        var result = await ctrl.Webhook();
+
+        Assert.IsType<OkResult>(result);
+        var updated = await db.Subscriptions.FirstAsync();
+        Assert.Null(updated.BillingAddress);
+        Assert.Equal(SubscriptionStatus.Active, updated.Status);
+    }
+
+    [Fact]
+    public async Task Webhook_Activated_BillingAddressAlreadySet_NotOverwritten()
+    {
+        using var db = CreateDbContext();
+        var sub = new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr_addr4",
+            Status = SubscriptionStatus.Pending,
+            BillingAddress = "Existing address"
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        var vipps = MockVipps();
+        var payload = new
+        {
+            agreementId = "agr_addr4",
+            eventId = "evt-addr4",
+            eventType = "recurring.agreement-activated.v1",
+            occurred = DateTime.UtcNow
+        };
+        var ctrl = CreateController(db,
+            settings: new AppSettings { Id = 1, VippsSubscriptionWebhookSecret = "secret" },
+            vipps: vipps);
+        SetupValidWebhookRequest(ctrl, JsonSerializer.Serialize(payload));
+        await ctrl.Webhook();
+
+        var updated = await db.Subscriptions.FirstAsync();
+        Assert.Equal("Existing address", updated.BillingAddress);
+        vipps.Verify(v => v.GetAgreementAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
     public async Task Webhook_ChargeCaptured_SetsNextChargeDateByInterval()
     {
         using var db = CreateDbContext();
@@ -223,6 +367,176 @@ public class SubscriptionsControllerTests : ControllerTestBase
 
         var updated = await db.Subscriptions.FirstAsync();
         Assert.Equal(occurred.AddMonths(1), updated.NextChargeDate);
+    }
+
+    [Fact]
+    public async Task Webhook_ChargeCaptured_PostsNextChargeWithIdempotencyKey()
+    {
+        using var db = CreateDbContext();
+        var occurred = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc);
+        await db.Products.AddAsync(MakePrimaryProduct());
+        var sub = new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr_next", Status = SubscriptionStatus.Active
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        var payload = new
+        {
+            agreementId = "agr_next",
+            eventId = "evt-next",
+            eventType = "recurring.charge-captured.v1",
+            chargeId = "chg_1",
+            occurred
+        };
+        var body = JsonSerializer.Serialize(payload);
+
+        var vipps = MockVipps();
+        vipps.Setup(v => v.CreateChargeAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<DateTime>(),
+                It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new VippsCreateChargeResponse { ChargeId = "chg_2" });
+
+        var expectedDue = occurred.AddMonths(1);
+
+        var ctrl = CreateController(db,
+            settings: new AppSettings { Id = 1, VippsSubscriptionWebhookSecret = "secret" },
+            vipps: vipps);
+        SetupValidWebhookRequest(ctrl, body);
+        await ctrl.Webhook();
+
+        vipps.Verify(v => v.CreateChargeAsync(
+            "agr_next",
+            29900,
+            expectedDue,
+            It.IsAny<string>(),
+            $"charge-{sub.Id}-{expectedDue.Ticks}"),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Webhook_ChargeCaptured_CreateChargeThrows_StillReturnsOk()
+    {
+        using var db = CreateDbContext();
+        var occurred = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc);
+        await db.Products.AddAsync(MakePrimaryProduct());
+        var sub = new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr_throw", Status = SubscriptionStatus.Active
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        var vipps = MockVipps();
+        vipps.Setup(v => v.CreateChargeAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<DateTime>(),
+                It.IsAny<string>(), It.IsAny<string>()))
+            .ThrowsAsync(new HttpRequestException("Vipps unavailable"));
+
+        var invoice = new Mock<IInvoiceService>();
+        invoice.Setup(i => i.GenerateForSubscriptionChargeAsync(
+                It.IsAny<int>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<DateTime>()))
+            .ReturnsAsync(7);
+
+        var payload = new
+        {
+            agreementId = "agr_throw",
+            eventId = "evt-throw",
+            eventType = "recurring.charge-captured.v1",
+            chargeId = "chg_t",
+            occurred
+        };
+        var ctrl = CreateController(db,
+            settings: new AppSettings { Id = 1, VippsSubscriptionWebhookSecret = "secret" },
+            vipps: vipps, invoice: invoice.Object);
+        SetupValidWebhookRequest(ctrl, JsonSerializer.Serialize(payload));
+        var result = await ctrl.Webhook();
+
+        Assert.IsType<OkResult>(result);
+        invoice.Verify(i => i.GenerateForSubscriptionChargeAsync(
+            sub.Id, "chg_t", 29900, occurred), Times.Once);
+    }
+
+    [Fact]
+    public async Task Webhook_ChargeCaptured_NullOccurred_DoesNotCallCreateCharge()
+    {
+        using var db = CreateDbContext();
+        await db.Products.AddAsync(MakePrimaryProduct());
+        var sub = new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr_noocc", Status = SubscriptionStatus.Active
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        var vipps = MockVipps();
+
+        var payload = new
+        {
+            agreementId = "agr_noocc",
+            eventId = "evt-noocc",
+            eventType = "recurring.charge-captured.v1",
+            chargeId = "chg_n"
+        };
+        var ctrl = CreateController(db,
+            settings: new AppSettings { Id = 1, VippsSubscriptionWebhookSecret = "secret" },
+            vipps: vipps);
+        SetupValidWebhookRequest(ctrl, JsonSerializer.Serialize(payload));
+        await ctrl.Webhook();
+
+        vipps.Verify(v => v.CreateChargeAsync(
+            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<DateTime>(),
+            It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        var updated = await db.Subscriptions.FirstAsync();
+        Assert.Null(updated.NextChargeDate);
+    }
+
+    [Fact]
+    public async Task Webhook_ChargeCaptured_YearlyProduct_DueDateIsPlusOneYear()
+    {
+        using var db = CreateDbContext();
+        var occurred = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc);
+        await db.Products.AddAsync(new Product
+        {
+            Id = 1, Name = "Garge Yearly", PriceInOre = 99900,
+            Interval = BillingInterval.Yearly, Type = ProductType.Primary, IsActive = true
+        });
+        var sub = new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "agr_yr", Status = SubscriptionStatus.Active
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        var vipps = MockVipps();
+        vipps.Setup(v => v.CreateChargeAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<DateTime>(),
+                It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new VippsCreateChargeResponse { ChargeId = "chg_yr2" });
+
+        var payload = new
+        {
+            agreementId = "agr_yr",
+            eventId = "evt-yr",
+            eventType = "recurring.charge-captured.v1",
+            chargeId = "chg_yr",
+            occurred
+        };
+        var ctrl = CreateController(db,
+            settings: new AppSettings { Id = 1, VippsSubscriptionWebhookSecret = "secret" },
+            vipps: vipps);
+        SetupValidWebhookRequest(ctrl, JsonSerializer.Serialize(payload));
+        await ctrl.Webhook();
+
+        var expectedDue = occurred.AddYears(1);
+        vipps.Verify(v => v.CreateChargeAsync(
+            "agr_yr", 99900, expectedDue, It.IsAny<string>(),
+            $"charge-{sub.Id}-{expectedDue.Ticks}"), Times.Once);
     }
 
     private static void SetupValidWebhookRequest(SubscriptionsController ctrl, string body) =>

--- a/garge-api.csproj
+++ b/garge-api.csproj
@@ -15,6 +15,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="garge-api.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="AspNetCoreRateLimit" Version="5.0.0" />
     <PackageReference Include="AutoMapper" Version="16.1.1" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />


### PR DESCRIPTION
## Summary

- Vipps now actually captures money. `initialCharge` on agreement creation; new `CreateChargeAsync` posts subsequent periodic charges. Webhook schedules next charge after each capture; daily `SubscriptionChargeSchedulerService` is the safety net (matches `IsTest` to current `VippsTestMode`, clamps `due` to `today+2d`, sends `orderId` for reconciliation).
- Buyer postal address sourced from Vipps userinfo via `scope` on the agreement; populated on `AgreementActivated` and rendered in invoice Bill-to. New nullable `Subscription.BillingAddress` column + migration.
- Subscription invoice gets VAT 25% subtotal/VAT breakdown when `VatEnabled` (bokføringsforskriften §5-1-1 compliance). Activation email confirms the 14-day right-of-withdrawal waiver (Angrerettsloven §22).
- `EmailLayout.RenderParties` shared by both invoices + the subscription email so layout edits live in one place.
- Admin refund: `RefundPaymentAsync` on `IVippsService`, `POST /shop/orders/{id}/refund` admin endpoint that flips order status to Refunded after Vipps accepts.
- Tests: refund (5), AgreementActivated address population (4), ChargeCaptured edges (3), scheduler (8). `InternalsVisibleTo` so tests can call the scheduler's internal sweep directly.

## Known follow-ups (not in this PR)

- **Webhook + scheduler both POST next charge.** `Idempotency-Key` dedupes at Vipps, but if `NextChargeDate` ever changes (e.g. proration) the keys diverge. Pick one source of truth in a follow-up.
- **Concurrent webhook race.** `TryRecordEventAsync` saves at the end of the handler; two webhooks with the same `eventId` could both pass the dedup check. Wrap in a transaction or save the dedup row early.

## Test plan

- [ ] `dotnet build` clean (0 errors locally)
- [ ] `dotnet test` — 178/178 pass locally
- [ ] Vipps test mode end-to-end: subscribe → consent screen lists Address → activation webhook fires → `Subscription.BillingAddress` populated → captured webhook generates invoice with VAT split + full Bill-to address
- [ ] Admin: pay an order → click Refund → confirm → status flips to Refunded, Vipps refund visible in dashboard
- [ ] Trigger scheduler manually (reduce `Interval` for one run) and confirm Vipps receives `Idempotency-Key` matching the webhook path's key
