### PR TITLE
feat(subscription): quantity field for add-on subscriptions

### DIFF
--- a/Controllers/AdminController.cs
+++ b/Controllers/AdminController.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
-using AutoMapper;
+using MapsterMapper;
 using garge_api.Models.Admin;
 using Microsoft.EntityFrameworkCore;
 using System.Security.Claims;

--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -1,4 +1,4 @@
-﻿using AutoMapper;
+﻿using MapsterMapper;
 using garge_api.Dtos.Auth;
 using garge_api.Helpers;
 using garge_api.Models;

--- a/Controllers/BatteryHealthController.cs
+++ b/Controllers/BatteryHealthController.cs
@@ -1,4 +1,4 @@
-using AutoMapper;
+using MapsterMapper;
 using garge_api.Dtos.Sensor;
 using garge_api.Helpers;
 using garge_api.Models;

--- a/Controllers/ElectricityController.cs
+++ b/Controllers/ElectricityController.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using System.Security.Claims;
 using garge_api.Constants;
-using AutoMapper;
+using MapsterMapper;
 using garge_api.Dtos.Electricity;
 using garge_api.Models;
 using Microsoft.EntityFrameworkCore;

--- a/Controllers/ProductsController.cs
+++ b/Controllers/ProductsController.cs
@@ -1,4 +1,4 @@
-using AutoMapper;
+using MapsterMapper;
 using garge_api.Dtos.Subscription;
 using garge_api.Models;
 using garge_api.Models.Subscription;

--- a/Controllers/SensorActivitiesController.cs
+++ b/Controllers/SensorActivitiesController.cs
@@ -1,4 +1,4 @@
-using AutoMapper;
+using MapsterMapper;
 using garge_api.Dtos.Sensor;
 using garge_api.Models;
 using garge_api.Models.Sensor;

--- a/Controllers/SensorController.cs
+++ b/Controllers/SensorController.cs
@@ -11,7 +11,7 @@ using Npgsql;
 using Swashbuckle.AspNetCore.Annotations;
 using System.Globalization;
 using System.Security.Claims;
-using AutoMapper;
+using MapsterMapper;
 using garge_api.Services;
 
 namespace garge_api.Controllers

--- a/Controllers/SettingsController.cs
+++ b/Controllers/SettingsController.cs
@@ -1,4 +1,4 @@
-using AutoMapper;
+using MapsterMapper;
 using garge_api.Dtos.Admin;
 using garge_api.Models;
 using garge_api.Models.Admin;

--- a/Controllers/ShopController.cs
+++ b/Controllers/ShopController.cs
@@ -1,4 +1,4 @@
-using AutoMapper;
+using MapsterMapper;
 using garge_api.Constants;
 using garge_api.Dtos.Shop;
 using garge_api.Helpers;

--- a/Controllers/SubscriptionsController.cs
+++ b/Controllers/SubscriptionsController.cs
@@ -1,4 +1,4 @@
-using AutoMapper;
+using MapsterMapper;
 using garge_api.Constants;
 using garge_api.Dtos.Subscription;
 using garge_api.Helpers;

--- a/Controllers/SubscriptionsController.cs
+++ b/Controllers/SubscriptionsController.cs
@@ -269,7 +269,15 @@ namespace garge_api.Controllers
 
             if (subscription == null) return NotFound("Active subscription not found.");
 
-            await _vipps.CancelAgreementAsync(subscription.VippsAgreementId, $"cancel-{subscription.Id}");
+            try
+            {
+                await _vipps.CancelAgreementAsync(subscription.VippsAgreementId, $"cancel-{subscription.Id}");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Vipps agreement cancel failed for subscription {SubscriptionId}", subscription.Id);
+                return StatusCode(502, "Payment provider unavailable.");
+            }
             subscription.Status = SubscriptionStatus.Stopped;
             subscription.UpdatedAt = DateTime.UtcNow;
 

--- a/Controllers/SubscriptionsController.cs
+++ b/Controllers/SubscriptionsController.cs
@@ -72,6 +72,7 @@ namespace garge_api.Controllers
                     ProductName = s.Product != null ? s.Product.Name : string.Empty,
                     ProductType = s.Product != null ? s.Product.Type.ToString() : string.Empty,
                     PriceInOre = s.Product != null ? s.Product.PriceInOre : 0,
+                    Quantity = s.Quantity,
                     Interval = s.Product != null ? s.Product.Interval.ToString() : string.Empty,
                     Status = s.Status.ToString(),
                     IsTest = s.IsTest,
@@ -184,6 +185,9 @@ namespace garge_api.Controllers
 
             if (product.Type == ProductType.Primary)
             {
+                if (dto.Quantity != 1)
+                    return BadRequest("Primary plan must have quantity 1.");
+
                 var hasActivePrimary = await _context.Subscriptions
                     .Include(s => s.Product)
                     .AnyAsync(s => s.UserId == userId &&
@@ -206,12 +210,14 @@ namespace garge_api.Controllers
             }
 
             var settings = await _settingsCache.GetAsync();
-            var effectivePriceInOre = Pricing.EffectiveInOre(product.PriceInOre, settings.VatEnabled);
+            var unitPriceInOre = Pricing.EffectiveInOre(product.PriceInOre, settings.VatEnabled);
+            var effectivePriceInOre = unitPriceInOre * dto.Quantity;
 
             var subscription = new Subscription
             {
                 UserId = userId,
                 ProductId = dto.ProductId,
+                Quantity = dto.Quantity,
                 VippsAgreementId = string.Empty,
                 Status = SubscriptionStatus.Pending,
                 IsTest = settings.VippsTestMode,
@@ -299,6 +305,54 @@ namespace garge_api.Controllers
                 subscription.Id, userId);
 
             return Ok();
+        }
+
+        /// <summary>Updates the quantity of an active AddOn subscription. User must reconfirm the new price in Vipps.</summary>
+        [HttpPatch("{id:int}/quantity")]
+        public async Task<IActionResult> UpdateSubscriptionQuantity(int id, [FromBody] UpdateSubscriptionQuantityDto dto)
+        {
+            var userId = User.UserId()!;
+
+            var subscription = await _context.Subscriptions
+                .Include(s => s.Product)
+                .FirstOrDefaultAsync(s => s.Id == id && s.UserId == userId);
+
+            if (subscription == null) return NotFound();
+            if (subscription.Status != SubscriptionStatus.Active)
+                return BadRequest("Subscription must be active.");
+            if (subscription.Product == null)
+                return BadRequest("Subscription product missing.");
+            if (subscription.Product.Type == ProductType.Primary)
+                return BadRequest("Primary plan quantity is fixed at 1.");
+            if (dto.Quantity == subscription.Quantity)
+                return BadRequest("New quantity matches current quantity.");
+
+            var settings = await _settingsCache.GetAsync();
+            var unitPriceInOre = Pricing.EffectiveInOre(subscription.Product.PriceInOre, settings.VatEnabled);
+            var newAmount = unitPriceInOre * dto.Quantity;
+
+            try
+            {
+                await _vipps.UpdateAgreementAmountAsync(
+                    subscription.VippsAgreementId,
+                    newAmount,
+                    $"updateqty-{subscription.Id}-{dto.Quantity}");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Vipps agreement update failed for subscription {SubscriptionId}", subscription.Id);
+                return StatusCode(502, "Payment provider unavailable.");
+            }
+
+            subscription.Quantity = dto.Quantity;
+            subscription.UpdatedAt = DateTime.UtcNow;
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("Subscription {SubscriptionId} quantity updated to {Quantity} for user {UserId}",
+                subscription.Id, dto.Quantity, userId);
+
+            var dtoOut = _mapper.Map<SubscriptionResponseDto>(subscription);
+            return Ok(new { subscription = dtoOut, message = "Quantity updated. Confirm the new price in your Vipps app." });
         }
 
         /// <summary>Webhook endpoint for Vipps agreement status changes.</summary>

