### PR TITLE
feat(battery): server-side health analyzer from voltage stream

### DIFF
--- a/Controllers/BatteryHealthController.cs
+++ b/Controllers/BatteryHealthController.cs
@@ -43,55 +43,19 @@ namespace garge_api.Controllers
         }
 
         /// <summary>
-        /// Stores a battery health reading for the voltage sensor identified by name.
-        /// Called by the operator when a battery health MQTT state message arrives.
+        /// Deprecated: battery health is now computed server-side by
+        /// <c>BatteryHealthAnalyzerService</c> from the voltage stream.
+        /// Endpoint is kept temporarily so firmware/operator that still
+        /// posts can do so without errors; the payload is ignored.
         /// </summary>
         [HttpPost("name/{sensorName}")]
-        [SwaggerOperation(Summary = "Creates a battery health record for a voltage sensor by name.")]
-        [SwaggerResponse(201, "The created battery health record.", typeof(BatteryHealthDto))]
-        [SwaggerResponse(404, "Voltage sensor not found.")]
-        [SwaggerResponse(403, "User does not have the required role.")]
-        public async Task<IActionResult> CreateBatteryHealth(string sensorName, [FromBody] CreateBatteryHealthDto dto)
+        [SwaggerOperation(Summary = "Deprecated. Battery health is now computed server-side; payload ignored.", Tags = new[] { "Deprecated" })]
+        [SwaggerResponse(200, "Acknowledged. No record written; analyzer runs from voltage stream.")]
+        public IActionResult CreateBatteryHealth(string sensorName, [FromBody] CreateBatteryHealthDto _)
         {
-            _logger.LogInformation("CreateBatteryHealth called by {@LogData}", new { CallerUserId = User.UserId(), SensorName = LogSanitizer.Sanitize(sensorName) });
-
-            if (!IsAdmin())
-            {
-                _logger.LogWarning("CreateBatteryHealth forbidden for {@LogData}", new { CallerUserId = User.UserId(), SensorName = LogSanitizer.Sanitize(sensorName) });
-                return Forbid();
-            }
-
-            var sensor = await _context.Sensors.FirstOrDefaultAsync(s => s.Name == sensorName);
-            if (sensor == null)
-            {
-                _logger.LogWarning("CreateBatteryHealth voltage sensor not found: {SensorName}", LogSanitizer.Sanitize(sensorName));
-                return NotFound(new { message = "Sensor not found!" });
-            }
-
-            var record = _mapper.Map<BatteryHealth>(dto);
-            record.SensorId = sensor.Id;
-            record.Timestamp = DateTime.UtcNow;
-
-            var previous = await _context.BatteryHealthData
-                .Where(bh => bh.SensorId == sensor.Id)
-                .OrderByDescending(bh => bh.Timestamp)
-                .FirstOrDefaultAsync();
-
-            // Offset matches firmware BatteryHealthController.h:
-            //   DISCONNECT_CONFIRM_CYCLES (18) + POST_CHARGE_WAIT_CYCLES (6) = 24h
-            // from real charger removal to record creation. Update both in
-            // lockstep if firmware constants change.
-            if (previous != null && dto.ChargesRecorded > previous.ChargesRecorded)
-                record.LastChargedAt = DateTime.UtcNow.AddHours(-24);
-            else
-                record.LastChargedAt = previous?.LastChargedAt;
-
-            _context.BatteryHealthData.Add(record);
-            await _context.SaveChangesAsync();
-
-            var result = _mapper.Map<BatteryHealthDto>(record);
-            _logger.LogInformation("Battery health record created: {@LogData}", new { record.Id, SensorName = LogSanitizer.Sanitize(sensorName), record.Status });
-            return CreatedAtAction(nameof(GetLatestBatteryHealth), new { sensorName }, result);
+            _logger.LogInformation("CreateBatteryHealth (deprecated) called for {SensorName}; ignoring payload — analyzer drives health from voltage.",
+                LogSanitizer.Sanitize(sensorName));
+            return Ok(new { message = "Battery health is computed server-side. This endpoint is a no-op." });
         }
 
         /// <summary>
@@ -130,7 +94,67 @@ namespace garge_api.Controllers
                 return Ok((BatteryHealthDto?)null);
             }
 
-            return Ok(_mapper.Map<BatteryHealthDto>(latest));
+            var dto = _mapper.Map<BatteryHealthDto>(latest);
+            dto.CalibrationOffsetV = sensor.CalibrationOffsetV;
+            return Ok(dto);
+        }
+
+        /// <summary>Returns detected charge events for a voltage sensor, optionally since a given timestamp.</summary>
+        [HttpGet("name/{sensorName}/events")]
+        [SwaggerOperation(Summary = "Returns detected battery charge events for a voltage sensor.")]
+        [SwaggerResponse(200, "Charge events.", typeof(IEnumerable<BatteryChargeEventDto>))]
+        public async Task<IActionResult> GetChargeEvents(string sensorName, [FromQuery] DateTime? since)
+        {
+            var sensor = await _context.Sensors.FirstOrDefaultAsync(s => s.Name == sensorName);
+            if (sensor == null) return NotFound(new { message = "Sensor not found!" });
+            if (!await UserCanAccessSensorAsync(sensor.Id)) return Forbid();
+
+            var query = _context.BatteryChargeEvents.Where(e => e.SensorId == sensor.Id);
+            if (since.HasValue) query = query.Where(e => e.StartedAt >= since.Value);
+            var events = await query.OrderByDescending(e => e.StartedAt).ToListAsync();
+            return Ok(_mapper.Map<List<BatteryChargeEventDto>>(events));
+        }
+
+        /// <summary>Stores a per-sensor calibration offset based on a multimeter reading at the moment of calibration.</summary>
+        [HttpPost("name/{sensorName}/calibration")]
+        [SwaggerOperation(Summary = "Calibrate a voltage sensor against a multimeter reading.")]
+        [SwaggerResponse(200, "Calibration offset stored.")]
+        public async Task<IActionResult> Calibrate(string sensorName, [FromBody] CalibrationDto dto)
+        {
+            var sensor = await _context.Sensors.FirstOrDefaultAsync(s => s.Name == sensorName);
+            if (sensor == null) return NotFound(new { message = "Sensor not found!" });
+            if (!await UserCanAccessSensorAsync(sensor.Id)) return Forbid();
+
+            var latest = await _context.SensorData
+                .Where(sd => sd.SensorId == sensor.Id)
+                .OrderByDescending(sd => sd.Timestamp)
+                .Select(sd => sd.Value)
+                .FirstOrDefaultAsync();
+            if (string.IsNullOrEmpty(latest) ||
+                !float.TryParse(latest, System.Globalization.CultureInfo.InvariantCulture, out var sensorReading))
+                return BadRequest(new { message = "No recent sensor reading to calibrate against." });
+
+            sensor.CalibrationOffsetV = dto.MultimeterVoltage - sensorReading;
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("Calibration set for {SensorName}: offset={Offset:F3}V",
+                LogSanitizer.Sanitize(sensorName), sensor.CalibrationOffsetV);
+            return Ok(new { calibrationOffsetV = sensor.CalibrationOffsetV });
+        }
+
+        /// <summary>Clears a sensor's stored calibration offset.</summary>
+        [HttpDelete("name/{sensorName}/calibration")]
+        [SwaggerOperation(Summary = "Clear a voltage sensor's calibration offset.")]
+        [SwaggerResponse(204, "Calibration cleared.")]
+        public async Task<IActionResult> ClearCalibration(string sensorName)
+        {
+            var sensor = await _context.Sensors.FirstOrDefaultAsync(s => s.Name == sensorName);
+            if (sensor == null) return NotFound(new { message = "Sensor not found!" });
+            if (!await UserCanAccessSensorAsync(sensor.Id)) return Forbid();
+
+            sensor.CalibrationOffsetV = null;
+            await _context.SaveChangesAsync();
+            return NoContent();
         }
     }
 }

