### PR TITLE
fix(battery): anchor S2 slope to post-charge resting (per-cycle)

### DIFF
--- a/Dtos/Sensor/BatteryHealthDto.cs
+++ b/Dtos/Sensor/BatteryHealthDto.cs
@@ -14,7 +14,7 @@ namespace garge_api.Dtos.Sensor
         public float? LastFullChargePeak { get; set; }
         public float? VoltageMin24h { get; set; }
         public int FullChargesLast30d { get; set; }
-        public float DailyDropPctPerWeek { get; set; }
+        public float? DailyDropPctPerWeek { get; set; }
         public float? ChargeAcceptanceRatio { get; set; }
 
         // Sensor-level calibration offset (volts). Frontend may add this to

--- a/Helpers/BatteryHealthMath.cs
+++ b/Helpers/BatteryHealthMath.cs
@@ -141,6 +141,55 @@ namespace garge_api.Helpers
         }
 
         /// <summary>
+        /// Median resting voltage in a settle window after a charge event
+        /// ended. Used to anchor per-cycle slope at a comparable state-of-
+        /// charge — post-charge surface charge has decayed and the battery
+        /// is back at its "fully topped up" rested voltage.
+        ///
+        /// Returns null if the window contains fewer than
+        /// <paramref name="minSamples"/> samples (next charge started before
+        /// settle completed, or the sensor lost connectivity).
+        /// </summary>
+        public static float? PostChargeResting(
+            IReadOnlyList<VoltageSample> samples,
+            DateTime chargeEndedAt,
+            TimeSpan settleStart,
+            TimeSpan settleEnd,
+            int minSamples = 3)
+        {
+            var windowStart = chargeEndedAt + settleStart;
+            var windowEnd = chargeEndedAt + settleEnd;
+            var values = samples
+                .Where(s => s.Timestamp >= windowStart && s.Timestamp <= windowEnd)
+                .Select(s => s.Value)
+                .OrderBy(v => v)
+                .ToList();
+            if (values.Count < minSamples) return null;
+            return Median(values);
+        }
+
+        /// <summary>
+        /// Cycle-anchored slope: linear least-squares fit across post-charge
+        /// resting samples (one anchor per detected full-charge event). This
+        /// is the only voltage statistic that physically reflects capacity
+        /// loss — every anchor is taken at the same state-of-charge
+        /// (just-after-full-charge), so anchor-to-anchor drift is degradation,
+        /// not SOC variation.
+        ///
+        /// Returns null if fewer than <paramref name="minAnchors"/> events
+        /// produced a settled post-charge measurement: without enough cycles
+        /// we cannot distinguish a one-off event from real degradation, so
+        /// the signal stays silent.
+        /// </summary>
+        public static float? ComputeCycleSlopePercentPerWeek(
+            IReadOnlyList<VoltageSample> anchors,
+            int minAnchors)
+        {
+            if (anchors.Count < minAnchors) return null;
+            return ComputeSlopePercentPerWeek(anchors);
+        }
+
+        /// <summary>
         /// Linear least-squares slope of values over time, expressed as
         /// percent change per week of the values' mean. Positive = rising.
         /// </summary>
@@ -173,7 +222,7 @@ namespace garge_api.Helpers
         /// </summary>
         public static HealthClassification ClassifyHealth(
             float dropPctFromPeak,
-            float slopePctPerWeek,
+            float? cycleSlopePctPerWeek,
             float? chargeAcceptanceRatio,
             int daysOfData,
             bool hasRecentCharge)
@@ -196,14 +245,20 @@ namespace garge_api.Helpers
                 _ => 2
             };
 
-            // S2 (slope is decline if negative; we compare magnitude of decline)
-            var declinePctWeek = slopePctPerWeek < 0 ? -slopePctPerWeek : 0;
-            var s2 = declinePctWeek switch
+            // S2 — null means we don't have enough cycle anchors to compute a
+            // meaningful trend; signal stays silent rather than penalize.
+            var s2 = 0;
+            var declinePctWeek = 0f;
+            if (cycleSlopePctPerWeek.HasValue)
             {
-                var d when d <= S2AttentionSlopePctWeek => 0,
-                var d when d <= S2ReplaceSlopePctWeek => 1,
-                _ => 2
-            };
+                declinePctWeek = cycleSlopePctPerWeek.Value < 0 ? -cycleSlopePctPerWeek.Value : 0;
+                s2 = declinePctWeek switch
+                {
+                    var d when d <= S2AttentionSlopePctWeek => 0,
+                    var d when d <= S2ReplaceSlopePctWeek => 1,
+                    _ => 2
+                };
+            }
 
             // S3 (only if we have a charge event)
             var s3 = 0;

