### PR TITLE
chore(debug): log forwarding headers on subscription initiate

### DIFF
--- a/Controllers/SubscriptionsController.cs
+++ b/Controllers/SubscriptionsController.cs
@@ -212,6 +212,15 @@ namespace garge_api.Controllers
             var settings = await _settingsCache.GetAsync();
             var unitPriceInOre = Pricing.EffectiveInOre(product.PriceInOre, settings.VatEnabled);
 
+            // TEMP DEBUG: log raw forwarding context so we can see why ConsentIp ends up as 127.0.0.x in k8s.
+            var rawRemote = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "(null)";
+            var xff = HttpContext.Request.Headers.TryGetValue("X-Forwarded-For", out var xffVal) ? xffVal.ToString() : "(absent)";
+            var xrealip = HttpContext.Request.Headers.TryGetValue("X-Real-IP", out var xrealVal) ? xrealVal.ToString() : "(absent)";
+            var forwardedHdr = HttpContext.Request.Headers.TryGetValue("Forwarded", out var fwdVal) ? fwdVal.ToString() : "(absent)";
+            _logger.LogInformation(
+                "InitiateSubscription IP debug: RemoteIpAddress={Remote} X-Forwarded-For={Xff} X-Real-IP={Xreal} Forwarded={Fwd}",
+                rawRemote, xff, xrealip, forwardedHdr);
+
             var subscription = new Subscription
             {
                 UserId = userId,
@@ -221,7 +230,7 @@ namespace garge_api.Controllers
                 Status = SubscriptionStatus.Pending,
                 IsTest = settings.VippsTestMode,
                 ConsentAcceptedAt = DateTime.UtcNow,
-                ConsentIp = IpTruncator.Truncate(HttpContext.Connection.RemoteIpAddress?.ToString())
+                ConsentIp = IpTruncator.Truncate(rawRemote)
             };
 
             _context.Subscriptions.Add(subscription);


### PR DESCRIPTION
Temporary diagnostic logging to figure out why ConsentIp is stored as 127.0.0.0 in k8s even after the ForwardedHeaders trust-any fix. Logs RemoteIpAddress + X-Forwarded-For + X-Real-IP + Forwarded headers on each /api/subscriptions/initiate. Revert once cause is known.