### PR TITLE
fix: return JSON body when ActiveSubscriptionRequirement forbids a request

### DIFF
--- a/Authorization/JsonForbidResultHandler.cs
+++ b/Authorization/JsonForbidResultHandler.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Policy;
+
+namespace garge_api.Authorization
+{
+    public class JsonForbidResultHandler : IAuthorizationMiddlewareResultHandler
+    {
+        private readonly AuthorizationMiddlewareResultHandler _default = new();
+
+        public async Task HandleAsync(
+            RequestDelegate next,
+            HttpContext context,
+            AuthorizationPolicy policy,
+            PolicyAuthorizationResult authorizeResult)
+        {
+            if (authorizeResult.Forbidden
+                && authorizeResult.AuthorizationFailure?.FailedRequirements
+                    .Any(r => r is ActiveSubscriptionRequirement) == true)
+            {
+                context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                await context.Response.WriteAsJsonAsync(new
+                {
+                    message = "You need an active subscription to claim more sensors or switches. Your existing devices keep working. See Shop for plans."
+                });
+                return;
+            }
+
+            await _default.HandleAsync(next, context, policy, authorizeResult);
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -174,6 +174,7 @@ namespace garge_api
                     policy.AddRequirements(new ActiveSubscriptionRequirement()));
             });
             builder.Services.AddSingleton<IAuthorizationHandler, ActiveSubscriptionHandler>();
+            builder.Services.AddSingleton<IAuthorizationMiddlewareResultHandler, JsonForbidResultHandler>();
             builder.Services.Configure<AppOptions>(builder.Configuration.GetSection("App"));
             builder.Services.Configure<VippsOptions>(builder.Configuration.GetSection("Vipps"));
             builder.Services.AddDataProtection()


### PR DESCRIPTION
## Summary
- New `Authorization/JsonForbidResultHandler.cs` implementing `IAuthorizationMiddlewareResultHandler`. Wraps the default handler; when `ActiveSubscriptionRequirement` is in the failed requirements, writes `{ message: "..." }` with status 403 instead of an empty body. Everything else flows through the default handler unchanged.
- Register the handler as a singleton next to `ActiveSubscriptionHandler` in `Program.cs`.
- 275 existing tests pass; no controllers change.