--- a/Dtos/Sensor/BatteryHealthDto.cs
+++ b/Dtos/Sensor/BatteryHealthDto.cs
@@ -5,11 +5,47 @@ namespace garge_api.Dtos.Sensor
         public int Id { get; set; }
         public int SensorId { get; set; }
         public required string Status { get; set; }
+
+        // Legacy fields. Kept during cutover so existing clients don't break.
         public float Baseline { get; set; }
         public float LastCharge { get; set; }
         public float DropPct { get; set; }
         public int ChargesRecorded { get; set; }
-        public DateTime Timestamp { get; set; }
         public DateTime? LastChargedAt { get; set; }
+
+        // Analyzer-computed fields.
+        public float CurrentVoltage { get; set; }
+        public float RestingMedian { get; set; }
+        public float PeakResting { get; set; }
+        public bool OnChargerNow { get; set; }
+        public DateTime? LastFullChargeAt { get; set; }
+        public float? LastFullChargePeak { get; set; }
+        public float? VoltageMin24h { get; set; }
+        public int FullChargesLast30d { get; set; }
+        public float DailyDropPctPerWeek { get; set; }
+        public float? ChargeAcceptanceRatio { get; set; }
+
+        // Sensor-level calibration offset (volts). Frontend may add this to
+        // CurrentVoltage to display "actual" voltage.
+        public float? CalibrationOffsetV { get; set; }
+
+        public DateTime Timestamp { get; set; }
+    }
+
+    public class BatteryChargeEventDto
+    {
+        public int Id { get; set; }
+        public int SensorId { get; set; }
+        public DateTime StartedAt { get; set; }
+        public DateTime EndedAt { get; set; }
+        public float PeakVoltage { get; set; }
+        public float RestingAtTime { get; set; }
+        public float PeakRatio { get; set; }
+        public int DurationMinutes { get; set; }
+    }
+
+    public class CalibrationDto
+    {
+        public required float MultimeterVoltage { get; set; }
     }
 }

