### PR TITLE
fix: rewrite ActiveSubscriptionRequirement around Primary + AddOn capacity

### DIFF
--- a/Authorization/ActiveSubscriptionHandler.cs
+++ b/Authorization/ActiveSubscriptionHandler.cs
@@ -9,6 +9,21 @@ using System.Security.Claims;
 
 namespace garge_api.Authorization
 {
+    /// <summary>
+    /// Allows a claim when the user has room for one more owned sensor under their current subscriptions.
+    ///
+    /// Capacity model:
+    ///   - An active Primary subscription grants a base allowance of 1 owned sensor.
+    ///   - Each active AddOn subscription contributes its Quantity to the allowance.
+    ///   - Without an active Primary, capacity is 0 — AddOns alone are not enough.
+    ///
+    /// A claim is allowed when ownedSensorCount &lt; capacity. Shared access (UserSensor.IsOwner = false)
+    /// is not counted toward ownedSensorCount, so the owner's subscription covers shared viewers.
+    ///
+    /// This handler only runs on the few endpoints that take new ownership (sensor/switch claim). Reads,
+    /// unclaim, profile, and account deletion are gated by [Authorize] alone so a user who drops out of
+    /// quota can still see their account and unclaim sensors to recover.
+    /// </summary>
     public class ActiveSubscriptionHandler : AuthorizationHandler<ActiveSubscriptionRequirement>
     {
         private readonly IServiceScopeFactory _scopeFactory;
@@ -47,19 +62,21 @@ namespace garge_api.Authorization
 
             var ownedSensorCount = await db.UserSensors.CountAsync(us => us.UserId == userId && us.IsOwner);
 
-            // Pure viewer (no owned sensors) — shared access only, allow through
-            if (ownedSensorCount == 0)
-            {
-                context.Succeed(requirement);
-                return;
-            }
+            var activeSubs = await db.Subscriptions
+                .Where(s => s.UserId == userId
+                         && s.Status == SubscriptionStatus.Active
+                         && (!s.IsTest || isTestMode))
+                .Select(s => new { Type = s.Product!.Type, s.Quantity })
+                .ToListAsync();
 
-            var subscriptionCount = await db.Subscriptions.CountAsync(s =>
-                s.UserId == userId &&
-                s.Status == SubscriptionStatus.Active &&
-                (!s.IsTest || isTestMode));
+            var primaryActive = activeSubs.Any(s => s.Type == ProductType.Primary);
+            var addOnCapacity = activeSubs
+                .Where(s => s.Type == ProductType.AddOn)
+                .Sum(s => s.Quantity);
 
-            if (subscriptionCount >= ownedSensorCount)
+            var capacity = primaryActive ? 1 + addOnCapacity : 0;
+
+            if (ownedSensorCount < capacity)
                 context.Succeed(requirement);
         }
     }

--- a/Controllers/AutomationController.cs
+++ b/Controllers/AutomationController.cs
@@ -14,7 +14,6 @@ namespace garge_api.Controllers
     [Route("api/automation")]
     [EnableCors("AllowAllOrigins")]
     [Authorize]