--- a/Controllers/SubscriptionsController.cs
+++ b/Controllers/SubscriptionsController.cs
@@ -306,7 +306,7 @@ namespace garge_api.Controllers
             return Ok();
         }
 
-        /// <summary>Updates the quantity of an active AddOn subscription. Next scheduled charge reflects the new total automatically (VARIABLE pricing).</summary>
+        /// <summary>Updates the quantity of an active AddOn subscription. Increases PATCH the Vipps agreement ceiling (user reconfirms in Vipps); decreases are DB-only.</summary>
         [HttpPatch("{id:int}/quantity")]
         public async Task<IActionResult> UpdateSubscriptionQuantity(int id, [FromBody] UpdateSubscriptionQuantityDto dto)
         {
@@ -326,6 +326,28 @@ namespace garge_api.Controllers
             if (dto.Quantity == subscription.Quantity)
                 return BadRequest("New quantity matches current quantity.");
 
+            var isIncrease = dto.Quantity > subscription.Quantity;
+
+            if (isIncrease)
+            {
+                var settings = await _settingsCache.GetAsync();
+                var unitPriceInOre = Pricing.EffectiveInOre(subscription.Product.PriceInOre, settings.VatEnabled);
+                var newCeiling = unitPriceInOre * dto.Quantity;
+
+                try
+                {
+                    await _vipps.UpdateAgreementMaxAmountAsync(
+                        subscription.VippsAgreementId,
+                        newCeiling,
+                        $"qtyceiling-{subscription.Id}-{dto.Quantity}");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Vipps ceiling update failed for subscription {SubscriptionId}", subscription.Id);
+                    return StatusCode(502, "Payment provider unavailable.");
+                }
+            }
+
             subscription.Quantity = dto.Quantity;
             subscription.UpdatedAt = DateTime.UtcNow;
             await _context.SaveChangesAsync();
@@ -334,7 +356,10 @@ namespace garge_api.Controllers
                 subscription.Id, dto.Quantity, userId);
 
             var dtoOut = _mapper.Map<SubscriptionResponseDto>(subscription);
-            return Ok(new { subscription = dtoOut, message = "Quantity updated. The next charge will reflect the new total." });
+            var message = isIncrease
+                ? "Quantity updated. Confirm the new charge ceiling in your Vipps app before the next charge."
+                : "Quantity updated. The next charge will reflect the new total.";
+            return Ok(new { subscription = dtoOut, message });
         }
 
         /// <summary>Webhook endpoint for Vipps agreement status changes.</summary>

--- a/Controllers/SubscriptionsController.cs
+++ b/Controllers/SubscriptionsController.cs
@@ -211,7 +211,6 @@ namespace garge_api.Controllers
 
             var settings = await _settingsCache.GetAsync();
             var unitPriceInOre = Pricing.EffectiveInOre(product.PriceInOre, settings.VatEnabled);
-            var effectivePriceInOre = unitPriceInOre * dto.Quantity;
 
             var subscription = new Subscription
             {
@@ -234,7 +233,7 @@ namespace garge_api.Controllers
             try
             {
                 var vippsResponse = await _vipps.CreateAgreementAsync(
-                    product, userId, redirectUrl, msisdn, effectivePriceInOre, idempotencyKey);
+                    product, userId, redirectUrl, msisdn, unitPriceInOre, dto.Quantity, idempotencyKey);
 
                 subscription.VippsAgreementId = vippsResponse.AgreementId;
                 subscription.VippsConfirmationUrl = vippsResponse.VippsConfirmationUrl;
@@ -307,7 +306,7 @@ namespace garge_api.Controllers
             return Ok();
         }
 
-        /// <summary>Updates the quantity of an active AddOn subscription. User must reconfirm the new price in Vipps.</summary>
+        /// <summary>Updates the quantity of an active AddOn subscription. Next scheduled charge reflects the new total automatically (VARIABLE pricing).</summary>
         [HttpPatch("{id:int}/quantity")]
         public async Task<IActionResult> UpdateSubscriptionQuantity(int id, [FromBody] UpdateSubscriptionQuantityDto dto)
         {
@@ -327,23 +326,6 @@ namespace garge_api.Controllers
             if (dto.Quantity == subscription.Quantity)
                 return BadRequest("New quantity matches current quantity.");
 
-            var settings = await _settingsCache.GetAsync();
-            var unitPriceInOre = Pricing.EffectiveInOre(subscription.Product.PriceInOre, settings.VatEnabled);
-            var newAmount = unitPriceInOre * dto.Quantity;
-
-            try
-            {
-                await _vipps.UpdateAgreementAmountAsync(
-                    subscription.VippsAgreementId,
-                    newAmount,
-                    $"updateqty-{subscription.Id}-{dto.Quantity}");
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Vipps agreement update failed for subscription {SubscriptionId}", subscription.Id);
-                return StatusCode(502, "Payment provider unavailable.");
-            }
-
             subscription.Quantity = dto.Quantity;
             subscription.UpdatedAt = DateTime.UtcNow;
             await _context.SaveChangesAsync();
@@ -352,7 +334,7 @@ namespace garge_api.Controllers
                 subscription.Id, dto.Quantity, userId);
 
             var dtoOut = _mapper.Map<SubscriptionResponseDto>(subscription);
-            return Ok(new { subscription = dtoOut, message = "Quantity updated. Confirm the new price in your Vipps app." });
+            return Ok(new { subscription = dtoOut, message = "Quantity updated. The next charge will reflect the new total." });
         }
 
         /// <summary>Webhook endpoint for Vipps agreement status changes.</summary>

--- a/Controllers/SwitchesController.cs
+++ b/Controllers/SwitchesController.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using Swashbuckle.AspNetCore.Annotations;
 using System.Security.Claims;
-using AutoMapper;
+using MapsterMapper;
 using garge_api.Models.Switch;
 using garge_api.Services;
 

--- a/Controllers/UserController.cs
+++ b/Controllers/UserController.cs
@@ -1,4 +1,4 @@
-using AutoMapper;
+using MapsterMapper;
 using garge_api.Dtos.User;
 using garge_api.Helpers;
 using garge_api.Hubs;

--- a/Dtos/Subscription/SubscriptionDtos.cs
+++ b/Dtos/Subscription/SubscriptionDtos.cs
@@ -10,6 +10,7 @@ namespace garge_api.Dtos.Subscription
         public string ProductName { get; set; } = string.Empty;
         public string ProductType { get; set; } = string.Empty;
         public int PriceInOre { get; set; }