--- a/Helpers/BatteryHealthMath.cs
+++ b/Helpers/BatteryHealthMath.cs
@@ -1,0 +1,229 @@
+namespace garge_api.Helpers
+{
+    /// <summary>
+    /// Pure-function helpers for battery-health analysis. All thresholds
+    /// are per-sensor ratios so calibration drift between sensors doesn't
+    /// affect classification. Unit-tested in isolation; no DB / time deps.
+    /// </summary>
+    public static class BatteryHealthMath
+    {
+        public record VoltageSample(DateTime Timestamp, float Value);
+
+        public record ChargeWindow(
+            DateTime StartedAt,
+            DateTime EndedAt,
+            float PeakVoltage,
+            float RestingAtTime,
+            int DurationMinutes)
+        {
+            public float PeakRatio => RestingAtTime > 0 ? PeakVoltage / RestingAtTime : 0;
+        }
+
+        // Charge-event detection ratios (relative to restingMedian).
+        public const float ChargeEntryRatio = 1.04f;
+        public const float ChargeExitRatio = 1.02f;
+        public const float ChargePeakMinRatio = 1.08f;
+        public const int ChargeMinMinutes = 60;
+        public const int ChargeExitSustainMinutes = 30;
+
+        // Status classification thresholds.
+        public const float S1AttentionDropPct = 2f;
+        public const float S1ReplaceDropPct = 5f;
+        public const float S2AttentionSlopePctWeek = 0.1f;
+        public const float S2ReplaceSlopePctWeek = 0.3f;
+        public const float S3GoodAcceptance = 1.10f;
+        public const float S3ReplaceAcceptance = 1.04f;
+
+        public const int LearningMinDays = 14;
+
+        /// <summary>
+        /// Resting voltage estimate: median of the bottom quartile (lowest
+        /// 25%) of samples in the window. Filters elevated charging periods.
+        /// </summary>
+        public static float ComputeRestingMedian(IReadOnlyList<VoltageSample> samples, DateTime asOf, TimeSpan window)
+        {
+            var cutoff = asOf - window;
+            var values = samples
+                .Where(s => s.Timestamp >= cutoff && s.Timestamp <= asOf)
+                .Select(s => s.Value)
+                .OrderBy(v => v)
+                .ToList();
+            if (values.Count == 0) return 0;
+            var quartileCount = Math.Max(1, values.Count / 4);
+            var bottom = values.Take(quartileCount).ToList();
+            return Median(bottom);
+        }
+
+        private static float Median(List<float> sortedAscending)
+        {
+            if (sortedAscending.Count == 0) return 0;
+            var n = sortedAscending.Count;
+            return n % 2 == 1
+                ? sortedAscending[n / 2]
+                : (sortedAscending[n / 2 - 1] + sortedAscending[n / 2]) / 2f;
+        }
+
+        /// <summary>
+        /// Highest resting median observed over the rolling window. Tracks
+        /// slow calibration drift by NOT being a lifetime max.
+        /// </summary>
+        public static float ComputePeakResting(IReadOnlyList<VoltageSample> samples, DateTime asOf, TimeSpan rollingWindow, TimeSpan restingWindow)
+        {
+            var start = asOf - rollingWindow;
+            if (samples.Count == 0) return 0;
+            // Sample the resting median across the rolling window at daily checkpoints.
+            float peak = 0;
+            for (var t = start; t <= asOf; t = t.AddDays(1))
+            {
+                var resting = ComputeRestingMedian(samples, t, restingWindow);
+                if (resting > peak) peak = resting;
+            }
+            return peak;
+        }
+
+        /// <summary>
+        /// Detect "full charge" events: contiguous windows of elevated
+        /// voltage (above ChargeEntryRatio × resting) lasting ≥ ChargeMinMinutes
+        /// and peaking at ≥ ChargePeakMinRatio × resting. Window ends after
+        /// ChargeExitSustainMinutes below ChargeExitRatio × resting.
+        /// </summary>
+        public static IReadOnlyList<ChargeWindow> DetectChargeEvents(IReadOnlyList<VoltageSample> samples, float restingMedian)
+        {
+            var events = new List<ChargeWindow>();
+            if (restingMedian <= 0 || samples.Count == 0) return events;
+
+            var entry = restingMedian * ChargeEntryRatio;
+            var exit = restingMedian * ChargeExitRatio;
+            var peakMin = restingMedian * ChargePeakMinRatio;
+
+            DateTime? winStart = null;
+            float winPeak = 0;
+            DateTime? exitCandidateSince = null;
+
+            foreach (var s in samples.OrderBy(s => s.Timestamp))
+            {
+                if (winStart == null)
+                {
+                    if (s.Value > entry)
+                    {
+                        winStart = s.Timestamp;
+                        winPeak = s.Value;
+                        exitCandidateSince = null;
+                    }
+                }
+                else
+                {
+                    if (s.Value > winPeak) winPeak = s.Value;
+
+                    if (s.Value < exit)
+                    {
+                        exitCandidateSince ??= s.Timestamp;
+                        if ((s.Timestamp - exitCandidateSince.Value).TotalMinutes >= ChargeExitSustainMinutes)
+                        {
+                            var endedAt = exitCandidateSince.Value;
+                            var durationMin = (int)Math.Round((endedAt - winStart.Value).TotalMinutes);
+                            if (durationMin >= ChargeMinMinutes && winPeak >= peakMin)
+                            {
+                                events.Add(new ChargeWindow(winStart.Value, endedAt, winPeak, restingMedian, durationMin));
+                            }
+                            winStart = null;
+                            winPeak = 0;
+                            exitCandidateSince = null;
+                        }
+                    }
+                    else
+                    {
+                        exitCandidateSince = null;
+                    }
+                }
+            }
+            return events;
+        }
+
+        /// <summary>
+        /// Linear least-squares slope of values over time, expressed as
+        /// percent change per week of the values' mean. Positive = rising.
+        /// </summary>
+        public static float ComputeSlopePercentPerWeek(IReadOnlyList<VoltageSample> samples)
+        {
+            if (samples.Count < 2) return 0;
+            var t0 = samples[0].Timestamp;
+            var xs = samples.Select(s => (s.Timestamp - t0).TotalDays).ToList();
+            var ys = samples.Select(s => (double)s.Value).ToList();
+            var meanX = xs.Average();
+            var meanY = ys.Average();
+            double num = 0, den = 0;
+            for (var i = 0; i < xs.Count; i++)
+            {
+                num += (xs[i] - meanX) * (ys[i] - meanY);
+                den += (xs[i] - meanX) * (xs[i] - meanX);
+            }
+            if (den == 0 || meanY == 0) return 0;
+            var slopePerDay = num / den;
+            var slopePerWeek = slopePerDay * 7;
+            return (float)(slopePerWeek / meanY * 100.0);
+        }
+
+        public record HealthClassification(string Status, string Reason, float DropPct);
+
+        /// <summary>
+        /// Combine the three signals into a final status. Worst wins.
+        /// Returns "learning" if fewer than <see cref="LearningMinDays"/>
+        /// days of data exist.
+        /// </summary>
+        public static HealthClassification ClassifyHealth(
+            float dropPctFromPeak,
+            float slopePctPerWeek,
+            float? chargeAcceptanceRatio,
+            int daysOfData)
+        {
+            if (daysOfData < LearningMinDays)
+                return new HealthClassification("learning", $"only {daysOfData}d of data (need ≥{LearningMinDays}d)", dropPctFromPeak);
+
+            // S1
+            var s1 = dropPctFromPeak switch
+            {
+                <= S1AttentionDropPct => 0,
+                <= S1ReplaceDropPct => 1,
+                _ => 2
+            };
+
+            // S2 (slope is decline if negative; we compare magnitude of decline)
+            var declinePctWeek = slopePctPerWeek < 0 ? -slopePctPerWeek : 0;
+            var s2 = declinePctWeek switch
+            {
+                var d when d <= S2AttentionSlopePctWeek => 0,
+                var d when d <= S2ReplaceSlopePctWeek => 1,
+                _ => 2
+            };
+
+            // S3 (only if we have a charge event)
+            var s3 = 0;
+            if (chargeAcceptanceRatio.HasValue)
+            {
+                s3 = chargeAcceptanceRatio.Value switch
+                {
+                    >= S3GoodAcceptance => 0,
+                    >= S3ReplaceAcceptance => 1,
+                    _ => 2
+                };
+            }
+
+            var worst = Math.Max(s1, Math.Max(s2, s3));
+            var status = worst switch
+            {
+                0 => "good",
+                1 => "attention",
+                _ => "replace"
+            };
+
+            var reasons = new List<string>();
+            if (s1 > 0) reasons.Add($"drop {dropPctFromPeak:F1}%");
+            if (s2 > 0) reasons.Add($"decline {declinePctWeek:F2}%/wk");
+            if (s3 > 0 && chargeAcceptanceRatio.HasValue) reasons.Add($"charge acceptance {chargeAcceptanceRatio.Value:F2}×");
+            var reason = reasons.Count > 0 ? string.Join(", ", reasons) : "all signals healthy";
+
+            return new HealthClassification(status, reason, dropPctFromPeak);
+        }
+    }
+}

--- a/Helpers/BatteryHealthMath.cs
+++ b/Helpers/BatteryHealthMath.cs
@@ -175,10 +175,18 @@ namespace garge_api.Helpers
             float dropPctFromPeak,
             float slopePctPerWeek,
             float? chargeAcceptanceRatio,
