### PR TITLE
fix: include subscriptionId in Vipps subscription return URL

### DIFF
--- a/Controllers/SubscriptionsController.cs
+++ b/Controllers/SubscriptionsController.cs
@@ -227,7 +227,7 @@ namespace garge_api.Controllers
             _context.Subscriptions.Add(subscription);
             await _context.SaveChangesAsync();
 
-            var redirectUrl = $"{_appOpts.FrontendBaseUrl}/profile/billing/return";
+            var redirectUrl = $"{_appOpts.FrontendBaseUrl}/profile/billing/return?subscriptionId={subscription.Id}";
             var idempotencyKey = $"sub-{subscription.Id}";
 
             try


### PR DESCRIPTION
## Summary

The subscription agreement redirect built a bare `/profile/billing/return` URL, so the frontend could not tell which subscription was just purchased and fell back to guessing — surfacing "Subscription not found" for users with more than one subscription.

- Append `?subscriptionId={subscription.Id}` to the redirect URL, mirroring the shop payment flow that already appends `?orderId=`.

Pairs with garge-app PR #321 which reads this param on the billing return page.