--- a/Migrations/20260517161858_MakeDailyDropPctNullable.Designer.cs
+++ b/Migrations/20260517161858_MakeDailyDropPctNullable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260517161858_MakeDailyDropPctNullable")]
+    partial class MakeDailyDropPctNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260517161858_MakeDailyDropPctNullable.cs
+++ b/Migrations/20260517161858_MakeDailyDropPctNullable.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeDailyDropPctNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<float>(
+                name: "DailyDropPctPerWeek",
+                table: "BatteryHealthData",
+                type: "real",
+                nullable: true,
+                oldClrType: typeof(float),
+                oldType: "real");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<float>(
+                name: "DailyDropPctPerWeek",
+                table: "BatteryHealthData",
+                type: "real",
+                nullable: false,
+                defaultValue: 0f,
+                oldClrType: typeof(float),
+                oldType: "real",
+                oldNullable: true);
+        }
+    }
+}

--- a/Models/Sensor/BatteryHealth.cs
+++ b/Models/Sensor/BatteryHealth.cs
@@ -32,7 +32,9 @@ namespace garge_api.Models.Sensor
         public float? LastFullChargePeak { get; set; }
         public float? VoltageMin24h { get; set; }
         public int FullChargesLast30d { get; set; }
-        public float DailyDropPctPerWeek { get; set; }
+        // Cycle-anchored slope (% per week of mean). Null when fewer than the
+        // minimum number of post-charge resting anchors have been collected.
+        public float? DailyDropPctPerWeek { get; set; }
         public float? ChargeAcceptanceRatio { get; set; }
 
         [Required]

--- a/Services/BatteryHealthAnalyzerService.cs
+++ b/Services/BatteryHealthAnalyzerService.cs
@@ -37,9 +37,18 @@ namespace garge_api.Services
         // recent-only stat to avoid false alarms.
         private static readonly TimeSpan CurrentRestingWindow = TimeSpan.FromDays(3);
         private static readonly TimeSpan PeakRestingRollingWindow = TimeSpan.FromDays(90);
-        private static readonly TimeSpan SlopeWindow = TimeSpan.FromDays(30);
         private static readonly TimeSpan ChargeEventLookback = TimeSpan.FromDays(90);
         private static readonly TimeSpan FullChargeCountWindow = TimeSpan.FromDays(30);
+
+        // Post-charge settle window: skip 12h of surface-charge decay, then
+        // take the median resting voltage between 12h and 36h after the
+        // charge event ended. This is the canonical "same SOC" anchor for
+        // cycle-over-cycle capacity tracking.
+        private static readonly TimeSpan PostChargeSettleStart = TimeSpan.FromHours(12);
+        private static readonly TimeSpan PostChargeSettleEnd = TimeSpan.FromHours(36);
+        // Minimum cycle anchors before S2 slope is meaningful — below this,
+        // we cannot tell a one-off event from a real declining trend.
+        private const int S2MinAnchors = 3;
 
         // OnChargerNow threshold: voltage above the sensor's 90d best rested
         // state. Per-sensor ratio so calibration drift between sensors is fine.
@@ -168,20 +177,31 @@ namespace garge_api.Services
                 .DefaultIfEmpty(null)
                 .Min();
 
-            // Fit slope to daily resting-voltage checkpoints (same bottom-25% median
-            // stat used for "Drop from peak") so both metrics describe the same
-            // underlying signal: trend of resting voltage. Using raw mean here
-            // would skew the slope whenever the window contains charging spikes.
-            var slopeCheckpoints = new List<BatteryHealthMath.VoltageSample>();
-            for (var t = now - SlopeWindow; t <= now; t = t.AddDays(1))
-            {
-                var r = BatteryHealthMath.ComputeRestingMedian(samples, t, RestingWindow);
-                if (r > 0) slopeCheckpoints.Add(new BatteryHealthMath.VoltageSample(t, r));
-            }
-            var slopePctWeek = BatteryHealthMath.ComputeSlopePercentPerWeek(slopeCheckpoints);
-
             var detected = BatteryHealthMath.DetectChargeEvents(samples, restingMedian);
             await UpsertChargeEventsAsync(db, sensor.Id, detected, ct);