-            int daysOfData)
+            int daysOfData,
+            bool hasRecentCharge)
         {
             if (daysOfData < LearningMinDays)
                 return new HealthClassification("learning", $"only {daysOfData}d of data (need ≥{LearningMinDays}d)", dropPctFromPeak);
+
+            // Without a recent charge event we cannot separate true battery
+            // degradation from normal self-discharge plus sensor parasitic drain.
+            // Skip the drop / slope penalties and report "learning" with a hint
+            // so the user knows a charge cycle is needed to assess health.
+            if (!hasRecentCharge)
+                return new HealthClassification("learning", "no charge events in 90d — connect charger to assess health", dropPctFromPeak);
 
             // S1
             var s1 = dropPctFromPeak switch

--- a/Migrations/20260514185631_AddBatteryHealthV2.Designer.cs
+++ b/Migrations/20260514185631_AddBatteryHealthV2.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260514185631_AddBatteryHealthV2")]
+    partial class AddBatteryHealthV2
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260514185631_AddBatteryHealthV2.cs
+++ b/Migrations/20260514185631_AddBatteryHealthV2.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBatteryHealthV2 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<float>(
+                name: "CalibrationOffsetV",
+                table: "Sensors",
+                type: "real",
+                nullable: true);
+
+            migrationBuilder.AddColumn<float>(
+                name: "ChargeAcceptanceRatio",
+                table: "BatteryHealthData",
+                type: "real",
+                nullable: true);
+
+            migrationBuilder.AddColumn<float>(
+                name: "CurrentVoltage",
+                table: "BatteryHealthData",
+                type: "real",
+                nullable: false,
+                defaultValue: 0f);
+
+            migrationBuilder.AddColumn<float>(
+                name: "DailyDropPctPerWeek",
+                table: "BatteryHealthData",
+                type: "real",
+                nullable: false,
+                defaultValue: 0f);
+
+            migrationBuilder.AddColumn<int>(
+                name: "FullChargesLast30d",
+                table: "BatteryHealthData",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastFullChargeAt",
+                table: "BatteryHealthData",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<float>(
+                name: "LastFullChargePeak",
+                table: "BatteryHealthData",
+                type: "real",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "OnChargerNow",
+                table: "BatteryHealthData",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<float>(
+                name: "PeakResting",
+                table: "BatteryHealthData",
+                type: "real",
+                nullable: false,
+                defaultValue: 0f);
+
+            migrationBuilder.AddColumn<float>(
+                name: "RestingMedian",
+                table: "BatteryHealthData",
+                type: "real",
+                nullable: false,
+                defaultValue: 0f);
+
+            migrationBuilder.AddColumn<float>(
+                name: "VoltageMin24h",
+                table: "BatteryHealthData",
+                type: "real",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "BatteryChargeEvents",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    SensorId = table.Column<int>(type: "integer", nullable: false),
+                    StartedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    EndedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    PeakVoltage = table.Column<float>(type: "real", nullable: false),
+                    RestingAtTime = table.Column<float>(type: "real", nullable: false),
+                    PeakRatio = table.Column<float>(type: "real", nullable: false),
+                    DurationMinutes = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BatteryChargeEvents", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_BatteryChargeEvents_Sensors_SensorId",
+                        column: x => x.SensorId,
+                        principalTable: "Sensors",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BatteryChargeEvents_SensorId_StartedAt",
+                table: "BatteryChargeEvents",
+                columns: new[] { "SensorId", "StartedAt" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "BatteryChargeEvents");
+
+            migrationBuilder.DropColumn(
+                name: "CalibrationOffsetV",
+                table: "Sensors");
+
+            migrationBuilder.DropColumn(
+                name: "ChargeAcceptanceRatio",
+                table: "BatteryHealthData");
+
+            migrationBuilder.DropColumn(
+                name: "CurrentVoltage",
+                table: "BatteryHealthData");
+
+            migrationBuilder.DropColumn(
+                name: "DailyDropPctPerWeek",
+                table: "BatteryHealthData");
+
+            migrationBuilder.DropColumn(
+                name: "FullChargesLast30d",
+                table: "BatteryHealthData");
+
+            migrationBuilder.DropColumn(
+                name: "LastFullChargeAt",
+                table: "BatteryHealthData");
+
+            migrationBuilder.DropColumn(
+                name: "LastFullChargePeak",
+                table: "BatteryHealthData");
+
+            migrationBuilder.DropColumn(
+                name: "OnChargerNow",
+                table: "BatteryHealthData");
+
+            migrationBuilder.DropColumn(
+                name: "PeakResting",
+                table: "BatteryHealthData");
+
+            migrationBuilder.DropColumn(
+                name: "RestingMedian",
+                table: "BatteryHealthData");
+
+            migrationBuilder.DropColumn(
+                name: "VoltageMin24h",
+                table: "BatteryHealthData");
+        }
+    }
+}

--- a/Models/ApplicationDbContext.cs
+++ b/Models/ApplicationDbContext.cs
@@ -26,6 +26,7 @@ namespace garge_api.Models
         public DbSet<Sensor.Sensor> Sensors { get; set; }
         public DbSet<SensorData> SensorData { get; set; }
         public DbSet<BatteryHealth> BatteryHealthData { get; set; }
+        public DbSet<BatteryChargeEvent> BatteryChargeEvents { get; set; }
         public DbSet<Switch.Switch> Switches { get; set; }
         public DbSet<SwitchData> SwitchData { get; set; }
         public DbSet<RefreshToken> RefreshTokens { get; set; }
@@ -84,6 +85,10 @@ namespace garge_api.Models
 
             modelBuilder.Entity<BatteryHealth>()
                 .HasIndex(bh => bh.SensorId);
+
+            modelBuilder.Entity<BatteryChargeEvent>()
+                .HasIndex(e => new { e.SensorId, e.StartedAt })
+                .IsUnique();
 
             modelBuilder.Entity<BatteryHealth>()
                 .HasIndex(bh => bh.Timestamp);

--- a/Models/Sensor/BatteryChargeEvent.cs
+++ b/Models/Sensor/BatteryChargeEvent.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace garge_api.Models.Sensor
+{
+    /// <summary>
+    /// One detected charge event for a voltage sensor: a contiguous window
+    /// where voltage stayed elevated above the sensor's own resting median
+    /// long enough and high enough to count as a real charge cycle.
+    ///
+    /// Detected by <c>BatteryHealthAnalyzerService</c> from <c>SensorData</c>;
+    /// de-duplicated by <c>(SensorId, StartedAt)</c>.
+    /// </summary>
+    public class BatteryChargeEvent
+    {
+        [Key]
+        public int Id { get; set; }
+
+        [Required]
+        public int SensorId { get; set; }
+
+        [ForeignKey(nameof(SensorId))]
+        public Sensor? Sensor { get; set; }
+
+        [Required]
+        public DateTime StartedAt { get; set; }
+
+        [Required]
+        public DateTime EndedAt { get; set; }
+
+        [Required]
+        public float PeakVoltage { get; set; }
+
+        [Required]
+        public float RestingAtTime { get; set; }
+
+        // peak / restingAtTime — health uses this for "charge acceptance" signal.
+        [Required]
+        public float PeakRatio { get; set; }
+
+        [Required]
+        public int DurationMinutes { get; set; }
+    }
+}

--- a/Models/Sensor/BatteryHealth.cs
+++ b/Models/Sensor/BatteryHealth.cs
@@ -3,6 +3,12 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace garge_api.Models.Sensor
 {
+    /// <summary>
+    /// Snapshot of a battery-voltage sensor's analyzer-computed health.
+    /// One row inserted by <c>BatteryHealthAnalyzerService</c> per analyzer
+    /// run (event-driven on new SensorData). The latest row is what the
+    /// UI reads.
+    /// </summary>
     public class BatteryHealth
     {
         [Key]
@@ -18,14 +24,28 @@ namespace garge_api.Models.Sensor
         [MaxLength(20)]
         public required string Status { get; set; }
 
+        // Legacy fields, kept for cutover period. Will be removed in phase 2.
+        // Populated by analyzer with mapped equivalents so old clients keep
+        // working until they migrate to the new field names.
         public float Baseline { get; set; }
         public float LastCharge { get; set; }
         public float DropPct { get; set; }
         public int ChargesRecorded { get; set; }
+        public DateTime? LastChargedAt { get; set; }
+
+        // New analyzer-computed fields ---
+        public float CurrentVoltage { get; set; }
+        public float RestingMedian { get; set; }
+        public float PeakResting { get; set; }
+        public bool OnChargerNow { get; set; }
+        public DateTime? LastFullChargeAt { get; set; }
+        public float? LastFullChargePeak { get; set; }
+        public float? VoltageMin24h { get; set; }
+        public int FullChargesLast30d { get; set; }
+        public float DailyDropPctPerWeek { get; set; }
+        public float? ChargeAcceptanceRatio { get; set; }
 
         [Required]
         public DateTime Timestamp { get; set; }
-
-        public DateTime? LastChargedAt { get; set; }
     }
 }

--- a/Models/Sensor/Sensor.cs
+++ b/Models/Sensor/Sensor.cs
@@ -33,6 +33,12 @@ namespace garge_api.Models.Sensor
         [Required]
         public required string ParentName { get; set; }
 
+        // User-supplied additive offset (volts) for voltage sensors with
+        // calibration drift. Frontend displays `value + offset` as the
+        // "actual" voltage; health logic itself is ratio-based so doesn't
+        // use this. Null means uncalibrated.
+        public float? CalibrationOffsetV { get; set; }
+
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     }
 }

