### PR TITLE
fix: lower password minimum length to 8

### DIFF
--- a/Dtos/Auth/RegisterUserDto.cs
+++ b/Dtos/Auth/RegisterUserDto.cs
@@ -14,7 +14,7 @@ namespace garge_api.Dtos.Auth
         public required string Email { get; set; }
 
         [Required]
-        [StringLength(128, MinimumLength = 10)]
+        [StringLength(128, MinimumLength = 8)]
         public required string Password { get; set; }
 
         [Required]

--- a/Dtos/Auth/ResetPasswordDto.cs
+++ b/Dtos/Auth/ResetPasswordDto.cs
@@ -14,7 +14,7 @@ namespace garge_api.Dtos.Auth
         public required string Code { get; set; }
 
         [Required]
-        [StringLength(128, MinimumLength = 10)]
+        [StringLength(128, MinimumLength = 8)]
         public required string NewPassword { get; set; }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -72,7 +72,7 @@ namespace garge_api
                     options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(30);
                     options.Lockout.AllowedForNewUsers = true;
 
-                    options.Password.RequiredLength = 10;
+                    options.Password.RequiredLength = 8;
                     options.Password.RequireDigit = true;
                     options.Password.RequireLowercase = true;
                     options.Password.RequireUppercase = true;


### PR DESCRIPTION
## Summary
- Drop password `MinimumLength` from 10 to 8 in `RegisterUserDto` and `ResetPasswordDto`.
- Drop `options.Password.RequiredLength` from 10 to 8 in Identity setup.
- Matches the frontend Zod schema (already 8). The 10-char minimum silently rejected 8-9 char passwords that passed client validation, producing a confusing "Failed to register" error.
- Existing accounts are unaffected — the minimum only applies to new registrations and password resets.