### PR TITLE
chore: rerun dependabot-title workflow on edit and synchronize

### DIFF
--- a/.github/workflows/dependabot-title.yml
+++ b/.github/workflows/dependabot-title.yml
@@ -2,7 +2,7 @@ name: 📝 Format Dependabot PR titles
 
 on:
   pull_request_target:
-    types: [opened, reopened]
+    types: [opened, reopened, edited, synchronize]
 
 permissions: {}
 


### PR DESCRIPTION
## Summary
- Mirror of the same change in garge-app.
- Add `edited` and `synchronize` to the `pull_request_target` types so the title-rewriter also runs when dependabot rebases a PR.
- The workflow already exits early when the title contains a backtick, so extra runs short-circuit cheaply.