--- a/Profiles/MappingProfile.cs
+++ b/Profiles/MappingProfile.cs
@@ -41,6 +41,7 @@ public class MappingProfile : IRegister
         config.NewConfig<SensorData, SensorDataDto>().TwoWays();
         config.NewConfig<BatteryHealth, BatteryHealthDto>().TwoWays();
         config.NewConfig<CreateBatteryHealthDto, BatteryHealth>();
+        config.NewConfig<BatteryChargeEvent, BatteryChargeEventDto>();
         config.NewConfig<SensorActivity, SensorActivityDto>().TwoWays();
         config.NewConfig<CreateSensorActivityDto, SensorActivity>();
         config.NewConfig<UpdateSensorActivityDto, SensorActivity>();

--- a/Program.cs
+++ b/Program.cs
@@ -95,6 +95,8 @@ namespace garge_api
             builder.Services.AddSingleton<IDeviceOwnershipService, DeviceOwnershipService>();
             builder.Services.AddSingleton<CoalescingDispatcher>();
             builder.Services.AddHostedService(sp => sp.GetRequiredService<CoalescingDispatcher>());
+            builder.Services.AddSingleton<BatteryHealthAnalyzerService>();
+            builder.Services.AddHostedService(sp => sp.GetRequiredService<BatteryHealthAnalyzerService>());
             builder.Services.AddHostedService<PostgresNotificationService>();
             builder.Services.AddSingleton<PostgresNotificationService>();
             builder.Services.AddHostedService<garge_api.Services.RefreshTokenCleanupService>();

--- a/Services/BatteryHealthAnalyzerService.cs
+++ b/Services/BatteryHealthAnalyzerService.cs
@@ -121,11 +121,18 @@ namespace garge_api.Services
                 return;
             }
 
+            // Drop unphysical readings. 12 V lead-acid systems never produce
+            // readings below ~5 V (sensor init artifacts, disconnects) or above
+            // ~20 V (charger overvoltage, wiring shorts). Including them poisons
+            // bottom-quartile resting-median and the slope built from it.
+            const float MinPlausibleVolt = 5.0f;
+            const float MaxPlausibleVolt = 20.0f;
             var samples = new List<BatteryHealthMath.VoltageSample>(rawSamples.Count);
             foreach (var s in rawSamples)
             {
-                if (float.TryParse(s.Value, System.Globalization.CultureInfo.InvariantCulture, out var v))
-                    samples.Add(new BatteryHealthMath.VoltageSample(s.Timestamp, v));
+                if (!float.TryParse(s.Value, System.Globalization.CultureInfo.InvariantCulture, out var v)) continue;
+                if (v < MinPlausibleVolt || v > MaxPlausibleVolt) continue;
+                samples.Add(new BatteryHealthMath.VoltageSample(s.Timestamp, v));
             }
             if (samples.Count == 0) return;
 
@@ -142,8 +149,17 @@ namespace garge_api.Services
                 .DefaultIfEmpty(null)
                 .Min();
 
-            var slopeSamples = samples.Where(s => s.Timestamp >= now - SlopeWindow).ToList();
-            var slopePctWeek = BatteryHealthMath.ComputeSlopePercentPerWeek(slopeSamples);
+            // Fit slope to daily resting-voltage checkpoints (same bottom-25% median
+            // stat used for "Drop from peak") so both metrics describe the same
+            // underlying signal: trend of resting voltage. Using raw mean here
+            // would skew the slope whenever the window contains charging spikes.
+            var slopeCheckpoints = new List<BatteryHealthMath.VoltageSample>();
+            for (var t = now - SlopeWindow; t <= now; t = t.AddDays(1))
+            {
+                var r = BatteryHealthMath.ComputeRestingMedian(samples, t, RestingWindow);
+                if (r > 0) slopeCheckpoints.Add(new BatteryHealthMath.VoltageSample(t, r));
+            }
+            var slopePctWeek = BatteryHealthMath.ComputeSlopePercentPerWeek(slopeCheckpoints);
 
             var detected = BatteryHealthMath.DetectChargeEvents(samples, restingMedian);
             await UpsertChargeEventsAsync(db, sensor.Id, detected, ct);
@@ -155,7 +171,8 @@ namespace garge_api.Services
 
             var daysOfData = (int)Math.Round((now - samples[0].Timestamp).TotalDays);
             var dropPct = peakResting > 0 ? (peakResting - restingMedian) / peakResting * 100f : 0f;
