### PR TITLE
fix(battery-health): clear LastChargedAt when firmware resets ChargesRecorded

### DIFF
--- a/Controllers/BatteryHealthController.cs
+++ b/Controllers/BatteryHealthController.cs
@@ -81,8 +81,20 @@ namespace garge_api.Controllers
             //   DISCONNECT_CONFIRM_CYCLES (18) + POST_CHARGE_WAIT_CYCLES (6) = 24h
             // from real charger removal to record creation. Update both in
             // lockstep if firmware constants change.
+            //
+            // Three branches:
+            //   - increment   -> new charge cycle; backdate by 24h
+            //   - decrement   -> firmware reset (NVS schema bump, factory reset);
+            //                    prior LastChargedAt no longer applies, clear it
+            //   - same/no prev with ChargesRecorded=0 -> no charge ever recorded;
+            //                                            keep null
+            //   - same/no prev with ChargesRecorded>0 -> carry prior timestamp
             if (previous != null && dto.ChargesRecorded > previous.ChargesRecorded)
                 record.LastChargedAt = DateTime.UtcNow.AddHours(-24);
+            else if (previous != null && dto.ChargesRecorded < previous.ChargesRecorded)
+                record.LastChargedAt = null;
+            else if (dto.ChargesRecorded == 0)
+                record.LastChargedAt = null;
             else
                 record.LastChargedAt = previous?.LastChargedAt;
 


### PR DESCRIPTION
## Summary
- Old logic only ran the LastChargedAt update branch when ChargesRecorded increased; otherwise it carried the prior value forward indefinitely. When firmware NVS reset (schema bump, factory reset, etc) ChargesRecorded went e.g. 14 -> 0 but the stale LastChargedAt stuck in the DB forever.
- Now: if ChargesRecorded decreased OR is 0, LastChargedAt is set to null. Increment branch unchanged.
- Verified live: prod sensors 7 (Tenere) and 18 (GSX 1300R) both pinned to a stale 2026-04-26 / 2026-05-02 timestamp despite ChargesRecorded=0 in every report since. Self-heals on next BH report after deploy.