### PR TITLE
feat(shop): expand description columns to 2000 chars

### DIFF
--- a/Dtos/Shop/ShopDtos.cs
+++ b/Dtos/Shop/ShopDtos.cs
@@ -19,7 +19,7 @@ namespace garge_api.Dtos.Shop
         [MaxLength(100)]
         public required string Name { get; set; }
 
-        [MaxLength(1000)]
+        [MaxLength(2000)]
         public string? Description { get; set; }
 
         [Required]
@@ -35,7 +35,7 @@ namespace garge_api.Dtos.Shop
         [MaxLength(100)]
         public required string Name { get; set; }
 
-        [MaxLength(1000)]
+        [MaxLength(2000)]
         public string? Description { get; set; }
 
         [Required]

--- a/Dtos/Subscription/ProductDtos.cs
+++ b/Dtos/Subscription/ProductDtos.cs
@@ -21,7 +21,7 @@ namespace garge_api.Dtos.Subscription
         [MaxLength(100)]
         public required string Name { get; set; }
 
-        [MaxLength(500)]
+        [MaxLength(2000)]
         public string? Description { get; set; }
 
         [Required]
@@ -41,7 +41,7 @@ namespace garge_api.Dtos.Subscription
         [MaxLength(100)]
         public required string Name { get; set; }
 
-        [MaxLength(500)]
+        [MaxLength(2000)]
         public string? Description { get; set; }
 
         [Required]

--- a/Migrations/20260514063653_ExpandDescriptionLength.Designer.cs
+++ b/Migrations/20260514063653_ExpandDescriptionLength.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260514063653_ExpandDescriptionLength")]
+    partial class ExpandDescriptionLength
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260514063653_ExpandDescriptionLength.cs
+++ b/Migrations/20260514063653_ExpandDescriptionLength.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class ExpandDescriptionLength : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "ShopItems",
+                type: "character varying(2000)",
+                maxLength: 2000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(1000)",
+                oldMaxLength: 1000,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Products",
+                type: "character varying(2000)",
+                maxLength: 2000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "ShopItems",
+                type: "character varying(1000)",
+                maxLength: 1000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(2000)",
+                oldMaxLength: 2000,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Products",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(2000)",
+                oldMaxLength: 2000,
+                oldNullable: true);
+        }
+    }
+}

--- a/Models/Shop/ShopItem.cs
+++ b/Models/Shop/ShopItem.cs
@@ -13,7 +13,7 @@ namespace garge_api.Models.Shop
         [MaxLength(100)]
         public required string Name { get; set; }
 
-        [MaxLength(1000)]
+        [MaxLength(2000)]
         public string? Description { get; set; }
 
         [Required]

--- a/Models/Subscription/Product.cs
+++ b/Models/Subscription/Product.cs
@@ -25,7 +25,7 @@ namespace garge_api.Models.Subscription
         [MaxLength(100)]
         public required string Name { get; set; }
 
-        [MaxLength(500)]
+        [MaxLength(2000)]
         public string? Description { get; set; }
 
         [Required]


### PR DESCRIPTION
## Summary
- Bumps ShopItem.Description and Product.Description MaxLength from 1000/500 to 2000 (plus matching CreateXxxDto / UpdateXxxDto attributes).
- Adds ExpandDescriptionLength migration: alters both varchar columns. Postgres widens in place, no rewrite, safe in-flight.
- Enables markdown-formatted product copy on /shop. Paired frontend PR: sondresjolyst/garge-app shop-markdown-descriptions.