-            var classification = BatteryHealthMath.ClassifyHealth(dropPct, slopePctWeek, acceptance, daysOfData);
+            var hasRecentCharge = recentEvents.Count > 0;
+            var classification = BatteryHealthMath.ClassifyHealth(dropPct, slopePctWeek, acceptance, daysOfData, hasRecentCharge);
 
             db.BatteryHealthData.Add(new BatteryHealth
             {

--- a/Services/BatteryHealthAnalyzerService.cs
+++ b/Services/BatteryHealthAnalyzerService.cs
@@ -1,0 +1,218 @@
+using garge_api.Helpers;
+using garge_api.Models;
+using garge_api.Models.Sensor;
+using Microsoft.EntityFrameworkCore;
+
+namespace garge_api.Services
+{
+    /// <summary>
+    /// Server-side battery-health analyzer. Replaces the firmware's NVS
+    /// state machine. On every new <c>SensorData</c> insert for a voltage
+    /// sensor, recompute health metrics from the voltage stream and
+    /// upsert a new <c>BatteryHealth</c> row plus any newly-detected
+    /// <c>BatteryChargeEvents</c>.
+    ///
+    /// Trigger: piggybacks on the existing <c>sensordata_change_trigger</c>
+    /// Postgres NOTIFY plumbing that <see cref="PostgresNotificationService"/>
+    /// already subscribes to for SwitchData. We add a separate listener so
+    /// the existing service stays focused.
+    ///
+    /// Fallback timer: every hour, scan for voltage sensors whose latest
+    /// BatteryHealth row is older than 90 min (or missing) and run the
+    /// analyzer for them. Covers missed notifications.
+    /// </summary>
+    public class BatteryHealthAnalyzerService : BackgroundService
+    {
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly ILogger<BatteryHealthAnalyzerService> _logger;
+        private static readonly TimeSpan FallbackInterval = TimeSpan.FromHours(1);
+        private static readonly TimeSpan StalenessThreshold = TimeSpan.FromMinutes(90);
+
+        private static readonly TimeSpan RestingWindow = TimeSpan.FromDays(14);
+        private static readonly TimeSpan PeakRestingRollingWindow = TimeSpan.FromDays(90);
+        private static readonly TimeSpan SlopeWindow = TimeSpan.FromDays(30);
+        private static readonly TimeSpan ChargeEventLookback = TimeSpan.FromDays(90);
+        private static readonly TimeSpan FullChargeCountWindow = TimeSpan.FromDays(30);
+
+        public BatteryHealthAnalyzerService(
+            IServiceScopeFactory scopeFactory,
+            ILogger<BatteryHealthAnalyzerService> logger)
+        {
+            _scopeFactory = scopeFactory;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await SweepStaleSensorsAsync(stoppingToken);
+                }
+                catch (OperationCanceledException) { }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "BatteryHealthAnalyzer: sweep failed");
+                }
+
+                try
+                {
+                    await Task.Delay(FallbackInterval, stoppingToken);
+                }
+                catch (OperationCanceledException) { }
+            }
+        }
+
+        /// <summary>
+        /// Public entry for the notification handler: analyze a single sensor.
+        /// </summary>
+        public async Task AnalyzeSensorAsync(int sensorId, CancellationToken ct)
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var sensor = await db.Sensors.FindAsync(new object?[] { sensorId }, ct);
+            if (sensor == null || !sensor.Type.Equals("voltage", StringComparison.OrdinalIgnoreCase))
+                return;
+
+            await RunForSensorAsync(db, sensor, ct);
+            await db.SaveChangesAsync(ct);
+        }
+
+        private async Task SweepStaleSensorsAsync(CancellationToken ct)
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+            var voltageSensors = await db.Sensors
+                .Where(s => s.Type == "voltage")
+                .ToListAsync(ct);
+
+            var cutoff = DateTime.UtcNow - StalenessThreshold;
+            foreach (var sensor in voltageSensors)
+            {
+                if (ct.IsCancellationRequested) return;
+                var latest = await db.BatteryHealthData
+                    .Where(bh => bh.SensorId == sensor.Id)
+                    .OrderByDescending(bh => bh.Timestamp)
+                    .Select(bh => (DateTime?)bh.Timestamp)
+                    .FirstOrDefaultAsync(ct);
+                if (latest != null && latest >= cutoff) continue;
+                await RunForSensorAsync(db, sensor, ct);
+            }
+
+            await db.SaveChangesAsync(ct);
+        }
+
+        private async Task RunForSensorAsync(ApplicationDbContext db, Sensor sensor, CancellationToken ct)
+        {
+            var now = DateTime.UtcNow;
+            var rangeStart = now - PeakRestingRollingWindow;
+
+            var rawSamples = await db.SensorData
+                .Where(sd => sd.SensorId == sensor.Id && sd.Timestamp >= rangeStart)
+                .OrderBy(sd => sd.Timestamp)
+                .Select(sd => new { sd.Timestamp, sd.Value })
+                .ToListAsync(ct);
+
+            if (rawSamples.Count == 0)
+            {
+                _logger.LogDebug("BatteryHealthAnalyzer: no samples for sensor {SensorId}", sensor.Id);
+                return;
+            }
+
+            var samples = new List<BatteryHealthMath.VoltageSample>(rawSamples.Count);
+            foreach (var s in rawSamples)
+            {
+                if (float.TryParse(s.Value, System.Globalization.CultureInfo.InvariantCulture, out var v))
+                    samples.Add(new BatteryHealthMath.VoltageSample(s.Timestamp, v));
+            }
+            if (samples.Count == 0) return;
+
+            var restingMedian = BatteryHealthMath.ComputeRestingMedian(samples, now, RestingWindow);
+            var peakResting = BatteryHealthMath.ComputePeakResting(samples, now, PeakRestingRollingWindow, RestingWindow);
+
+            var currentVoltage = samples[^1].Value;
+            var onChargerNow = restingMedian > 0
+                && samples.TakeLast(3).All(s => s.Value >= restingMedian * 1.05f);
+
+            var voltageMin24h = samples
+                .Where(s => s.Timestamp >= now.AddHours(-24))
+                .Select(s => (float?)s.Value)
+                .DefaultIfEmpty(null)
+                .Min();
+
+            var slopeSamples = samples.Where(s => s.Timestamp >= now - SlopeWindow).ToList();
+            var slopePctWeek = BatteryHealthMath.ComputeSlopePercentPerWeek(slopeSamples);
+
+            var detected = BatteryHealthMath.DetectChargeEvents(samples, restingMedian);
+            await UpsertChargeEventsAsync(db, sensor.Id, detected, ct);
+
+            var recentEvents = detected.Where(e => e.EndedAt >= now - ChargeEventLookback).ToList();
+            var fullChargesLast30d = detected.Count(e => e.EndedAt >= now - FullChargeCountWindow);
+            var lastEvent = detected.OrderByDescending(e => e.EndedAt).FirstOrDefault();
+            float? acceptance = recentEvents.Count > 0 ? recentEvents.Max(e => e.PeakRatio) : null;
+
+            var daysOfData = (int)Math.Round((now - samples[0].Timestamp).TotalDays);
+            var dropPct = peakResting > 0 ? (peakResting - restingMedian) / peakResting * 100f : 0f;
+            var classification = BatteryHealthMath.ClassifyHealth(dropPct, slopePctWeek, acceptance, daysOfData);
+
+            db.BatteryHealthData.Add(new BatteryHealth
+            {
+                SensorId = sensor.Id,
+                Status = classification.Status,
+                // Legacy field mapping for cutover backwards-compat:
+                Baseline = peakResting,
+                LastCharge = lastEvent?.PeakVoltage ?? 0f,
+                DropPct = dropPct,
+                ChargesRecorded = fullChargesLast30d,
+                LastChargedAt = lastEvent?.EndedAt,
+                // New analyzer-computed fields:
+                CurrentVoltage = currentVoltage,
+                RestingMedian = restingMedian,
+                PeakResting = peakResting,
+                OnChargerNow = onChargerNow,
+                LastFullChargeAt = lastEvent?.EndedAt,
+                LastFullChargePeak = lastEvent?.PeakVoltage,
+                VoltageMin24h = voltageMin24h,
+                FullChargesLast30d = fullChargesLast30d,
+                DailyDropPctPerWeek = slopePctWeek,
+                ChargeAcceptanceRatio = acceptance,
+                Timestamp = now,
+            });
+
+            _logger.LogInformation(
+                "BatteryHealthAnalyzer: sensor {SensorId} status={Status} resting={Resting:F3} peakResting={PeakResting:F3} drop={Drop:F2}% slope={Slope:F3}%/wk onCharger={OnCharger} fullCharges30d={Count}",
+                sensor.Id, classification.Status, restingMedian, peakResting, dropPct, slopePctWeek, onChargerNow, fullChargesLast30d);
+        }
+
+        private static async Task UpsertChargeEventsAsync(
+            ApplicationDbContext db,
+            int sensorId,
+            IReadOnlyList<BatteryHealthMath.ChargeWindow> detected,
+            CancellationToken ct)
+        {
+            if (detected.Count == 0) return;
+            var startTimes = detected.Select(d => d.StartedAt).ToList();
+            var existing = await db.BatteryChargeEvents
+                .Where(e => e.SensorId == sensorId && startTimes.Contains(e.StartedAt))
+                .Select(e => e.StartedAt)
+                .ToListAsync(ct);
+            var existingSet = existing.ToHashSet();
+            foreach (var d in detected)
+            {
+                if (existingSet.Contains(d.StartedAt)) continue;
+                db.BatteryChargeEvents.Add(new BatteryChargeEvent
+                {
+                    SensorId = sensorId,
+                    StartedAt = d.StartedAt,
+                    EndedAt = d.EndedAt,
+                    PeakVoltage = d.PeakVoltage,
+                    RestingAtTime = d.RestingAtTime,
+                    PeakRatio = d.PeakRatio,
+                    DurationMinutes = d.DurationMinutes,
+                });
+            }
+        }
+    }
+}