+
+            // Cycle-anchored slope: one anchor per detected charge event,
+            // taken from the post-charge settle window. Each anchor is a
+            // same-SOC measurement, so anchor-to-anchor drift reflects
+            // capacity loss rather than state-of-charge variation. A
+            // calendar-time slope of raw bottom-25 medians (the prior
+            // approach) could not distinguish a transient deep-discharge
+            // event from real degradation — both showed as a negative slope.
+            var anchors = detected
+                .Select(e => new
+                {
+                    e.EndedAt,
+                    Resting = BatteryHealthMath.PostChargeResting(
+                        samples,
+                        e.EndedAt,
+                        PostChargeSettleStart,
+                        PostChargeSettleEnd)
+                })
+                .Where(a => a.Resting.HasValue)
+                .OrderBy(a => a.EndedAt)
+                .Select(a => new BatteryHealthMath.VoltageSample(a.EndedAt, a.Resting!.Value))
+                .ToList();
+            var cycleSlopePctWeek = BatteryHealthMath.ComputeCycleSlopePercentPerWeek(anchors, S2MinAnchors);
 
             var recentEvents = detected.Where(e => e.EndedAt >= now - ChargeEventLookback).ToList();
             var fullChargesLast30d = detected.Count(e => e.EndedAt >= now - FullChargeCountWindow);
@@ -197,7 +217,7 @@ namespace garge_api.Services
                 ? Math.Max(0f, (peakResting - currentResting) / peakResting * 100f)
                 : 0f;
             var hasRecentCharge = recentEvents.Count > 0;
