### PR TITLE
fix(signalr): include admins in device ownership lists

### DIFF
--- a/Services/DeviceOwnershipService.cs
+++ b/Services/DeviceOwnershipService.cs
@@ -92,7 +92,12 @@ namespace garge_api.Services
                     .ToListAsync(ct);
             }
 
-            return directOwners.Concat(indirectOwners).Distinct().ToList();
+            // Mirror SwitchesController.UserHasRequiredRoleAsync admin bypass:
+            // admin / SwitchAdmin can read every switch via REST, so they should
+            // also receive live SignalR events for every switch.
+            var admins = await GetUserIdsInRolesAsync(db, new[] { "Admin", "SwitchAdmin" }, ct);
+
+            return directOwners.Concat(indirectOwners).Concat(admins).Distinct().ToList();
         }
 
         private async Task<IReadOnlyCollection<string>> LoadSensorOwnersAsync(int sensorId, CancellationToken ct)
@@ -100,9 +105,24 @@ namespace garge_api.Services
             using var scope = _scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
-            return await db.UserSensors
+            var directOwners = await db.UserSensors
                 .Where(us => us.SensorId == sensorId)
                 .Select(us => us.UserId)
+                .Distinct()
+                .ToListAsync(ct);
+
+            // Same admin bypass as switches: admin / SensorAdmin see every sensor.
+            var admins = await GetUserIdsInRolesAsync(db, new[] { "Admin", "SensorAdmin" }, ct);
+
+            return directOwners.Concat(admins).Distinct().ToList();
+        }
+
+        private static async Task<List<string>> GetUserIdsInRolesAsync(ApplicationDbContext db, string[] roleNames, CancellationToken ct)
+        {
+            return await db.UserRoles
+                .Join(db.Roles, ur => ur.RoleId, r => r.Id, (ur, r) => new { ur.UserId, r.Name })
+                .Where(x => x.Name != null && roleNames.Contains(x.Name))
+                .Select(x => x.UserId)
                 .Distinct()
                 .ToListAsync(ct);
         }


### PR DESCRIPTION
## Summary

`SwitchesController.UserHasRequiredRoleAsync` short-circuits to `true` for `Admin` / `SwitchAdmin`. `SensorController.UserCanAccessSensorAsync` does the same for `Admin` / `SensorAdmin`. The ownership service used by the SignalR dispatch path did not mirror that bypass, so admins could read every switch/sensor via REST but the SignalR `user-{id}` group never received live events for items they don't directly own.

## Fix

`LoadSwitchOwnersAsync` and `LoadSensorOwnersAsync` now union the direct/indirect owners with the user ids in the relevant admin roles, looked up via a single Identity-tables query (`AspNetUserRoles` ⨝ `AspNetRoles`).

Roles included:

| Owner type | Admin roles |
|---|---|
| switch | `Admin`, `SwitchAdmin` |
| sensor | `Admin`, `SensorAdmin` |

`IMemoryCache` TTL on the ownership service still applies — admin role membership is cached together with the owner list, invalidated by the same paths.

## Test plan

- [x] `dotnet test garge-api.Tests` — 216 pass.
- [ ] Live: log in as admin, toggle a Wiz switch you don't own directly. Dashboard card flips state without refresh.
- [ ] Two browser tabs, one admin + one regular user without ownership: admin sees the event, regular user does not.
