### PR TITLE
refactor(battery): remove deprecated POST /api/battery-health/name endpoint

### DIFF
--- a/Controllers/BatteryHealthController.cs
+++ b/Controllers/BatteryHealthController.cs
@@ -43,23 +43,6 @@ namespace garge_api.Controllers
         }
 
         /// <summary>
-        /// Deprecated no-op kept until firmware (liz-sensors#131) stops posting
-        /// battery health. Body is intentionally untyped so we don't need to
-        /// hold a DTO shape just to accept and discard the payload. Removed
-        /// once phase 3 firmware ships.
-        /// </summary>
-        [HttpPost("name/{sensorName}")]
-        [SwaggerOperation(Summary = "Deprecated. Battery health is now computed server-side; payload ignored.", Tags = new[] { "Deprecated" })]
-        [SwaggerResponse(200, "Acknowledged. No record written; analyzer runs from voltage stream.")]
-        [Obsolete("Battery health is computed server-side by BatteryHealthAnalyzerService. Remove after firmware no longer posts (liz-sensors#131).")]
-        public IActionResult CreateBatteryHealth(string sensorName)
-        {
-            _logger.LogInformation("CreateBatteryHealth (deprecated) called for {SensorName}; ignoring payload — analyzer drives health from voltage.",
-                LogSanitizer.Sanitize(sensorName));
-            return Ok(new { message = "Battery health is computed server-side. This endpoint is a no-op." });
-        }
-
-        /// <summary>
         /// Returns the latest battery health record for the voltage sensor identified by name.
         /// </summary>
         [HttpGet("name/{sensorName}/latest")]


### PR DESCRIPTION
## Summary
- Server-side analyzer has been authoritative since phase 1 (#209); the POST endpoint was kept as a 200-OK no-op during cutover.
- Firmware stops posting after liz-sensors#132. Operator MQTT bridge to this endpoint is removed in garge-operator#116.
- This PR deletes the endpoint entirely. `GET /latest`, `GET /events`, `POST/DELETE /calibration` retained.

**⚠ Merge order:** merge this LAST, after liz-sensors#132 has been deployed to all 21 sensors AND garge-operator#116 is merged + deployed. Otherwise firmware/operator will hit 404 on every voltage cycle. Verify zero `POST /api/battery-health` calls in API logs for 1-2 weeks before merging.