+        public int Quantity { get; set; }
         public string Interval { get; set; } = string.Empty;
         public string VippsAgreementId { get; set; } = string.Empty;
         public string Status { get; set; } = string.Empty;
@@ -31,6 +32,16 @@ namespace garge_api.Dtos.Subscription
 
         [Required]
         public bool ConsentToWaiveWithdrawal { get; set; }
+
+        [Range(1, 50)]
+        public int Quantity { get; set; } = 1;
+    }
+
+    public class UpdateSubscriptionQuantityDto
+    {
+        [Required]
+        [Range(1, 50)]
+        public int Quantity { get; set; }
     }
 
     public class InitiateSubscriptionResponseDto
@@ -49,6 +60,7 @@ namespace garge_api.Dtos.Subscription
         public string ProductName { get; set; } = string.Empty;
         public string ProductType { get; set; } = string.Empty;
         public int PriceInOre { get; set; }
+        public int Quantity { get; set; }
         public string Interval { get; set; } = string.Empty;
         public string Status { get; set; } = string.Empty;
         public bool IsTest { get; set; }

--- a/Migrations/20260514072604_AddSubscriptionQuantity.Designer.cs
+++ b/Migrations/20260514072604_AddSubscriptionQuantity.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260514072604_AddSubscriptionQuantity")]
+    partial class AddSubscriptionQuantity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260514072604_AddSubscriptionQuantity.cs
+++ b/Migrations/20260514072604_AddSubscriptionQuantity.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSubscriptionQuantity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Quantity",
+                table: "Subscriptions",
+                type: "integer",
+                nullable: false,
+                defaultValue: 1);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Quantity",
+                table: "Subscriptions");
+        }
+    }
+}

--- a/Models/Subscription/Subscription.cs
+++ b/Models/Subscription/Subscription.cs
@@ -37,6 +37,10 @@ namespace garge_api.Models.Subscription
         public string? VippsConfirmationUrl { get; set; }
 
         [Required]
+        [Range(1, 50)]
+        public int Quantity { get; set; } = 1;
+
+        [Required]
         public SubscriptionStatus Status { get; set; } = SubscriptionStatus.Pending;
 
         public DateTime? StartDate { get; set; }

--- a/Profiles/MappingProfile.cs
+++ b/Profiles/MappingProfile.cs
@@ -73,7 +73,8 @@ public class MappingProfile : Profile
             .ForMember(d => d.Interval, o => o.MapFrom(s => s.Product != null ? s.Product.Interval.ToString() : string.Empty))
             .ForMember(d => d.ProductName, o => o.MapFrom(s => s.Product != null ? s.Product.Name : string.Empty))
             .ForMember(d => d.ProductType, o => o.MapFrom(s => s.Product != null ? s.Product.Type.ToString() : string.Empty))
-            .ForMember(d => d.PriceInOre, o => o.MapFrom(s => s.Product != null ? s.Product.PriceInOre : 0));
+            .ForMember(d => d.PriceInOre, o => o.MapFrom(s => s.Product != null ? s.Product.PriceInOre : 0))
+            .ForMember(d => d.Quantity, o => o.MapFrom(s => s.Quantity));
 
         // Shop mappings
         CreateMap<ShopItem, ShopItemResponseDto>();

--- a/Profiles/MappingProfile.cs
+++ b/Profiles/MappingProfile.cs
@@ -1,4 +1,4 @@
-﻿using AutoMapper;
+using Mapster;
 using garge_api.Dtos.Admin;
 using garge_api.Dtos.Auth;
 using garge_api.Dtos.Electricity;
@@ -15,87 +15,87 @@ using garge_api.Models.Subscription;
 using garge_api.Models.Switch;
 using Microsoft.AspNetCore.Identity;
 