--- a/Services/PostgresNotificationService.cs
+++ b/Services/PostgresNotificationService.cs
@@ -15,13 +15,15 @@ namespace garge_api.Services
         private readonly string _connectionString;
         private readonly CoalescingDispatcher _dispatcher;
         private readonly IDeviceOwnershipService _ownership;
+        private readonly BatteryHealthAnalyzerService _batteryAnalyzer;
 
         public PostgresNotificationService(
             IServiceScopeFactory scopeFactory,
             ILogger<PostgresNotificationService> logger,
             IConfiguration configuration,
             CoalescingDispatcher dispatcher,
-            IDeviceOwnershipService ownership)
+            IDeviceOwnershipService ownership,
+            BatteryHealthAnalyzerService batteryAnalyzer)
         {
             _scopeFactory = scopeFactory;
             _logger = logger;
@@ -29,6 +31,7 @@ namespace garge_api.Services
                                 ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
             _dispatcher = dispatcher;
             _ownership = ownership;
+            _batteryAnalyzer = batteryAnalyzer;
             _logger.LogWarning("PostgresNotificationService initialized");
         }
 
@@ -148,6 +151,18 @@ namespace garge_api.Services
             foreach (var userId in owners)
             {
                 _dispatcher.EnqueueSensorForUser(userId, evt);
+            }
+
+            // Voltage sensors get re-analyzed on every new reading. The
+            // analyzer self-filters by sensor type, so calling it for all
+            // sensors is cheap.
+            try
+            {
+                await _batteryAnalyzer.AnalyzeSensorAsync(sensorData.SensorId, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Battery health analyzer failed for sensor {SensorId}", sensorData.SensorId);
             }
         }
     }

--- a/garge-api.Tests/BatteryHealthMathTests.cs
+++ b/garge-api.Tests/BatteryHealthMathTests.cs
@@ -90,7 +90,7 @@ public class BatteryHealthMathTests
     [Fact]
     public void ClassifyHealth_InsufficientData_ReturnsLearning()
     {
-        var result = BatteryHealthMath.ClassifyHealth(0f, 0f, null, daysOfData: 5);
+        var result = BatteryHealthMath.ClassifyHealth(0f, 0f, null, daysOfData: 5, hasRecentCharge: false);
         Assert.Equal("learning", result.Status);
     }
 
@@ -101,7 +101,8 @@ public class BatteryHealthMathTests
             dropPctFromPeak: 1f,
             slopePctPerWeek: -0.05f,
             chargeAcceptanceRatio: 1.15f,
-            daysOfData: 30);
+            daysOfData: 30,
+            hasRecentCharge: true);
         Assert.Equal("good", result.Status);
     }
 
@@ -112,7 +113,8 @@ public class BatteryHealthMathTests
             dropPctFromPeak: 7f,    // > replace threshold
             slopePctPerWeek: 0f,
             chargeAcceptanceRatio: 1.15f,
-            daysOfData: 30);
+            daysOfData: 30,
+            hasRecentCharge: true);
         Assert.Equal("replace", result.Status);
     }
 
@@ -123,7 +125,8 @@ public class BatteryHealthMathTests
             dropPctFromPeak: 0f,
             slopePctPerWeek: -0.2f,   // attention range
             chargeAcceptanceRatio: 1.15f,
-            daysOfData: 30);
+            daysOfData: 30,
+            hasRecentCharge: true);
         Assert.Equal("attention", result.Status);
     }
 
@@ -131,11 +134,14 @@ public class BatteryHealthMathTests
     public void ClassifyHealth_NoChargeEvent_S3Skipped()
     {
         // No charge acceptance data — S3 must not push status above S1/S2 verdict.
+        // Charge events exist (hasRecentCharge true) but acceptance ratio is unset
+        // (e.g. only short charges that didn't qualify).
         var result = BatteryHealthMath.ClassifyHealth(
             dropPctFromPeak: 1f,
             slopePctPerWeek: -0.05f,
             chargeAcceptanceRatio: null,
-            daysOfData: 30);
+            daysOfData: 30,
+            hasRecentCharge: true);
         Assert.Equal("good", result.Status);
     }
 
@@ -146,8 +152,24 @@ public class BatteryHealthMathTests
             dropPctFromPeak: 1f,
             slopePctPerWeek: -0.05f,
             chargeAcceptanceRatio: 1.02f, // < replace threshold
-            daysOfData: 30);
+            daysOfData: 30,
+            hasRecentCharge: true);
         Assert.Equal("replace", result.Status);
+    }
+
+    [Fact]
+    public void ClassifyHealth_NoRecentCharge_ReturnsLearning()
+    {
+        // Without a charge event we cannot tell degradation from self-discharge.
+        // Even bad-looking drop + slope must not be flagged as replace.
+        var result = BatteryHealthMath.ClassifyHealth(
+            dropPctFromPeak: 7f,
+            slopePctPerWeek: -1f,
+            chargeAcceptanceRatio: null,
+            daysOfData: 30,
+            hasRecentCharge: false);
+        Assert.Equal("learning", result.Status);
+        Assert.Contains("charger", result.Reason);
     }
 
     [Fact]

