### PR TITLE
chore: add workflow to backtick package names in dependabot PR titles

### DIFF
--- a/.github/workflows/dependabot-title.yml
+++ b/.github/workflows/dependabot-title.yml
@@ -4,13 +4,14 @@ on:
   pull_request_target:
     types: [opened, reopened]
 
-permissions:
-  pull-requests: write
+permissions: {}
 
 jobs:
   rewrite:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Add backticks around package name
         env:

--- a/.github/workflows/dependabot-title.yml
+++ b/.github/workflows/dependabot-title.yml
@@ -1,0 +1,31 @@
+name: 📝 Format Dependabot PR titles
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  rewrite:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add backticks around package name
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: ${{ github.event.pull_request.title }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [[ "$TITLE" == *'`'* ]]; then
+            echo "Already formatted, skipping"
+            exit 0
+          fi
+          new_title=$(printf '%s' "$TITLE" | sed -E 's/^(deps: bump )([^ ]+)( from .+)$/\1`\2`\3/')
+          if [[ "$new_title" == "$TITLE" ]]; then
+            echo "Title pattern did not match, skipping"
+            exit 0
+          fi
+          gh pr edit "$NUMBER" --title "$new_title" --repo "$REPO"


### PR DESCRIPTION
## Summary
- Mirror of the same change in garge-app.
- Add `.github/workflows/dependabot-title.yml` that triggers on dependabot PR open/reopen and rewrites the title from `deps: bump <pkg> from X to Y` to `deps: bump `<pkg>` from X to Y`.
- Uses `pull_request_target` so it runs with write access against the base repo. Skips titles that already contain a backtick or do not match the expected pattern.