-public class MappingProfile : Profile
+public class MappingProfile : IRegister
 {
-    public MappingProfile()
+    public void Register(TypeAdapterConfig config)
     {
         // Admin mappings
-        CreateMap<IdentityRole, RoleDto>();
-        CreateMap<RolePermission, RolePermissionDto>().ReverseMap();
-        CreateMap<User, UserDto>();
-        CreateMap<AppSettings, AppSettingsDto>();
-        CreateMap<AppSettings, PublicSettingsDto>();
-        CreateMap<UpdateAppSettingsDto, AppSettings>()
-            .ForAllMembers(opt => opt.Condition((_, _, srcMember) => srcMember != null));
+        config.NewConfig<IdentityRole, RoleDto>();
+        config.NewConfig<RolePermission, RolePermissionDto>().TwoWays();
+        config.NewConfig<User, UserDto>();
+        config.NewConfig<AppSettings, AppSettingsDto>();
+        config.NewConfig<AppSettings, PublicSettingsDto>();
+        config.NewConfig<UpdateAppSettingsDto, AppSettings>()
+            .IgnoreNullValues(true);
 
         // Electricity mappings
-        CreateMap<PriceResponse, PriceResponseDto>();
-        CreateMap<AreaPrices, AreaPricesDto>();
-        CreateMap<PriceEntry, PriceEntryDto>();
+        config.NewConfig<PriceResponse, PriceResponseDto>();
+        config.NewConfig<AreaPrices, AreaPricesDto>();
+        config.NewConfig<PriceEntry, PriceEntryDto>();
 
         // Sensor mappings
-        CreateMap<CreateSensorDataDto, SensorData>();
-        CreateMap<CreateSensorDto, Sensor>();
-        CreateMap<Sensor, SensorDto>().ReverseMap();
-        CreateMap<UpdateSensorDto, Sensor>();
-        CreateMap<SensorData, SensorDataDto>().ReverseMap();
-        CreateMap<BatteryHealth, BatteryHealthDto>().ReverseMap();
-        CreateMap<CreateBatteryHealthDto, BatteryHealth>();
-        CreateMap<SensorActivity, SensorActivityDto>().ReverseMap();
-        CreateMap<CreateSensorActivityDto, SensorActivity>();
-        CreateMap<UpdateSensorActivityDto, SensorActivity>();
+        config.NewConfig<CreateSensorDataDto, SensorData>();
+        config.NewConfig<CreateSensorDto, Sensor>();
+        config.NewConfig<Sensor, SensorDto>().TwoWays();
+        config.NewConfig<UpdateSensorDto, Sensor>();
+        config.NewConfig<SensorData, SensorDataDto>().TwoWays();
+        config.NewConfig<BatteryHealth, BatteryHealthDto>().TwoWays();
+        config.NewConfig<CreateBatteryHealthDto, BatteryHealth>();
+        config.NewConfig<SensorActivity, SensorActivityDto>().TwoWays();
+        config.NewConfig<CreateSensorActivityDto, SensorActivity>();
+        config.NewConfig<UpdateSensorActivityDto, SensorActivity>();
 
         // Switch mappings
-        CreateMap<Switch, SwitchDto>().ReverseMap();
-        CreateMap<CreateSwitchDto, Switch>();
-        CreateMap<UpdateSwitchDto, Switch>();
-        CreateMap<SwitchData, SwitchDataDto>().ReverseMap();
-        CreateMap<CreateSwitchDataDto, SwitchData>();
+        config.NewConfig<Switch, SwitchDto>().TwoWays();
+        config.NewConfig<CreateSwitchDto, Switch>();
+        config.NewConfig<UpdateSwitchDto, Switch>();
+        config.NewConfig<SwitchData, SwitchDataDto>().TwoWays();
+        config.NewConfig<CreateSwitchDataDto, SwitchData>();
 
         // User mappings
-        CreateMap<UserProfile, UserProfileDto>()
-            .ForMember(d => d.FirstName, o => o.MapFrom(s => s.User.FirstName))
-            .ForMember(d => d.LastName, o => o.MapFrom(s => s.User.LastName))
-            .ForMember(d => d.Email, o => o.MapFrom(s => s.User.Email))
-            .ForMember(d => d.PhoneNumber, o => o.MapFrom(s => s.User.PhoneNumber))
-            .ForMember(d => d.EmailConfirmed, o => o.MapFrom(s => s.User.EmailConfirmed));
-        CreateMap<RegisterUserDto, User>();
+        config.NewConfig<UserProfile, UserProfileDto>()
+            .Map(d => d.FirstName, s => s.User.FirstName)
+            .Map(d => d.LastName, s => s.User.LastName)
+            .Map(d => d.Email, s => s.User.Email)
+            .Map(d => d.PhoneNumber, s => s.User.PhoneNumber)
+            .Map(d => d.EmailConfirmed, s => s.User.EmailConfirmed);
+        config.NewConfig<RegisterUserDto, User>();
 
         // Subscription plan mappings
-        CreateMap<Product, ProductResponseDto>()
-            .ForMember(d => d.Interval, o => o.MapFrom(s => s.Interval.ToString()))
-            .ForMember(d => d.Type, o => o.MapFrom(s => s.Type.ToString()));
-        CreateMap<CreateProductDto, Product>();
-        CreateMap<UpdateProductDto, Product>();
+        config.NewConfig<Product, ProductResponseDto>()
+            .Map(d => d.Interval, s => s.Interval.ToString())
+            .Map(d => d.Type, s => s.Type.ToString());
+        config.NewConfig<CreateProductDto, Product>();
+        config.NewConfig<UpdateProductDto, Product>();
 
-        CreateMap<garge_api.Models.Subscription.Subscription, SubscriptionResponseDto>()
-            .ForMember(d => d.Status, o => o.MapFrom(s => s.Status.ToString()))
-            .ForMember(d => d.Interval, o => o.MapFrom(s => s.Product != null ? s.Product.Interval.ToString() : string.Empty))
-            .ForMember(d => d.ProductName, o => o.MapFrom(s => s.Product != null ? s.Product.Name : string.Empty))
-            .ForMember(d => d.ProductType, o => o.MapFrom(s => s.Product != null ? s.Product.Type.ToString() : string.Empty))
-            .ForMember(d => d.PriceInOre, o => o.MapFrom(s => s.Product != null ? s.Product.PriceInOre : 0))
-            .ForMember(d => d.Quantity, o => o.MapFrom(s => s.Quantity));
+        config.NewConfig<garge_api.Models.Subscription.Subscription, SubscriptionResponseDto>()
+            .Map(d => d.Status, s => s.Status.ToString())
+            .Map(d => d.Interval, s => s.Product != null ? s.Product.Interval.ToString() : string.Empty)
+            .Map(d => d.ProductName, s => s.Product != null ? s.Product.Name : string.Empty)
+            .Map(d => d.ProductType, s => s.Product != null ? s.Product.Type.ToString() : string.Empty)
+            .Map(d => d.PriceInOre, s => s.Product != null ? s.Product.PriceInOre : 0)
+            .Map(d => d.Quantity, s => s.Quantity);
 
         // Shop mappings
-        CreateMap<ShopItem, ShopItemResponseDto>();
-        CreateMap<CreateShopItemDto, ShopItem>();
-        CreateMap<UpdateShopItemDto, ShopItem>();
+        config.NewConfig<ShopItem, ShopItemResponseDto>();
+        config.NewConfig<CreateShopItemDto, ShopItem>();
+        config.NewConfig<UpdateShopItemDto, ShopItem>();
 
-        CreateMap<Order, OrderResponseDto>()
-            .ForMember(d => d.Status, o => o.MapFrom(s => s.Status.ToString()))
-            .ForMember(d => d.Items, o => o.MapFrom(s => s.OrderItems))
-            .ForMember(d => d.HasInvoice, o => o.MapFrom(s => s.Invoice != null));
+        config.NewConfig<Order, OrderResponseDto>()
+            .Map(d => d.Status, s => s.Status.ToString())
+            .Map(d => d.Items, s => s.OrderItems)
+            .Map(d => d.HasInvoice, s => s.Invoice != null);
 
-        CreateMap<OrderItem, OrderItemResponseDto>()
-            .ForMember(d => d.ShopItemName, o => o.MapFrom(s => s.ShopItem != null ? s.ShopItem.Name : string.Empty));
+        config.NewConfig<OrderItem, OrderItemResponseDto>()
+            .Map(d => d.ShopItemName, s => s.ShopItem != null ? s.ShopItem.Name : string.Empty);
 
-        CreateMap<Invoice, InvoiceResponseDto>();
+        config.NewConfig<Invoice, InvoiceResponseDto>();
 
-        CreateMap<Order, AdminOrderResponseDto>()
-            .ForMember(d => d.Status, o => o.MapFrom(s => s.Status.ToString()))
-            .ForMember(d => d.Items, o => o.MapFrom(s => s.OrderItems))
-            .ForMember(d => d.HasInvoice, o => o.MapFrom(s => s.Invoice != null))
-            .ForMember(d => d.UserEmail, o => o.MapFrom(s => s.User != null ? s.User.Email ?? string.Empty : string.Empty))
-            .ForMember(d => d.UserName, o => o.MapFrom(s => s.User != null ? $"{s.User.FirstName} {s.User.LastName}" : string.Empty));
+        config.NewConfig<Order, AdminOrderResponseDto>()
+            .Map(d => d.Status, s => s.Status.ToString())
+            .Map(d => d.Items, s => s.OrderItems)
+            .Map(d => d.HasInvoice, s => s.Invoice != null)
+            .Map(d => d.UserEmail, s => s.User != null ? s.User.Email ?? string.Empty : string.Empty)
+            .Map(d => d.UserName, s => s.User != null ? s.User.FirstName + " " + s.User.LastName : string.Empty);
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,7 @@
 using garge_api.Models;
 using garge_api.Constants;
+using Mapster;
+using MapsterMapper;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
@@ -56,7 +58,10 @@ namespace garge_api
                 options.Level = CompressionLevel.Fastest;
             });
 
-            builder.Services.AddAutoMapper(_ => { }, typeof(MappingProfile));
+            var mapsterConfig = TypeAdapterConfig.GlobalSettings;
+            mapsterConfig.Scan(typeof(MappingProfile).Assembly);
+            builder.Services.AddSingleton(mapsterConfig);
+            builder.Services.AddScoped<IMapper, ServiceMapper>();
 
             builder.Services.AddDbContext<ApplicationDbContext>(options =>
                 options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));

--- a/Services/IVippsService.cs
+++ b/Services/IVippsService.cs
@@ -85,6 +85,7 @@ namespace garge_api.Services
             int effectivePriceInOre, string idempotencyKey);
         Task<VippsAgreementResponse> GetAgreementAsync(string agreementId);
         Task CancelAgreementAsync(string agreementId, string idempotencyKey);
