### PR TITLE
ci: align release + docker workflows with operator/app pattern

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,18 +1,26 @@
 name: 🔨 Build and Push Docker Image
 
 on:
+  pull_request:
+  push:
+    branches: [development]
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag for the Docker image'
+        description: "Tag for the Docker image"
+        type: string
         required: true
-  release:
-    types:
-      - published
-  push:
-    branches:
-      - development
-  pull_request:
+  workflow_call:
+    inputs:
+      tag:
+        description: "Tag for the Docker image"
+        type: string
+        required: true
+    secrets:
+      DOCKER_PASSWORD:
+        required: true
+      GARGE_PAT:
+        required: false
 
 permissions:
   contents: read
@@ -52,7 +60,7 @@ jobs:
 
   prod:
     needs: test
-    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    if: inputs.tag != ''
     uses: equinor/ops-actions/.github/workflows/docker.yml@e925ef9959a37d43073b77efa2f73c64253fbd55 # v9.37.2
     secrets:
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -61,4 +69,14 @@ jobs:
       registry: registry.hub.docker.com
       username: sondresjo
       repository: sondresjo/garge-api
-      tag: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+      tag: ${{ inputs.tag }}
+
+  update-chart:
+    needs: prod
+    if: inputs.tag != ''
+    uses: sondresjolyst/garge/.github/workflows/update-chart.yml@main
+    secrets:
+      GARGE_PAT: ${{ secrets.GARGE_PAT }}
+    with:
+      chart_name: garge-api
+      tag: ${{ inputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,32 @@
 name: 🚀 Create release
 
 on:
+  workflow_dispatch:
   push:
-    branches:
-      - main
+    branches: [main]
 
-permissions:
-  contents: write # Required to update changelog file
-  pull-requests: write # Required to create release PRs
-  issues: write
+permissions: {}
 
 jobs:
   release-please:
     name: Release Please
     uses: equinor/ops-actions/.github/workflows/release-please.yml@e925ef9959a37d43073b77efa2f73c64253fbd55 # v9.37.2
+    permissions:
+      contents: write # Required to update changelog file
+      pull-requests: write # Required to create release PRs
+      issues: write
     with:
       release_type: simple
+
+  deploy-prod:
+    name: Deploy Prod
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    permissions:
+      contents: read # Required to checkout code
+    uses: ./.github/workflows/docker.yml
+    secrets:
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      GARGE_PAT: ${{ secrets.GARGE_PAT }}
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
## Summary

Release-please run for #169 (merged) didn't deploy prod — `release.yml` only ran the `release-please` job and stopped. `docker.yml` was on the old `release: published` trigger, never invoked from release-please.

Match the pattern that `garge-operator` and `garge-app` already use.

## Changes

`release.yml`
- New `deploy-prod` job, gated on `needs.release-please.outputs.release_created == 'true'`, that calls `./.github/workflows/docker.yml` via `workflow_call` with the new `tag_name`.

`docker.yml`
- New `workflow_call` trigger with `inputs.tag` and the required secrets (`DOCKER_PASSWORD`, `GARGE_PAT`).
- `prod` gate switches from `release || workflow_dispatch` to `inputs.tag != ''`, so any caller that passes a tag deploys (release-please for tagged releases, manual `workflow_dispatch` for one-offs).
- New `update-chart` job that runs after `prod` publish and calls `sondresjolyst/garge/.github/workflows/update-chart.yml@main` to bump the helm chart for `garge-api`.

`dev` job unchanged — still publishes `:dev` on push to `development`. `test` job still gates both `dev` and `prod`.

## Test plan

- [ ] After merge to `development`, verify dev image still publishes on push.
- [ ] On next release-please run for `main`: `release-please` succeeds → `deploy-prod` triggers `docker.yml` workflow_call → `prod` publishes the tagged image → `update-chart` updates the chart.