-            var classification = BatteryHealthMath.ClassifyHealth(dropPct, slopePctWeek, acceptance, daysOfData, hasRecentCharge);
+            var classification = BatteryHealthMath.ClassifyHealth(dropPct, cycleSlopePctWeek, acceptance, daysOfData, hasRecentCharge);
 
             db.BatteryHealthData.Add(new BatteryHealth
             {
@@ -214,14 +234,16 @@ namespace garge_api.Services
                 LastFullChargePeak = lastEvent?.PeakVoltage,
                 VoltageMin24h = voltageMin24h,
                 FullChargesLast30d = fullChargesLast30d,
-                DailyDropPctPerWeek = slopePctWeek,
+                DailyDropPctPerWeek = cycleSlopePctWeek,
                 ChargeAcceptanceRatio = acceptance,
                 Timestamp = now,
             });
 
             _logger.LogInformation(
-                "BatteryHealthAnalyzer: sensor {SensorId} status={Status} currentResting={CurrentResting:F3} restingMedian14d={Resting:F3} peakResting={PeakResting:F3} drop={Drop:F2}% slope={Slope:F3}%/wk onCharger={OnCharger} fullCharges30d={Count}",
-                sensor.Id, classification.Status, currentResting, restingMedian, peakResting, dropPct, slopePctWeek, onChargerNow, fullChargesLast30d);
+                "BatteryHealthAnalyzer: sensor {SensorId} status={Status} currentResting={CurrentResting:F3} restingMedian14d={Resting:F3} peakResting={PeakResting:F3} drop={Drop:F2}% cycleSlope={Slope} anchors={Anchors}/{MinAnchors} onCharger={OnCharger} fullCharges30d={Count}",
+                sensor.Id, classification.Status, currentResting, restingMedian, peakResting, dropPct,
+                cycleSlopePctWeek.HasValue ? $"{cycleSlopePctWeek.Value:F3}%/wk" : "null",
+                anchors.Count, S2MinAnchors, onChargerNow, fullChargesLast30d);
         }
 
         private static async Task UpsertChargeEventsAsync(

--- a/garge-api.Tests/BatteryHealthMathTests.cs
+++ b/garge-api.Tests/BatteryHealthMathTests.cs
@@ -90,7 +90,7 @@ public class BatteryHealthMathTests
     [Fact]
     public void ClassifyHealth_InsufficientData_ReturnsLearning()
     {
-        var result = BatteryHealthMath.ClassifyHealth(0f, 0f, null, daysOfData: 5, hasRecentCharge: false);
+        var result = BatteryHealthMath.ClassifyHealth(0f, (float?)null, null, daysOfData: 5, hasRecentCharge: false);
         Assert.Equal("learning", result.Status);
     }
 
@@ -99,7 +99,7 @@ public class BatteryHealthMathTests
     {
         var result = BatteryHealthMath.ClassifyHealth(
             dropPctFromPeak: 1f,
-            slopePctPerWeek: -0.05f,
+            cycleSlopePctPerWeek: -0.05f,
             chargeAcceptanceRatio: 1.15f,
             daysOfData: 30,
             hasRecentCharge: true);
@@ -111,7 +111,7 @@ public class BatteryHealthMathTests
     {
         var result = BatteryHealthMath.ClassifyHealth(
             dropPctFromPeak: 7f,    // > replace threshold
-            slopePctPerWeek: 0f,
+            cycleSlopePctPerWeek: 0f,
             chargeAcceptanceRatio: 1.15f,
             daysOfData: 30,
             hasRecentCharge: true);
@@ -123,7 +123,7 @@ public class BatteryHealthMathTests
     {
         var result = BatteryHealthMath.ClassifyHealth(
             dropPctFromPeak: 0f,
-            slopePctPerWeek: -0.2f,   // attention range
+            cycleSlopePctPerWeek: -0.2f,   // attention range
             chargeAcceptanceRatio: 1.15f,
             daysOfData: 30,
             hasRecentCharge: true);
@@ -138,7 +138,7 @@ public class BatteryHealthMathTests
         // (e.g. only short charges that didn't qualify).
         var result = BatteryHealthMath.ClassifyHealth(
             dropPctFromPeak: 1f,
-            slopePctPerWeek: -0.05f,
+            cycleSlopePctPerWeek: -0.05f,
             chargeAcceptanceRatio: null,
             daysOfData: 30,
             hasRecentCharge: true);
@@ -150,7 +150,7 @@ public class BatteryHealthMathTests
     {
         var result = BatteryHealthMath.ClassifyHealth(
             dropPctFromPeak: 1f,
-            slopePctPerWeek: -0.05f,
+            cycleSlopePctPerWeek: -0.05f,
             chargeAcceptanceRatio: 1.02f, // < replace threshold
             daysOfData: 30,
             hasRecentCharge: true);
@@ -164,12 +164,92 @@ public class BatteryHealthMathTests
         // Even bad-looking drop + slope must not be flagged as replace.
         var result = BatteryHealthMath.ClassifyHealth(
             dropPctFromPeak: 7f,
-            slopePctPerWeek: -1f,
+            cycleSlopePctPerWeek: -1f,
             chargeAcceptanceRatio: null,
             daysOfData: 30,
             hasRecentCharge: false);
         Assert.Equal("learning", result.Status);
         Assert.Contains("charger", result.Reason);
+    }
+
+    [Fact]
+    public void ClassifyHealth_NullSlope_S2Skipped()
+    {
+        // Cycle slope null = insufficient anchors. Even a normally-bad slope
+        // value (passed via the other tests) must not pin status when null.
+        var result = BatteryHealthMath.ClassifyHealth(
+            dropPctFromPeak: 0f,
+            cycleSlopePctPerWeek: null,
+            chargeAcceptanceRatio: 1.15f,
+            daysOfData: 30,
+            hasRecentCharge: true);
+        Assert.Equal("good", result.Status);
+    }
+
+    [Fact]
+    public void PostChargeResting_Settled_ReturnsMedian()
+    {
+        var start = DateTime.UtcNow.AddDays(-2);
+        // Charge ended at t=0 of this trace. Sample voltage hourly 0..48h.
+        // Surface charge decays 0-12h, then stable at 12.7V from 12-48h.
+        var samples = Trace(start, 48, h => h < 12 ? 13.2f : 12.70f);
+        var resting = BatteryHealthMath.PostChargeResting(
+            samples,
+            chargeEndedAt: start,
+            settleStart: TimeSpan.FromHours(12),
+            settleEnd: TimeSpan.FromHours(36));
+        Assert.NotNull(resting);
+        Assert.InRange(resting!.Value, 12.69f, 12.71f);
+    }
+
+    [Fact]
+    public void PostChargeResting_NotEnoughSamples_ReturnsNull()
+    {
+        // Only one sample inside the 12-36h window.
+        var start = DateTime.UtcNow.AddDays(-2);
+        var samples = new List<BatteryHealthMath.VoltageSample>
+        {
+            new(start.AddHours(20), 12.70f),
+        };
+        var resting = BatteryHealthMath.PostChargeResting(
+            samples,
+            chargeEndedAt: start,
+            settleStart: TimeSpan.FromHours(12),
+            settleEnd: TimeSpan.FromHours(36),
+            minSamples: 3);
+        Assert.Null(resting);
+    }
+
+    [Fact]
+    public void ComputeCycleSlopePercentPerWeek_BelowMinAnchors_ReturnsNull()
+    {
+        var now = DateTime.UtcNow;
+        var anchors = new List<BatteryHealthMath.VoltageSample>
+        {
+            new(now.AddDays(-30), 12.70f),
+            new(now.AddDays(-15), 12.68f),
+        };
+        var slope = BatteryHealthMath.ComputeCycleSlopePercentPerWeek(anchors, minAnchors: 3);
+        Assert.Null(slope);
+    }
+
+    [Fact]
+    public void ComputeCycleSlopePercentPerWeek_DecliningAnchors_NegativeSlope()
+    {
+        // 5 post-charge anchors 7 days apart, each 0.05V lower than the
+        // previous. Real degradation pattern; slope should be clearly < 0.
+        var now = DateTime.UtcNow;
+        var anchors = new List<BatteryHealthMath.VoltageSample>
+        {
+            new(now.AddDays(-28), 12.80f),
+            new(now.AddDays(-21), 12.75f),
+            new(now.AddDays(-14), 12.70f),
+            new(now.AddDays(-7),  12.65f),
+            new(now,              12.60f),
+        };
+        var slope = BatteryHealthMath.ComputeCycleSlopePercentPerWeek(anchors, minAnchors: 3);
+        Assert.NotNull(slope);
+        Assert.True(slope!.Value < -0.1f, $"expected negative slope, got {slope}");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

The previous S2 signal fit a line through "bottom-25 voltage median over 30 days". That stat varies for two reasons that look identical to a linear fit: state-of-charge changes (deep discharge then recovery) and true capacity loss (each charge cycle ends a touch lower). No window-size tuning or threshold change can separate them — they live in the same input data.

### Real prod failure — sensor 10

Deep discharge May 9, charger reapplied, fully recovered to 12.73 V by May 17. Analyzer fit saw -2.5%/wk decline → Status=replace despite no actual capacity loss.

### Fix — redefine S2 to match the physics

For each detected full-charge event, sample resting voltage 12-36 hours after `EndedAt` (post-surface-charge settle window). Use those per-cycle anchors as the slope inputs. Every anchor is taken at the same SOC (just-after-full-charge), so anchor-to-anchor drift reflects capacity loss only.

If fewer than 3 anchors exist in the lookback, S2 returns null and contributes 0 to status (same behavior as S3 with no charge event). Sparse-cycling sensors stay silent rather than emit unreliable signals; S1 (drop from peak) still active.

### Sensor 10 expected outcome

1 charge event in 90d → 1 anchor → < 3 → `DailyDropPctPerWeek=null` → S2 silent → Status drops to `good`.

### Changes

- `BatteryHealthMath.PostChargeResting` — median resting in a settle window after a charge event ended.
- `BatteryHealthMath.ComputeCycleSlopePercentPerWeek` — slope across cycle anchors; null below minAnchors.
- `ClassifyHealth(... float? cycleSlopePctPerWeek ...)` — null means signal silent.
- `BatteryHealth.DailyDropPctPerWeek` and DTO become `float?` with EF migration `MakeDailyDropPctNullable`.
- 5 new tests cover the new helpers + null-slope status path.

Pairs with garge-app frontend update.