+        Task UpdateAgreementAmountAsync(string agreementId, int amountInOre, string idempotencyKey);
 
         Task<VippsCreateChargeResponse> CreateChargeAsync(
             string agreementId, int amountInOre, DateTime dueDate,

--- a/Services/IVippsService.cs
+++ b/Services/IVippsService.cs
@@ -85,6 +85,7 @@ namespace garge_api.Services
             int unitPriceInOre, int quantity, string idempotencyKey);
         Task<VippsAgreementResponse> GetAgreementAsync(string agreementId);
         Task CancelAgreementAsync(string agreementId, string idempotencyKey);
+        Task UpdateAgreementMaxAmountAsync(string agreementId, int newMaxAmountInOre, string idempotencyKey);
 
         Task<VippsCreateChargeResponse> CreateChargeAsync(
             string agreementId, int amountInOre, DateTime dueDate,

--- a/Services/IVippsService.cs
+++ b/Services/IVippsService.cs
@@ -82,10 +82,9 @@ namespace garge_api.Services
 
         Task<VippsCreateAgreementResponse> CreateAgreementAsync(
             Product product, string userId, string redirectUrl, string phoneNumber,
-            int effectivePriceInOre, string idempotencyKey);
+            int unitPriceInOre, int quantity, string idempotencyKey);
         Task<VippsAgreementResponse> GetAgreementAsync(string agreementId);
         Task CancelAgreementAsync(string agreementId, string idempotencyKey);