--- a/garge-api.Tests/BatteryHealthMathTests.cs
+++ b/garge-api.Tests/BatteryHealthMathTests.cs
@@ -1,0 +1,170 @@
+using garge_api.Helpers;
+using Xunit;
+
+namespace garge_api.Tests;
+
+public class BatteryHealthMathTests
+{
+    private static List<BatteryHealthMath.VoltageSample> Trace(DateTime start, int hours, Func<int, float> voltageAtHour)
+    {
+        var samples = new List<BatteryHealthMath.VoltageSample>();
+        for (var h = 0; h < hours; h++)
+            samples.Add(new BatteryHealthMath.VoltageSample(start.AddHours(h), voltageAtHour(h)));
+        return samples;
+    }
+
+    [Fact]
+    public void ComputeRestingMedian_FlatVoltage_ReturnsFlatValue()
+    {
+        var now = DateTime.UtcNow;
+        var samples = Trace(now.AddDays(-14), 14 * 24, _ => 12.40f);
+        var resting = BatteryHealthMath.ComputeRestingMedian(samples, now, TimeSpan.FromDays(14));
+        Assert.InRange(resting, 12.39f, 12.41f);
+    }
+
+    [Fact]
+    public void ComputeRestingMedian_MixOfRestingAndCharging_PicksRestingValues()
+    {
+        var now = DateTime.UtcNow;
+        // 14 days: alternating 24h resting (12.40) / 24h charging (13.10)
+        var samples = Trace(now.AddDays(-14), 14 * 24, h => (h / 24) % 2 == 0 ? 12.40f : 13.10f);
+        var resting = BatteryHealthMath.ComputeRestingMedian(samples, now, TimeSpan.FromDays(14));
+        Assert.InRange(resting, 12.39f, 12.41f);
+    }
+
+    [Fact]
+    public void DetectChargeEvents_FloatCharger_DetectsExactlyOneEvent()
+    {
+        var now = DateTime.UtcNow;
+        var start = now.AddDays(-3);
+        // Resting at 12.40 for 12h, then float-charging steady at 13.05 for 60h
+        var samples = Trace(start, 72, h => h < 12 ? 12.40f : 13.05f);
+        var events = BatteryHealthMath.DetectChargeEvents(samples, restingMedian: 12.40f);
+        // Float never drops back below 1.02 * resting, so the window is still open at end of trace.
+        // Detector requires sustained drop to close — open windows aren't counted.
+        // So expect 0 closed events here; that's correct (charger still on).
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void DetectChargeEvents_RealChargeThenDisconnect_DetectsOne()
+    {
+        var now = DateTime.UtcNow;
+        var start = now.AddDays(-3);
+        // 12h resting (12.40), 24h charging (13.60 peak, well above 1.08x = 13.39),
+        // drop to 12.42 for 12h
+        var samples = Trace(start, 48, h => h switch
+        {
+            < 12 => 12.40f,
+            < 36 => 13.60f,
+            _ => 12.42f
+        });
+        var events = BatteryHealthMath.DetectChargeEvents(samples, restingMedian: 12.40f);
+        Assert.Single(events);
+        Assert.InRange(events[0].PeakRatio, 1.09f, 1.12f);
+    }
+
+    [Fact]
+    public void DetectChargeEvents_ShortNoiseSpike_Ignored()
+    {
+        var now = DateTime.UtcNow;
+        var start = now.AddDays(-2);
+        // Flat resting, single 1-hour blip above entry but below peak min
+        var samples = Trace(start, 48, h => h == 20 ? 13.00f : 12.40f);
+        var events = BatteryHealthMath.DetectChargeEvents(samples, restingMedian: 12.40f);
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void ComputeSlopePercentPerWeek_DecliningResting_NegativeSlope()
+    {
+        var now = DateTime.UtcNow;
+        // 30 days, resting declines from 12.60 to 12.40
+        var samples = Trace(now.AddDays(-30), 30 * 24, h => 12.60f - 0.20f * (h / (30f * 24f)));
+        var slope = BatteryHealthMath.ComputeSlopePercentPerWeek(samples);
+        Assert.True(slope < 0);
+        // 0.20V drop / 30d = ~0.046V/wk; as % of mean ~12.5 = ~0.37%/wk
+        Assert.InRange(slope, -0.5f, -0.3f);
+    }
+
+    [Fact]
+    public void ClassifyHealth_InsufficientData_ReturnsLearning()
+    {
+        var result = BatteryHealthMath.ClassifyHealth(0f, 0f, null, daysOfData: 5);
+        Assert.Equal("learning", result.Status);
+    }
+
+    [Fact]
+    public void ClassifyHealth_AllSignalsGood_ReturnsGood()
+    {
+        var result = BatteryHealthMath.ClassifyHealth(
+            dropPctFromPeak: 1f,
+            slopePctPerWeek: -0.05f,
+            chargeAcceptanceRatio: 1.15f,
+            daysOfData: 30);
+        Assert.Equal("good", result.Status);
+    }
+
+    [Fact]
+    public void ClassifyHealth_S1Replace_OverridesOthers()
+    {
+        var result = BatteryHealthMath.ClassifyHealth(
+            dropPctFromPeak: 7f,    // > replace threshold
+            slopePctPerWeek: 0f,
+            chargeAcceptanceRatio: 1.15f,
+            daysOfData: 30);
+        Assert.Equal("replace", result.Status);
+    }
+
+    [Fact]
+    public void ClassifyHealth_S2DeclineAttention_ReturnsAttention()
+    {
+        var result = BatteryHealthMath.ClassifyHealth(
+            dropPctFromPeak: 0f,
+            slopePctPerWeek: -0.2f,   // attention range
+            chargeAcceptanceRatio: 1.15f,
+            daysOfData: 30);
+        Assert.Equal("attention", result.Status);
+    }
+
+    [Fact]
+    public void ClassifyHealth_NoChargeEvent_S3Skipped()
+    {
+        // No charge acceptance data — S3 must not push status above S1/S2 verdict.
+        var result = BatteryHealthMath.ClassifyHealth(
+            dropPctFromPeak: 1f,
+            slopePctPerWeek: -0.05f,
+            chargeAcceptanceRatio: null,
+            daysOfData: 30);
+        Assert.Equal("good", result.Status);
+    }
+
+    [Fact]
+    public void ClassifyHealth_BadChargeAcceptance_ReturnsReplace()
+    {
+        var result = BatteryHealthMath.ClassifyHealth(
+            dropPctFromPeak: 1f,
+            slopePctPerWeek: -0.05f,
+            chargeAcceptanceRatio: 1.02f, // < replace threshold
+            daysOfData: 30);
+        Assert.Equal("replace", result.Status);
+    }
+
+    [Fact]
+    public void DetectChargeEvents_CalibrationDrift_StillDetects()
+    {
+        // Sensor reads 0.8V higher than reality. Resting "looks like" 13.20.
+        // Ratios still classify correctly because everything scales.
+        var now = DateTime.UtcNow;
+        var start = now.AddDays(-3);
+        var samples = Trace(start, 48, h => h switch
+        {
+            < 12 => 13.20f,
+            < 36 => 14.50f, // peak well above 1.08x = 14.256
+            _ => 13.22f
+        });
+        var events = BatteryHealthMath.DetectChargeEvents(samples, restingMedian: 13.20f);
+        Assert.Single(events);
+        Assert.InRange(events[0].PeakRatio, 1.09f, 1.12f);
+    }
+}


### PR DESCRIPTION
## Summary
- Move battery health detection from firmware NVS state machine to a server-side BackgroundService that analyzes the SensorData voltage stream.
- Per-sensor relative-ratio algorithm so cross-sensor calibration drift doesn't matter.
- Triggered event-driven from the existing Postgres LISTEN/NOTIFY pipeline on SensorData inserts; hourly fallback sweep for missed events.
- Three combined classification signals (drop from peak resting / decline slope / charge acceptance ratio). Status 'learning' now means <14 days of data rather than firmware NVS state.
- New BatteryChargeEvent table tracks detected events. New endpoints for events + calibration offset.
- Old POST endpoint kept as no-op for backwards compat during cutover; firmware publish will be stripped in a later phase 3 PR.
- 13 new unit tests cover float-charger float, real charges, drift, all classification branches.
- Frontend updates land in a separate PR once this deploys.