-    [Authorize(Policy = "ActiveSubscription")]
     public class AutomationController : ControllerBase
     {
         private readonly ApplicationDbContext _context;

--- a/Controllers/BatteryHealthController.cs
+++ b/Controllers/BatteryHealthController.cs
@@ -17,7 +17,6 @@ namespace garge_api.Controllers
     [Route("api/battery-health")]
     [EnableCors("AllowAllOrigins")]
     [Authorize]
-    [Authorize(Policy = "ActiveSubscription")]
     public class BatteryHealthController : ControllerBase
     {
         private readonly ApplicationDbContext _context;

--- a/Controllers/ElectricityController.cs
+++ b/Controllers/ElectricityController.cs
@@ -17,7 +17,6 @@ namespace garge_api.Controllers
     [Route("api/electricity")]
     [EnableCors("AllowAllOrigins")]
     [Authorize]
-    [Authorize(Policy = "ActiveSubscription")]
     public class ElectricityController : ControllerBase
     {
         private readonly NordPoolService _nordPoolService;

--- a/Controllers/GroupsController.cs
+++ b/Controllers/GroupsController.cs
@@ -14,7 +14,6 @@ namespace garge_api.Controllers
     [Route("api/groups")]
     [EnableCors("AllowAllOrigins")]
     [Authorize]
-    [Authorize(Policy = "ActiveSubscription")]
     public class GroupsController : ControllerBase
     {
         private readonly ApplicationDbContext _context;

--- a/Controllers/MqttController.cs
+++ b/Controllers/MqttController.cs
@@ -17,7 +17,6 @@ namespace garge_api.Controllers
     [Route("api/mqtt")]
     [EnableCors("AllowAllOrigins")]
     [Authorize]
-    [Authorize(Policy = "ActiveSubscription")]
     public class MqttController : ControllerBase
     {
         private readonly ApplicationDbContext _context;

--- a/Controllers/PushSubscriptionController.cs
+++ b/Controllers/PushSubscriptionController.cs
@@ -16,7 +16,7 @@ namespace garge_api.Controllers
     [ApiController]
     [Route("api/push-subscriptions")]
     [EnableCors("AllowAllOrigins")]
-    [Authorize(Policy = "ActiveSubscription")]
+    [Authorize]
     public class PushSubscriptionController(
         ApplicationDbContext db,
         IConfiguration configuration,

--- a/Controllers/SensorActivitiesController.cs
+++ b/Controllers/SensorActivitiesController.cs
@@ -15,7 +15,6 @@ namespace garge_api.Controllers
     [Route("api/sensors/{sensorId}/activities")]
     [EnableCors("AllowAllOrigins")]
     [Authorize]
-    [Authorize(Policy = "ActiveSubscription")]
     public class SensorActivitiesController : ControllerBase
     {
         private readonly ApplicationDbContext _context;

--- a/Controllers/SensorController.cs
+++ b/Controllers/SensorController.cs
@@ -23,7 +23,6 @@ namespace garge_api.Controllers
     [Route("api/sensors")]
     [EnableCors("AllowAllOrigins")]
     [Authorize]
-    [Authorize(Policy = "ActiveSubscription")]
     public class SensorController : ControllerBase
     {
         private readonly ApplicationDbContext _context;
@@ -527,7 +526,7 @@ namespace garge_api.Controllers
         /// <param name="dto">The registration code DTO.</param>
         /// <returns>Success or error message.</returns>
         [HttpPost("claim")]
-        [Authorize]
+        [Authorize(Policy = "ActiveSubscription")]
         public async Task<IActionResult> ClaimSensor([FromBody] ClaimSensorDto dto)
         {
             _logger.LogInformation("ClaimSensor called by {@LogData}", new { CallerUserId = User.UserId(), RegistrationCode = dto.RegistrationCode });

--- a/Controllers/SwitchesController.cs
+++ b/Controllers/SwitchesController.cs
@@ -18,7 +18,6 @@ namespace garge_api.Controllers
     [Route("api/switches")]
     [EnableCors("AllowAllOrigins")]
     [Authorize]
-    [Authorize(Policy = "ActiveSubscription")]
     public class SwitchesController : ControllerBase
     {
         private readonly ApplicationDbContext _context;
@@ -659,7 +658,7 @@ namespace garge_api.Controllers
         }
 
         [HttpPost("claim")]
-        [Authorize]
+        [Authorize(Policy = "ActiveSubscription")]
         [SwaggerOperation(Summary = "Claims a switch using a registration code.")]
         [SwaggerResponse(200, "Switch claimed successfully.")]
         [SwaggerResponse(400, "Registration code is required.")]

--- a/Controllers/UserController.cs
+++ b/Controllers/UserController.cs
@@ -23,7 +23,6 @@ namespace garge_api.Controllers
     [Route("api/users")]
     [EnableCors("AllowAllOrigins")]
     [Authorize]
-    [Authorize(Policy = "ActiveSubscription")]
     public class UserController : ControllerBase
     {
         private readonly ApplicationDbContext _context;

--- a/garge-api.Tests/ActiveSubscriptionHandlerTests.cs
+++ b/garge-api.Tests/ActiveSubscriptionHandlerTests.cs
@@ -15,11 +15,19 @@ namespace garge_api.Tests;
 
 public class ActiveSubscriptionHandlerTests
 {
+    private const int PrimaryProductId = 1;
+    private const int AddOnProductId = 2;
+
     private static (ActiveSubscriptionHandler handler, ApplicationDbContext db) Create()
     {
         var db = new ApplicationDbContext(
             new DbContextOptionsBuilder<ApplicationDbContext>()
                 .UseInMemoryDatabase(Guid.NewGuid().ToString()).Options);
+
+        db.Products.AddRange(
+            new Product { Id = PrimaryProductId, Name = "Primary", PriceInOre = 0, Interval = BillingInterval.Monthly, Type = ProductType.Primary },
+            new Product { Id = AddOnProductId,  Name = "AddOn",   PriceInOre = 0, Interval = BillingInterval.Monthly, Type = ProductType.AddOn });
+        db.SaveChanges();
 
         var serviceProvider = new Mock<IServiceProvider>();
         serviceProvider.Setup(sp => sp.GetService(typeof(ApplicationDbContext))).Returns(db);
@@ -43,6 +51,20 @@ public class ActiveSubscriptionHandlerTests
         return new AuthorizationHandlerContext([new ActiveSubscriptionRequirement()], principal, null);
     }
 
+    private static Subscription Primary(string userId, SubscriptionStatus status = SubscriptionStatus.Active, int quantity = 1, bool isTest = false)
+        => new()
+        {
+            UserId = userId, ProductId = PrimaryProductId,
+            VippsAgreementId = $"primary-{userId}", Status = status, Quantity = quantity, IsTest = isTest,
+        };
+
+    private static Subscription AddOn(string userId, int quantity, SubscriptionStatus status = SubscriptionStatus.Active, bool isTest = false)
+        => new()
+        {
+            UserId = userId, ProductId = AddOnProductId,
+            VippsAgreementId = $"addon-{userId}-{Guid.NewGuid():N}", Status = status, Quantity = quantity, IsTest = isTest,
+        };
+
     private static async Task Handle(ActiveSubscriptionHandler handler, AuthorizationHandlerContext ctx)
         => await ((IAuthorizationHandler)handler).HandleAsync(ctx);
 
@@ -61,50 +83,11 @@ public class ActiveSubscriptionHandlerTests
     }
 
     [Fact]
-    public async Task PureViewer_NoOwnedSensors_Succeeds()
+    public async Task NoSubscription_NoOwnedSensors_Fails()
     {
+        // A brand-new user with no Primary cannot claim their first sensor.
         var (handler, db) = Create();
         await db.AppSettings.AddAsync(new AppSettings { Id = 1 });
-        await db.SaveChangesAsync();
-
-        var ctx = MakeContext("viewer-1");
-        await Handle(handler, ctx);
-
-        Assert.True(ctx.HasSucceeded);
-    }
-
-    [Fact]
-    public async Task OneOwnedSensor_OneActiveSubscription_Succeeds()
-    {
-        var (handler, db) = Create();
-        await db.AppSettings.AddAsync(new AppSettings { Id = 1 });
-        await db.UserSensors.AddAsync(new UserSensor { UserId = "user-1", SensorId = 1, IsOwner = true });
-        await db.Subscriptions.AddAsync(new Subscription
-        {
-            UserId = "user-1", ProductId = 1,
-            VippsAgreementId = "agr1", Status = SubscriptionStatus.Active
-        });
-        await db.SaveChangesAsync();
-
-        var ctx = MakeContext("user-1");
-        await Handle(handler, ctx);
-
-        Assert.True(ctx.HasSucceeded);
-    }
-
-    [Fact]
-    public async Task TwoOwnedSensors_OneSubscription_Fails()
-    {
-        var (handler, db) = Create();
-        await db.AppSettings.AddAsync(new AppSettings { Id = 1 });
-        await db.UserSensors.AddRangeAsync(
-            new UserSensor { UserId = "user-1", SensorId = 1, IsOwner = true },
-            new UserSensor { UserId = "user-1", SensorId = 2, IsOwner = true });
-        await db.Subscriptions.AddAsync(new Subscription
-        {
-            UserId = "user-1", ProductId = 1,
-            VippsAgreementId = "agr1", Status = SubscriptionStatus.Active
-        });
         await db.SaveChangesAsync();
 
         var ctx = MakeContext("user-1");
@@ -114,16 +97,12 @@ public class ActiveSubscriptionHandlerTests
     }
 
     [Fact]
-    public async Task TwoOwnedSensors_TwoSubscriptions_Succeeds()
+    public async Task PrimaryActive_NoOwnedSensors_Succeeds()
     {
+        // Primary covers the first sensor — claim is allowed.
         var (handler, db) = Create();
         await db.AppSettings.AddAsync(new AppSettings { Id = 1 });
-        await db.UserSensors.AddRangeAsync(
-            new UserSensor { UserId = "user-1", SensorId = 1, IsOwner = true },
-            new UserSensor { UserId = "user-1", SensorId = 2, IsOwner = true });
-        await db.Subscriptions.AddRangeAsync(
-            new Subscription { UserId = "user-1", ProductId = 1, VippsAgreementId = "agr1", Status = SubscriptionStatus.Active },
-            new Subscription { UserId = "user-1", ProductId = 2, VippsAgreementId = "agr2", Status = SubscriptionStatus.Active });
+        await db.Subscriptions.AddAsync(Primary("user-1"));
         await db.SaveChangesAsync();
 
         var ctx = MakeContext("user-1");
@@ -133,16 +112,60 @@ public class ActiveSubscriptionHandlerTests
     }
 
     [Fact]
-    public async Task OwnedSensor_PendingSubscriptionOnly_Fails()
+    public async Task PrimaryActive_OneOwnedSensor_Fails()
     {
+        // Primary covers exactly one sensor; without AddOn, the next claim is denied.
         var (handler, db) = Create();
         await db.AppSettings.AddAsync(new AppSettings { Id = 1 });
         await db.UserSensors.AddAsync(new UserSensor { UserId = "user-1", SensorId = 1, IsOwner = true });
-        await db.Subscriptions.AddAsync(new Subscription
-        {
-            UserId = "user-1", ProductId = 1,
-            VippsAgreementId = "agr1", Status = SubscriptionStatus.Pending
-        });
+        await db.Subscriptions.AddAsync(Primary("user-1"));
+        await db.SaveChangesAsync();
+
+        var ctx = MakeContext("user-1");
+        await Handle(handler, ctx);
+
+        Assert.False(ctx.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task PrimaryPlusAddOnQuantityTwo_TwoOwnedSensors_Succeeds()
+    {
+        // Capacity = 1 (Primary) + 2 (AddOn × 2) = 3; with 2 owned the user can claim a third.
+        var (handler, db) = Create();
+        await db.AppSettings.AddAsync(new AppSettings { Id = 1 });
+        await db.UserSensors.AddRangeAsync(
+            new UserSensor { UserId = "user-1", SensorId = 1, IsOwner = true },
+            new UserSensor { UserId = "user-1", SensorId = 2, IsOwner = true });
+        await db.Subscriptions.AddRangeAsync(Primary("user-1"), AddOn("user-1", quantity: 2));
+        await db.SaveChangesAsync();
+
+        var ctx = MakeContext("user-1");
+        await Handle(handler, ctx);
+
+        Assert.True(ctx.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task AddOnWithoutPrimary_Fails()
+    {
+        // AddOn alone does not grant capacity — Primary is required as the base.
+        var (handler, db) = Create();
+        await db.AppSettings.AddAsync(new AppSettings { Id = 1 });
+        await db.Subscriptions.AddAsync(AddOn("user-1", quantity: 5));
+        await db.SaveChangesAsync();
+
+        var ctx = MakeContext("user-1");
+        await Handle(handler, ctx);
+
+        Assert.False(ctx.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task PendingPrimary_NotCountedAsActive()
+    {
+        var (handler, db) = Create();
+        await db.AppSettings.AddAsync(new AppSettings { Id = 1 });
+        await db.Subscriptions.AddAsync(Primary("user-1", status: SubscriptionStatus.Pending));
         await db.SaveChangesAsync();
 
         var ctx = MakeContext("user-1");
@@ -154,18 +177,13 @@ public class ActiveSubscriptionHandlerTests
     [Fact]
     public async Task SharedSensor_IsOwnerFalse_NotCountedForBilling()
     {
+        // User owns 1 sensor (covered by Primary). A shared sensor (IsOwner=false) must not
+        // push them over capacity, so the user can still claim another sensor.
         var (handler, db) = Create();
         await db.AppSettings.AddAsync(new AppSettings { Id = 1 });
-        // User owns 1 sensor, has 1 subscription — should succeed
-        // Plus 1 shared sensor (IsOwner=false) that must NOT count towards billing
         await db.UserSensors.AddRangeAsync(
-            new UserSensor { UserId = "user-1", SensorId = 1, IsOwner = true },
-            new UserSensor { UserId = "user-1", SensorId = 2, IsOwner = false });
-        await db.Subscriptions.AddAsync(new Subscription
-        {
-            UserId = "user-1", ProductId = 1,
-            VippsAgreementId = "agr1", Status = SubscriptionStatus.Active
-        });
+            new UserSensor { UserId = "user-1", SensorId = 1, IsOwner = false });
+        await db.Subscriptions.AddAsync(Primary("user-1"));
         await db.SaveChangesAsync();
 
         var ctx = MakeContext("user-1");
@@ -179,13 +197,7 @@ public class ActiveSubscriptionHandlerTests
     {
         var (handler, db) = Create();
         await db.AppSettings.AddAsync(new AppSettings { Id = 1, VippsTestMode = false });
-        await db.UserSensors.AddAsync(new UserSensor { UserId = "user-1", SensorId = 1, IsOwner = true });
-        await db.Subscriptions.AddAsync(new Subscription
-        {
-            UserId = "user-1", ProductId = 1,
-            VippsAgreementId = "agr1", Status = SubscriptionStatus.Active,
-            IsTest = true
-        });
+        await db.Subscriptions.AddAsync(Primary("user-1", isTest: true));
         await db.SaveChangesAsync();
 
         var ctx = MakeContext("user-1");
@@ -199,13 +211,7 @@ public class ActiveSubscriptionHandlerTests
     {
         var (handler, db) = Create();
         await db.AppSettings.AddAsync(new AppSettings { Id = 1, VippsTestMode = true });
-        await db.UserSensors.AddAsync(new UserSensor { UserId = "user-1", SensorId = 1, IsOwner = true });
-        await db.Subscriptions.AddAsync(new Subscription
-        {
-            UserId = "user-1", ProductId = 1,
-            VippsAgreementId = "agr1", Status = SubscriptionStatus.Active,
-            IsTest = true
-        });
+        await db.Subscriptions.AddAsync(Primary("user-1", isTest: true));
         await db.SaveChangesAsync();
 
         var ctx = MakeContext("user-1");


### PR DESCRIPTION
## Summary
- `ActiveSubscriptionHandler` now uses a capacity model: `capacity = primaryActive ? 1 + sum(activeAddOn.Quantity) : 0`. A claim is allowed when `ownedSensorCount < capacity`. AddOns without a Primary grant nothing; `UserSensor.IsOwner = false` rows never count.
- Move `[Authorize(Policy = "ActiveSubscription")]` off every controller class. Apply it only on `POST /sensors/claim` and `POST /switches/claim`. Everything else (reads, unclaim, profile, account deletion) only requires authentication so a user who falls out of quota can still see their account and drop sensors to recover.
- Tests updated to the new model: brand-new user with no Primary fails, Primary alone covers the first sensor, AddOn × N extends capacity, AddOn without Primary fails. 276/276 passing.