-        Task UpdateAgreementAmountAsync(string agreementId, int amountInOre, string idempotencyKey);
 
         Task<VippsCreateChargeResponse> CreateChargeAsync(
             string agreementId, int amountInOre, DateTime dueDate,

--- a/Services/InvoiceService.cs
+++ b/Services/InvoiceService.cs
@@ -127,6 +127,35 @@ namespace garge_api.Services
                 .FirstOrDefaultAsync(s => s.Id == subscriptionId)
                 ?? throw new InvalidOperationException($"Subscription {subscriptionId} not found");
 
+            // Fallback: if the agreement-activated webhook hasn't populated
+            // BillingAddress yet (race with first charge), fetch from Vipps now.
+            // Vipps service may be absent in test setups; skip silently then.
+            if (string.IsNullOrEmpty(subscription.BillingAddress))
+            {
+                var vipps = scope.ServiceProvider.GetService<IVippsService>();
+                if (vipps != null)
+                {
+                    try
+                    {
+                        var details = await vipps.GetAgreementAsync(subscription.VippsAgreementId);
+                        if (!string.IsNullOrEmpty(details?.Sub))
+                        {
+                            var info = await vipps.GetUserInfoAsync(details.Sub);
+                            var formatted = VippsAddressFormatter.Format(info?.Address);
+                            if (!string.IsNullOrEmpty(formatted))
+                            {
+                                subscription.BillingAddress = formatted;
+                                await db.SaveChangesAsync();
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Invoice fallback: failed to fetch Vipps billing address for subscription {SubscriptionId}", subscription.Id);
+                    }
+                }
+            }
+
             var settings = await db.AppSettings.FindAsync(1) ?? new AppSettings();
 
             var invoice = new Invoice

--- a/Services/SubscriptionChargeSchedulerService.cs
+++ b/Services/SubscriptionChargeSchedulerService.cs
@@ -55,17 +55,19 @@ namespace garge_api.Services
                     if (sub.Product == null || !sub.NextChargeDate.HasValue) continue;
 
                     var dueDate = sub.NextChargeDate.Value;
+                    var unitPriceInOre = Pricing.EffectiveInOre(sub.Product.PriceInOre, settings.VatEnabled);
+                    var amountInOre = unitPriceInOre * sub.Quantity;
                     try
                     {
                         await vipps.CreateChargeAsync(
                             sub.VippsAgreementId,
-                            sub.Product.PriceInOre,
+                            amountInOre,
                             dueDate,
                             sub.Product.Name,
                             idempotencyKey: $"charge-{sub.Id}-{dueDate.Ticks}");
 
-                        _logger.LogInformation("ChargeScheduler: posted charge for subscription {SubId} due {DueDate}",
-                            sub.Id, dueDate);
+                        _logger.LogInformation("ChargeScheduler: posted charge for subscription {SubId} amount {Amount} due {DueDate}",
+                            sub.Id, amountInOre, dueDate);
                     }
                     catch (Exception ex)
                     {

--- a/Services/VippsService.cs
+++ b/Services/VippsService.cs
@@ -143,6 +143,11 @@ namespace garge_api.Services
             var suggestedMaxAmount = unitPriceInOre * quantity;
             var initialAmount = suggestedMaxAmount;
 
+            // Vipps caps productDescription at 100 chars (validation-error otherwise).
+            // Our descriptions may contain markdown up to 2000 chars; truncate plainly.
+            var productDescription = product.Description ?? string.Empty;
+            if (productDescription.Length > 100) productDescription = productDescription[..100];
+
             var body = new
             {
                 pricing = new
@@ -165,7 +170,7 @@ namespace garge_api.Services
                 merchantRedirectUrl = redirectUrl,
                 merchantAgreementUrl = $"{_appOpts.FrontendBaseUrl}/terms",
                 productName = product.Name,
-                productDescription = product.Description ?? string.Empty,
+                productDescription,
                 phoneNumber,
                 scope = "name address email phoneNumber"
             };

--- a/Services/VippsService.cs
+++ b/Services/VippsService.cs
@@ -132,16 +132,24 @@ namespace garge_api.Services
 
         public async Task<VippsCreateAgreementResponse> CreateAgreementAsync(
             Product product, string userId, string redirectUrl, string phoneNumber,
-            int effectivePriceInOre, string idempotencyKey)
+            int unitPriceInOre, int quantity, string idempotencyKey)
         {
             var e = await GetEffectiveAsync();
+
+            // VARIABLE pricing: user approves a ceiling at signup; each scheduled
+            // charge may be a different amount up to that ceiling. Quantity changes
+            // therefore need no Vipps re-approval as long as new total stays under
+            // suggestedMaxAmount. Cap allows the agreement to grow from 1 to 50 units.
+            const int MaxQuantityCeiling = 50;
+            var suggestedMaxAmount = unitPriceInOre * MaxQuantityCeiling;
+            var initialAmount = unitPriceInOre * quantity;
 
             var body = new
             {
                 pricing = new
                 {
-                    type = "LEGACY",
-                    amount = effectivePriceInOre,
+                    type = "VARIABLE",
+                    suggestedMaxAmount,
                     currency = "NOK"
                 },
                 interval = new
@@ -151,7 +159,7 @@ namespace garge_api.Services
                 },
                 initialCharge = new
                 {
-                    amount = effectivePriceInOre,
+                    amount = initialAmount,
                     description = product.Name,
                     transactionType = "DIRECT_CAPTURE"
                 },
@@ -228,22 +236,6 @@ namespace garge_api.Services
 
             var response = await _http.SendAsync(request);
             await ReadAsStringAndEnsureSuccessAsync(response, "cancel-agreement");
-        }
-
-        public async Task UpdateAgreementAmountAsync(string agreementId, int amountInOre, string idempotencyKey)
-        {
-            var e = await GetEffectiveAsync();
-
-            var request = new HttpRequestMessage(HttpMethod.Patch,
-                $"{e.BaseUrl}/recurring/v3/agreements/{agreementId}");
-            AddCommonHeaders(request, e, idempotencyKey);
-            request.Content = BuildJsonContent(new
-            {
-                pricing = new { type = "LEGACY", amount = amountInOre, currency = "NOK" }
-            });
-
-            var response = await _http.SendAsync(request);
-            await ReadAsStringAndEnsureSuccessAsync(response, "update-agreement-amount");
         }
 
         public async Task<VippsCreatePaymentResponse> CreatePaymentAsync(

--- a/Services/VippsService.cs
+++ b/Services/VippsService.cs
@@ -230,6 +230,22 @@ namespace garge_api.Services
             await ReadAsStringAndEnsureSuccessAsync(response, "cancel-agreement");
         }
 
+        public async Task UpdateAgreementAmountAsync(string agreementId, int amountInOre, string idempotencyKey)
+        {
+            var e = await GetEffectiveAsync();
+
+            var request = new HttpRequestMessage(HttpMethod.Patch,
+                $"{e.BaseUrl}/recurring/v3/agreements/{agreementId}");
+            AddCommonHeaders(request, e, idempotencyKey);
+            request.Content = BuildJsonContent(new
+            {
+                pricing = new { type = "LEGACY", amount = amountInOre, currency = "NOK" }
+            });
+
+            var response = await _http.SendAsync(request);
+            await ReadAsStringAndEnsureSuccessAsync(response, "update-agreement-amount");
+        }
+
         public async Task<VippsCreatePaymentResponse> CreatePaymentAsync(
             Order order, List<VippsOrderLine> receiptLines, string redirectUrl,
             string phoneNumber, string idempotencyKey)

--- a/Services/VippsService.cs
+++ b/Services/VippsService.cs
@@ -136,13 +136,12 @@ namespace garge_api.Services
         {
             var e = await GetEffectiveAsync();
 
-            // VARIABLE pricing: user approves a ceiling at signup; each scheduled
-            // charge may be a different amount up to that ceiling. Quantity changes
-            // therefore need no Vipps re-approval as long as new total stays under
-            // suggestedMaxAmount. Cap allows the agreement to grow from 1 to 50 units.
-            const int MaxQuantityCeiling = 50;
-            var suggestedMaxAmount = unitPriceInOre * MaxQuantityCeiling;
-            var initialAmount = unitPriceInOre * quantity;
+            // VARIABLE pricing: user approves a ceiling equal to the current
+            // unit*quantity. Each scheduled charge may be at most that ceiling.
+            // Raising quantity later PATCHes the ceiling (Vipps re-asks the user);
+            // lowering quantity is a DB-only change since charges stay under the cap.
+            var suggestedMaxAmount = unitPriceInOre * quantity;
+            var initialAmount = suggestedMaxAmount;
 
             var body = new
             {
@@ -236,6 +235,28 @@ namespace garge_api.Services
 
             var response = await _http.SendAsync(request);
             await ReadAsStringAndEnsureSuccessAsync(response, "cancel-agreement");
+        }
+
+        public async Task UpdateAgreementMaxAmountAsync(string agreementId, int newMaxAmountInOre, string idempotencyKey)
+        {
+            var e = await GetEffectiveAsync();
+
+            var request = new HttpRequestMessage(HttpMethod.Patch,
+                $"{e.BaseUrl}/recurring/v3/agreements/{agreementId}");
+            AddCommonHeaders(request, e, idempotencyKey);
+            request.Content = BuildJsonContent(new
+            {
+                pricing = new { suggestedMaxAmount = newMaxAmountInOre }
+            });
+
+            var response = await _http.SendAsync(request);
+            var body = await response.Content.ReadAsStringAsync();
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogError("Vipps update-agreement-max-amount failed: {Status} body={Body}",
+                    (int)response.StatusCode, body);
+                response.EnsureSuccessStatusCode();
+            }
         }
 
         public async Task<VippsCreatePaymentResponse> CreatePaymentAsync(

--- a/Services/VippsService.cs
+++ b/Services/VippsService.cs
@@ -250,13 +250,7 @@ namespace garge_api.Services
             });
 
             var response = await _http.SendAsync(request);
-            var body = await response.Content.ReadAsStringAsync();
-            if (!response.IsSuccessStatusCode)
-            {
-                _logger.LogError("Vipps update-agreement-max-amount failed: {Status} body={Body}",
-                    (int)response.StatusCode, body);
-                response.EnsureSuccessStatusCode();
-            }
+            await ReadAsStringAndEnsureSuccessAsync(response, "update-agreement-max-amount");
         }
 
         public async Task<VippsCreatePaymentResponse> CreatePaymentAsync(
@@ -543,11 +537,21 @@ namespace garge_api.Services
             var body = await response.Content.ReadAsStringAsync();
             if (!response.IsSuccessStatusCode)
             {
-                // Body may echo phone, agreementId, name etc. Log only the
-                // Vipps-specific identifiers so PII does not land in log sinks.
+                // Body may echo phone, agreementId, name etc. Prefer logging Vipps's
+                // own identifiers (errorCode/ref/traceId) so PII doesn't land in log
+                // sinks. Fall back to the raw body when none are present — happens
+                // for problem+json shapes that don't use Vipps's legacy error envelope.
                 var (errorCode, errorRef, traceId) = TryExtractVippsErrorIds(body);
-                _logger.LogError("Vipps {Operation} failed: {Status} ErrorCode={ErrorCode} ErrorRef={ErrorRef} TraceId={TraceId}",
-                    operation, (int)response.StatusCode, errorCode ?? "-", errorRef ?? "-", traceId ?? "-");
+                if (errorCode == null && errorRef == null && traceId == null)
+                {
+                    _logger.LogError("Vipps {Operation} failed: {Status} body={Body}",
+                        operation, (int)response.StatusCode, body);
+                }
+                else
+                {
+                    _logger.LogError("Vipps {Operation} failed: {Status} ErrorCode={ErrorCode} ErrorRef={ErrorRef} TraceId={TraceId}",
+                        operation, (int)response.StatusCode, errorCode ?? "-", errorRef ?? "-", traceId ?? "-");
+                }
                 response.EnsureSuccessStatusCode();
             }
             return body;

--- a/garge-api.Tests/AdminControllerTests.cs
+++ b/garge-api.Tests/AdminControllerTests.cs
@@ -1,4 +1,4 @@
-using AutoMapper;
+using MapsterMapper;
 using garge_api.Controllers;
 using garge_api.Dtos.Admin;
 using garge_api.Models;

--- a/garge-api.Tests/ControllerTestBase.cs
+++ b/garge-api.Tests/ControllerTestBase.cs
@@ -1,4 +1,4 @@
-using AutoMapper;
+using MapsterMapper;
 using garge_api.Controllers;
 using garge_api.Models;
 using Microsoft.AspNetCore.Authentication;

--- a/garge-api.Tests/SubscriptionsControllerTests.cs
+++ b/garge-api.Tests/SubscriptionsControllerTests.cs
@@ -754,7 +754,7 @@ public class SubscriptionsControllerTests : ControllerTestBase
     }
 
     [Fact]
-    public async Task UpdateQuantity_ActiveAddOn_UpdatesDbRowOnly()
+    public async Task UpdateQuantity_Increase_PatchesVippsCeilingAndUpdatesRow()
     {
         using var db = CreateDbContext();
         await db.Products.AddRangeAsync(MakePrimaryProduct(), MakeAddOnProduct());
@@ -766,12 +766,45 @@ public class SubscriptionsControllerTests : ControllerTestBase
         await db.Subscriptions.AddAsync(sub);
         await db.SaveChangesAsync();
 
-        var ctrl = CreateController(db);
+        var vipps = MockVipps();
+        int? capturedCeiling = null;
+        vipps.Setup(v => v.UpdateAgreementMaxAmountAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
+            .Callback<string, int, string>((_, amount, _) => capturedCeiling = amount)
+            .Returns(Task.CompletedTask);
+
+        var ctrl = CreateController(db, vipps: vipps);
         var result = await ctrl.UpdateSubscriptionQuantity(sub.Id, new UpdateSubscriptionQuantityDto { Quantity = 5 });
 
         Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(4900 * 5, capturedCeiling);
         var updated = await db.Subscriptions.FindAsync(sub.Id);
         Assert.Equal(5, updated!.Quantity);
+    }
+
+    [Fact]
+    public async Task UpdateQuantity_Decrease_DbOnlyNoVippsCall()
+    {
+        using var db = CreateDbContext();
+        await db.Products.AddRangeAsync(MakePrimaryProduct(), MakeAddOnProduct());
+        var sub = new Subscription
+        {
+            UserId = "user-1", ProductId = 2,
+            VippsAgreementId = "addon_agr", Status = SubscriptionStatus.Active, Quantity = 5
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        var vipps = MockVipps();
+        vipps.Setup(v => v.UpdateAgreementMaxAmountAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
+            .Returns(Task.CompletedTask);
+
+        var ctrl = CreateController(db, vipps: vipps);
+        var result = await ctrl.UpdateSubscriptionQuantity(sub.Id, new UpdateSubscriptionQuantityDto { Quantity = 3 });
+
+        Assert.IsType<OkObjectResult>(result);
+        vipps.Verify(v => v.UpdateAgreementMaxAmountAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+        var updated = await db.Subscriptions.FindAsync(sub.Id);
+        Assert.Equal(3, updated!.Quantity);
     }
 
     [Fact]

--- a/garge-api.Tests/SubscriptionsControllerTests.cs
+++ b/garge-api.Tests/SubscriptionsControllerTests.cs
@@ -540,7 +540,7 @@ public class SubscriptionsControllerTests : ControllerTestBase
 
         var vipps = MockVipps();
         vipps.Setup(v => v.CreateAgreementAsync(It.IsAny<Product>(), It.IsAny<string>(),
-                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()))
             .ReturnsAsync(new VippsCreateAgreementResponse
             {
                 AgreementId = "agr_new",
@@ -606,7 +606,7 @@ public class SubscriptionsControllerTests : ControllerTestBase
 
         var vipps = MockVipps();
         vipps.Setup(v => v.CreateAgreementAsync(It.IsAny<Product>(), It.IsAny<string>(),
-                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()))
             .ReturnsAsync(new VippsCreateAgreementResponse { AgreementId = "addon_agr", VippsConfirmationUrl = "https://vipps.no/confirm/addon" });
 
         var ctrl = CreateController(db, vipps: vipps);
@@ -687,10 +687,15 @@ public class SubscriptionsControllerTests : ControllerTestBase
         await db.SaveChangesAsync();
 
         var vipps = MockVipps();
-        int? capturedAmount = null;
+        int? capturedUnit = null;
+        int? capturedQty = null;
         vipps.Setup(v => v.CreateAgreementAsync(It.IsAny<Product>(), It.IsAny<string>(),
-                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
-            .Callback<Product, string, string, string, int, string>((_, _, _, _, amount, _) => capturedAmount = amount)
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()))
+            .Callback<Product, string, string, string, int, int, string>((_, _, _, _, unit, qty, _) =>
+            {
+                capturedUnit = unit;
+                capturedQty = qty;
+            })
             .ReturnsAsync(new VippsCreateAgreementResponse { AgreementId = "addon_agr", VippsConfirmationUrl = "https://vipps.no/x" });
 
         var ctrl = CreateController(db, vipps: vipps);
@@ -700,7 +705,8 @@ public class SubscriptionsControllerTests : ControllerTestBase
             ProductId = 2, PhoneNumber = "4791234567", ConsentToWaiveWithdrawal = true, Quantity = 5
         });
 
-        Assert.Equal(4900 * 5, capturedAmount);
+        Assert.Equal(4900, capturedUnit);
+        Assert.Equal(5, capturedQty);
     }
 
     [Fact]
@@ -717,7 +723,7 @@ public class SubscriptionsControllerTests : ControllerTestBase
 
         var vipps = MockVipps();
         vipps.Setup(v => v.CreateAgreementAsync(It.IsAny<Product>(), It.IsAny<string>(),
-                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()))
             .ReturnsAsync(new VippsCreateAgreementResponse { AgreementId = "addon_agr", VippsConfirmationUrl = "https://vipps.no/x" });
 
         var ctrl = CreateController(db, vipps: vipps);
@@ -748,7 +754,7 @@ public class SubscriptionsControllerTests : ControllerTestBase
     }
 
     [Fact]
-    public async Task UpdateQuantity_ActiveAddOn_CallsVippsUpdateAndUpdatesRow()
+    public async Task UpdateQuantity_ActiveAddOn_UpdatesDbRowOnly()
     {
         using var db = CreateDbContext();
         await db.Products.AddRangeAsync(MakePrimaryProduct(), MakeAddOnProduct());
@@ -760,17 +766,10 @@ public class SubscriptionsControllerTests : ControllerTestBase
         await db.Subscriptions.AddAsync(sub);
         await db.SaveChangesAsync();
 
-        var vipps = MockVipps();
-        int? capturedAmount = null;
-        vipps.Setup(v => v.UpdateAgreementAmountAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
-            .Callback<string, int, string>((_, amount, _) => capturedAmount = amount)
-            .Returns(Task.CompletedTask);
-
-        var ctrl = CreateController(db, vipps: vipps);
+        var ctrl = CreateController(db);
         var result = await ctrl.UpdateSubscriptionQuantity(sub.Id, new UpdateSubscriptionQuantityDto { Quantity = 5 });
 
         Assert.IsType<OkObjectResult>(result);
-        Assert.Equal(4900 * 5, capturedAmount);
         var updated = await db.Subscriptions.FindAsync(sub.Id);
         Assert.Equal(5, updated!.Quantity);
     }

--- a/garge-api.Tests/SubscriptionsControllerTests.cs
+++ b/garge-api.Tests/SubscriptionsControllerTests.cs
@@ -673,4 +673,162 @@ public class SubscriptionsControllerTests : ControllerTestBase
 
         Assert.IsType<NotFoundObjectResult>(result);
     }
+
+    [Fact]
+    public async Task InitiateAddOn_WithQuantity_SendsPriceTimesQuantityToVipps()
+    {
+        using var db = CreateDbContext();
+        await db.Products.AddRangeAsync(MakePrimaryProduct(), MakeAddOnProduct());
+        await db.Subscriptions.AddAsync(new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "primary_agr", Status = SubscriptionStatus.Active
+        });
+        await db.SaveChangesAsync();
+
+        var vipps = MockVipps();
+        int? capturedAmount = null;
+        vipps.Setup(v => v.CreateAgreementAsync(It.IsAny<Product>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
+            .Callback<Product, string, string, string, int, string>((_, _, _, _, amount, _) => capturedAmount = amount)
+            .ReturnsAsync(new VippsCreateAgreementResponse { AgreementId = "addon_agr", VippsConfirmationUrl = "https://vipps.no/x" });
+
+        var ctrl = CreateController(db, vipps: vipps);
+
+        await ctrl.InitiateSubscription(new InitiateSubscriptionDto
+        {
+            ProductId = 2, PhoneNumber = "4791234567", ConsentToWaiveWithdrawal = true, Quantity = 5
+        });
+
+        Assert.Equal(4900 * 5, capturedAmount);
+    }
+
+    [Fact]
+    public async Task InitiateAddOn_WithQuantity_StoresQuantityOnSubscription()
+    {
+        using var db = CreateDbContext();
+        await db.Products.AddRangeAsync(MakePrimaryProduct(), MakeAddOnProduct());
+        await db.Subscriptions.AddAsync(new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "primary_agr", Status = SubscriptionStatus.Active
+        });
+        await db.SaveChangesAsync();
+
+        var vipps = MockVipps();
+        vipps.Setup(v => v.CreateAgreementAsync(It.IsAny<Product>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
+            .ReturnsAsync(new VippsCreateAgreementResponse { AgreementId = "addon_agr", VippsConfirmationUrl = "https://vipps.no/x" });
+
+        var ctrl = CreateController(db, vipps: vipps);
+
+        await ctrl.InitiateSubscription(new InitiateSubscriptionDto
+        {
+            ProductId = 2, PhoneNumber = "4791234567", ConsentToWaiveWithdrawal = true, Quantity = 3
+        });
+
+        var addon = await db.Subscriptions.SingleAsync(s => s.ProductId == 2);
+        Assert.Equal(3, addon.Quantity);
+    }
+
+    [Fact]
+    public async Task InitiatePrimary_WithQuantityAbove1_Returns400()
+    {
+        using var db = CreateDbContext();
+        await db.Products.AddAsync(MakePrimaryProduct());
+        await db.SaveChangesAsync();
+
+        var ctrl = CreateController(db);
+        var result = await ctrl.InitiateSubscription(new InitiateSubscriptionDto
+        {
+            ProductId = 1, PhoneNumber = "4791234567", ConsentToWaiveWithdrawal = true, Quantity = 2
+        });
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task UpdateQuantity_ActiveAddOn_CallsVippsUpdateAndUpdatesRow()
+    {
+        using var db = CreateDbContext();
+        await db.Products.AddRangeAsync(MakePrimaryProduct(), MakeAddOnProduct());
+        var sub = new Subscription
+        {
+            UserId = "user-1", ProductId = 2,
+            VippsAgreementId = "addon_agr", Status = SubscriptionStatus.Active, Quantity = 3
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        var vipps = MockVipps();
+        int? capturedAmount = null;
+        vipps.Setup(v => v.UpdateAgreementAmountAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
+            .Callback<string, int, string>((_, amount, _) => capturedAmount = amount)
+            .Returns(Task.CompletedTask);
+
+        var ctrl = CreateController(db, vipps: vipps);
+        var result = await ctrl.UpdateSubscriptionQuantity(sub.Id, new UpdateSubscriptionQuantityDto { Quantity = 5 });
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(4900 * 5, capturedAmount);
+        var updated = await db.Subscriptions.FindAsync(sub.Id);
+        Assert.Equal(5, updated!.Quantity);
+    }
+
+    [Fact]
+    public async Task UpdateQuantity_NotOwner_Returns404()
+    {
+        using var db = CreateDbContext();
+        await db.Products.AddAsync(MakeAddOnProduct());
+        var sub = new Subscription
+        {
+            UserId = "other-user", ProductId = 2,
+            VippsAgreementId = "addon_agr", Status = SubscriptionStatus.Active, Quantity = 1
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        var ctrl = CreateController(db, userId: "user-1");
+        var result = await ctrl.UpdateSubscriptionQuantity(sub.Id, new UpdateSubscriptionQuantityDto { Quantity = 5 });
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task UpdateQuantity_Primary_Returns400()
+    {
+        using var db = CreateDbContext();
+        await db.Products.AddAsync(MakePrimaryProduct());
+        var sub = new Subscription
+        {
+            UserId = "user-1", ProductId = 1,
+            VippsAgreementId = "primary_agr", Status = SubscriptionStatus.Active, Quantity = 1
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        var ctrl = CreateController(db);
+        var result = await ctrl.UpdateSubscriptionQuantity(sub.Id, new UpdateSubscriptionQuantityDto { Quantity = 2 });
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task UpdateQuantity_NotActive_Returns400()
+    {
+        using var db = CreateDbContext();
+        await db.Products.AddAsync(MakeAddOnProduct());
+        var sub = new Subscription
+        {
+            UserId = "user-1", ProductId = 2,
+            VippsAgreementId = "addon_agr", Status = SubscriptionStatus.Pending, Quantity = 1
+        };
+        await db.Subscriptions.AddAsync(sub);
+        await db.SaveChangesAsync();
+
+        var ctrl = CreateController(db);
+        var result = await ctrl.UpdateSubscriptionQuantity(sub.Id, new UpdateSubscriptionQuantityDto { Quantity = 3 });
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
 }

--- a/garge-api.Tests/UserControllerTests.cs
+++ b/garge-api.Tests/UserControllerTests.cs
@@ -1,4 +1,4 @@
-using AutoMapper;
+using MapsterMapper;
 using garge_api.Controllers;
 using garge_api.Dtos.User;
 using garge_api.Hubs;

--- a/garge-api.csproj
+++ b/garge-api.csproj
@@ -20,7 +20,8 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCoreRateLimit" Version="5.0.0" />
-    <PackageReference Include="AutoMapper" Version="16.1.1" />
+    <PackageReference Include="Mapster" Version="7.4.0" />
+    <PackageReference Include="Mapster.DependencyInjection" Version="1.0.1" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
     <PackageReference Include="brevo_csharp" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />


### PR DESCRIPTION
## Summary
- Adds Quantity (1..50, default 1) column on Subscription. Migration backfills existing rows to 1.
- InitiateSubscription accepts Quantity; Vipps agreement created at unitPrice * quantity. Primary enforced to Quantity=1.
- New PATCH /api/subscriptions/{id}/quantity: AddOn-only, Active-only, calls Vipps Recurring API to update the agreement's pricing.amount; user must reconfirm in Vipps app.
- IVippsService gains UpdateAgreementAmountAsync (PATCH /recurring/v3/agreements/{id}).
- 7 new tests cover initiate happy paths, primary qty guard, update happy path, owner check, primary update guard, non-active guard.
- Frontend depends on this: sondresjolyst/garge-app subscription-quantity.