### PR TITLE
fix: scope sensor telemetry reads to the caller's ownership window

### DIFF
--- a/Controllers/BatteryHealthController.cs
+++ b/Controllers/BatteryHealthController.cs
@@ -48,6 +48,35 @@ namespace garge_api.Controllers
             return await _context.UserSensors.AnyAsync(us => us.UserId == userId && us.SensorId == sensorId);
         }
 
+        // Bound derived battery data to the caller's own ownership window(s) so a new owner of a
+        // re-claimed/resold sensor never sees the previous owner's history. Admins see everything.
+        private IQueryable<BatteryHealth> WithinOwnershipWindow(IQueryable<BatteryHealth> query)
+        {
+            if (IsAdmin()) return query;
+            var userId = User.UserId();
+            return query.Where(bh => _context.SensorOwnershipPeriods.Any(p =>
+                p.UserId == userId && p.SensorId == bh.SensorId
+                && bh.Timestamp >= p.StartedAt && (p.EndedAt == null || bh.Timestamp < p.EndedAt)));
+        }
+
+        private IQueryable<BatteryChargeEvent> WithinOwnershipWindow(IQueryable<BatteryChargeEvent> query)
+        {
+            if (IsAdmin()) return query;
+            var userId = User.UserId();
+            return query.Where(e => _context.SensorOwnershipPeriods.Any(p =>
+                p.UserId == userId && p.SensorId == e.SensorId
+                && e.StartedAt >= p.StartedAt && (p.EndedAt == null || e.StartedAt < p.EndedAt)));
+        }
+
+        private IQueryable<SensorData> WithinOwnershipWindow(IQueryable<SensorData> query)
+        {
+            if (IsAdmin()) return query;
+            var userId = User.UserId();
+            return query.Where(sd => _context.SensorOwnershipPeriods.Any(p =>
+                p.UserId == userId && p.SensorId == sd.SensorId
+                && sd.Timestamp >= p.StartedAt && (p.EndedAt == null || sd.Timestamp < p.EndedAt)));
+        }
+
         /// <summary>
         /// Returns the latest battery health record for the voltage sensor identified by name.
         /// </summary>
@@ -73,8 +102,8 @@ namespace garge_api.Controllers
                 return Forbid();
             }
 
-            var latest = await _context.BatteryHealthData
-                .Where(bh => bh.SensorId == sensor.Id)
+            var latest = await WithinOwnershipWindow(
+                    _context.BatteryHealthData.Where(bh => bh.SensorId == sensor.Id))
                 .OrderByDescending(bh => bh.Timestamp)
                 .FirstOrDefaultAsync();
 
@@ -99,7 +128,7 @@ namespace garge_api.Controllers
             if (sensor == null) return NotFound(new { message = "Sensor not found!" });
             if (!await UserCanAccessSensorAsync(sensor.Id)) return Forbid();
 
-            var query = _context.BatteryChargeEvents.Where(e => e.SensorId == sensor.Id);
+            var query = WithinOwnershipWindow(_context.BatteryChargeEvents.Where(e => e.SensorId == sensor.Id));
             if (since.HasValue) query = query.Where(e => e.StartedAt >= since.Value);
             var events = await query.OrderByDescending(e => e.StartedAt).ToListAsync();
             return Ok(_mapper.Map<List<BatteryChargeEventDto>>(events));
@@ -115,8 +144,8 @@ namespace garge_api.Controllers
             if (sensor == null) return NotFound(new { message = "Sensor not found!" });
             if (!await UserCanAccessSensorAsync(sensor.Id)) return Forbid();
 
-            var latest = await _context.SensorData
-                .Where(sd => sd.SensorId == sensor.Id)
+            var latest = await WithinOwnershipWindow(
+                    _context.SensorData.Where(sd => sd.SensorId == sensor.Id))
                 .OrderByDescending(sd => sd.Timestamp)
                 .Select(sd => sd.Value)
                 .FirstOrDefaultAsync();

--- a/Controllers/SensorController.cs
+++ b/Controllers/SensorController.cs
@@ -57,6 +57,23 @@ namespace garge_api.Controllers
         }
 
         /// <summary>
+        /// Restricts a SensorData query to readings that fall inside the caller's own ownership
+        /// period(s), so a new owner of a re-claimed/resold sensor never sees the previous owner's
+        /// history. Admins see everything. The access check (UserCanAccessSensorAsync) still gates
+        /// whether the sensor is visible at all; this bounds the time window of the data returned.
+        /// </summary>
+        private IQueryable<SensorData> WithinOwnershipWindow(IQueryable<SensorData> query)
+        {
+            if (IsAdmin()) return query;
+            var userId = User.UserId();
+            return query.Where(sd => _context.SensorOwnershipPeriods.Any(p =>
+                p.UserId == userId
+                && p.SensorId == sd.SensorId
+                && sd.Timestamp >= p.StartedAt
+                && (p.EndedAt == null || sd.Timestamp < p.EndedAt)));
+        }
+
+        /// <summary>
         /// Retrieves all sensors the user has access to.
         /// </summary>
         /// <returns>A list of sensors the user has access to.</returns>
@@ -177,9 +194,8 @@ namespace garge_api.Controllers
                 return Forbid();
             }
 
-            var query = _context.SensorData
-                .Where(sd => sd.SensorId == sensorId)
-                .AsQueryable();
+            var query = WithinOwnershipWindow(
+                _context.SensorData.Where(sd => sd.SensorId == sensorId));
 
             DateTime? effectiveStart = null;
             DateTime? effectiveEnd = null;
@@ -206,7 +222,7 @@ namespace garge_api.Controllers
             var groupBySpan = !string.IsNullOrEmpty(groupBy) ? ParseTimeRange(groupBy) : null;
             if (groupBySpan.HasValue)
             {
-                var grouped = await GetAveragedDataAsync(new[] { sensorId }, (long)groupBySpan.Value.TotalSeconds, effectiveStart, effectiveEnd);
+                var grouped = await GetAveragedDataAsync(new[] { sensorId }, (long)groupBySpan.Value.TotalSeconds, effectiveStart, effectiveEnd, User.UserId(), IsAdmin());
                 totalCount = grouped.Count;
                 result = grouped;
             }
@@ -271,9 +287,8 @@ namespace garge_api.Controllers
                 }
             }
 
-            var query = _context.SensorData
-                .Where(sd => sensorIds.Contains(sd.SensorId))
-                .AsQueryable();
+            var query = WithinOwnershipWindow(
+                _context.SensorData.Where(sd => sensorIds.Contains(sd.SensorId)));
 
             DateTime? effectiveStart = null;
             DateTime? effectiveEnd = null;
@@ -300,7 +315,7 @@ namespace garge_api.Controllers
             var groupBySpan = !string.IsNullOrEmpty(groupBy) ? ParseTimeRange(groupBy) : null;
             if (groupBySpan.HasValue)
             {
-                var grouped = await GetAveragedDataAsync(sensorIds, (long)groupBySpan.Value.TotalSeconds, effectiveStart, effectiveEnd);
+                var grouped = await GetAveragedDataAsync(sensorIds, (long)groupBySpan.Value.TotalSeconds, effectiveStart, effectiveEnd, User.UserId(), IsAdmin());
                 totalCount = grouped.Count;
                 result = grouped;
             }
@@ -327,7 +342,8 @@ namespace garge_api.Controllers
         }
 
         private async Task<List<SensorDataDto>> GetAveragedDataAsync(
-            IEnumerable<int> sensorIds, long bucketSeconds, DateTime? effectiveStart, DateTime? effectiveEnd)
+            IEnumerable<int> sensorIds, long bucketSeconds, DateTime? effectiveStart, DateTime? effectiveEnd,
+            string? userId, bool isAdmin)
         {
             var effectiveBucket = EnforcedBucketSeconds(bucketSeconds, effectiveStart, effectiveEnd);
 
@@ -340,6 +356,16 @@ namespace garge_api.Controllers
 
             if (effectiveStart.HasValue) { whereClauses.Add("sd.\"Timestamp\" >= @startDate"); parameters.Add(new("startDate", effectiveStart.Value)); }
             if (effectiveEnd.HasValue) { whereClauses.Add("sd.\"Timestamp\" <= @endDate"); parameters.Add(new("endDate", effectiveEnd.Value)); }
+
+            // Bound to the caller's own ownership window(s) — see WithinOwnershipWindow. Admins see all.
+            if (!isAdmin)
+            {
+                whereClauses.Add(@"EXISTS (SELECT 1 FROM ""SensorOwnershipPeriods"" p
+                    WHERE p.""UserId"" = @userId AND p.""SensorId"" = sd.""SensorId""
+                    AND sd.""Timestamp"" >= p.""StartedAt""
+                    AND (p.""EndedAt"" IS NULL OR sd.""Timestamp"" < p.""EndedAt""))");
+                parameters.Add(new("userId", (object?)userId ?? DBNull.Value));
+            }
 
             var sql = $"""
                 SELECT
@@ -557,6 +583,19 @@ namespace garge_api.Controllers
             if (!alreadyClaimed)
             {
                 _context.UserSensors.Add(new UserSensor { UserId = userId!, SensorId = sensor.Id, IsOwner = true });
+
+                // Open an ownership period that bounds which telemetry this user may read. The
+                // first-ever owner starts at the epoch sentinel (sees all history); every later
+                // (resale) owner starts now, so they never see the previous owner's readings.
+                var firstEverOwner = !await _context.SensorOwnershipPeriods.AnyAsync(p => p.SensorId == sensor.Id);
+                _context.SensorOwnershipPeriods.Add(new SensorOwnershipPeriod
+                {
+                    UserId = userId!,
+                    SensorId = sensor.Id,
+                    StartedAt = firstEverOwner ? SensorOwnershipPeriod.FirstOwnerStart : DateTime.UtcNow,
+                    EndedAt = null
+                });
+
                 await _context.SaveChangesAsync();
                 _ownership.InvalidateSensor(sensor.Id);
                 await _hub.Clients.Group(DeviceHub.UserGroup(userId!)).SendAsync("device-created", new { kind = "sensor", id = sensor.Id });
@@ -602,6 +641,14 @@ namespace garge_api.Controllers
             {
                 _context.UserSensors.Remove(userSensor);
                 _ownership.InvalidateSensor(id);
+
+                // Close this user's open ownership period so they no longer read new readings,
+                // and a future owner of the same sensor cannot see this user's history.
+                var openPeriods = await _context.SensorOwnershipPeriods
+                    .Where(p => p.UserId == userId && p.SensorId == id && p.EndedAt == null)
+                    .ToListAsync();
+                foreach (var period in openPeriods)
+                    period.EndedAt = DateTime.UtcNow;
             }
 
             // Remove any custom name the user has set for this sensor
@@ -1074,8 +1121,8 @@ namespace garge_api.Controllers
                 return Forbid();
             }
 
-            var latestData = await _context.SensorData
-                .Where(sd => sd.SensorId == sensorId)
+            var latestData = await WithinOwnershipWindow(
+                    _context.SensorData.Where(sd => sd.SensorId == sensorId))
                 .OrderByDescending(sd => sd.Timestamp)
                 .FirstOrDefaultAsync();
 

--- a/Controllers/UserController.cs
+++ b/Controllers/UserController.cs
@@ -273,8 +273,12 @@ namespace garge_api.Controllers
                 .Select(p => new { p.SensorId, p.ContentType, p.Data, p.CreatedAt })
                 .ToListAsync();
 
+            // Bound to the user's own ownership window(s): they export the data from periods they
+            // owned, not a previous owner's readings on a re-claimed sensor.
             var sensorReadings = await _context.SensorData
-                .Where(sd => sensorIds.Contains(sd.SensorId))
+                .Where(sd => sensorIds.Contains(sd.SensorId)
+                    && _context.SensorOwnershipPeriods.Any(p => p.UserId == id && p.SensorId == sd.SensorId
+                        && sd.Timestamp >= p.StartedAt && (p.EndedAt == null || sd.Timestamp < p.EndedAt)))
                 .OrderBy(sd => sd.Timestamp)
                 .Select(sd => new { sd.SensorId, sd.Value, sd.Timestamp })
                 .ToListAsync();
@@ -286,7 +290,9 @@ namespace garge_api.Controllers
                 .ToListAsync();
 
             var batteryHealth = await _context.BatteryHealthData
-                .Where(bh => sensorIds.Contains(bh.SensorId))
+                .Where(bh => sensorIds.Contains(bh.SensorId)
+                    && _context.SensorOwnershipPeriods.Any(p => p.UserId == id && p.SensorId == bh.SensorId
+                        && bh.Timestamp >= p.StartedAt && (p.EndedAt == null || bh.Timestamp < p.EndedAt)))
                 .OrderBy(bh => bh.Timestamp)
                 .ToListAsync();
 

--- a/Migrations/20260520171339_AddSensorOwnershipPeriod.Designer.cs
+++ b/Migrations/20260520171339_AddSensorOwnershipPeriod.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260520171339_AddSensorOwnershipPeriod")]
+    partial class AddSensorOwnershipPeriod
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260520171339_AddSensorOwnershipPeriod.cs
+++ b/Migrations/20260520171339_AddSensorOwnershipPeriod.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSensorOwnershipPeriod : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "SensorOwnershipPeriods",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<string>(type: "text", nullable: false),
+                    SensorId = table.Column<int>(type: "integer", nullable: false),
+                    StartedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    EndedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SensorOwnershipPeriods", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SensorOwnershipPeriods_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_SensorOwnershipPeriods_Sensors_SensorId",
+                        column: x => x.SensorId,
+                        principalTable: "Sensors",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SensorOwnershipPeriods_SensorId_StartedAt",
+                table: "SensorOwnershipPeriods",
+                columns: new[] { "SensorId", "StartedAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SensorOwnershipPeriods_UserId_SensorId",
+                table: "SensorOwnershipPeriods",
+                columns: new[] { "UserId", "SensorId" });
+
+            // Backfill: every existing ownership becomes an open period starting at the epoch
+            // sentinel (1970-01-01) so current owners keep their full history — no behaviour
+            // change at rollout. The resale boundary only takes effect for future re-claims.
+            migrationBuilder.Sql(@"
+                INSERT INTO ""SensorOwnershipPeriods"" (""UserId"", ""SensorId"", ""StartedAt"", ""EndedAt"")
+                SELECT ""UserId"", ""SensorId"", TIMESTAMPTZ '1970-01-01 00:00:00+00', NULL
+                FROM ""UserSensors"";
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SensorOwnershipPeriods");
+        }
+    }
+}

--- a/Models/ApplicationDbContext.cs
+++ b/Models/ApplicationDbContext.cs
@@ -41,6 +41,7 @@ namespace garge_api.Models
         public DbSet<GroupSwitch> GroupSwitches { get; set; }
         public DbSet<UserSwitchCustomName> UserSwitchCustomNames { get; set; }
         public DbSet<UserSensor> UserSensors { get; set; }
+        public DbSet<SensorOwnershipPeriod> SensorOwnershipPeriods { get; set; }
         public DbSet<UserSwitch> UserSwitches { get; set; }
         public DbSet<StoredElectricityPrice> StoredElectricityPrices { get; set; }
         public DbSet<SensorPhoto> SensorPhotos { get; set; }
@@ -188,6 +189,24 @@ namespace garge_api.Models
                 .HasOne(x => x.Sensor)
                 .WithMany()
                 .HasForeignKey(x => x.SensorId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<SensorOwnershipPeriod>()
+                .HasIndex(p => new { p.UserId, p.SensorId });
+
+            modelBuilder.Entity<SensorOwnershipPeriod>()
+                .HasIndex(p => new { p.SensorId, p.StartedAt });
+
+            modelBuilder.Entity<SensorOwnershipPeriod>()
+                .HasOne(p => p.User)
+                .WithMany()
+                .HasForeignKey(p => p.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<SensorOwnershipPeriod>()
+                .HasOne(p => p.Sensor)
+                .WithMany()
+                .HasForeignKey(p => p.SensorId)
                 .OnDelete(DeleteBehavior.Cascade);
 
             modelBuilder.Entity<UserSwitch>()

--- a/Models/Sensor/SensorOwnershipPeriod.cs
+++ b/Models/Sensor/SensorOwnershipPeriod.cs
@@ -1,0 +1,39 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace garge_api.Models.Sensor
+{
+    /// <summary>
+    /// One row per (user, sensor) ownership stint. Bounds which telemetry a user may read so a new
+    /// owner of a re-claimed/resold sensor never sees the previous owner's history.
+    ///
+    /// <para><see cref="StartedAt"/> is when the stint began; <see cref="EndedAt"/> is when the user
+    /// unclaimed/sold, or null while still owned. A user sees telemetry only inside their own period(s)
+    /// (an allowlist), so removing one ex-owner never widens another user's view.</para>
+    ///
+    /// <para>The first-ever owner of a sensor gets <see cref="FirstOwnerStart"/> so they keep any
+    /// pre-claim setup readings; every subsequent (resale) owner starts at their claim time.</para>
+    /// </summary>
+    public class SensorOwnershipPeriod
+    {
+        /// <summary>Sentinel start for the first-ever owner so they see all history from the sensor's birth.</summary>
+        public static readonly DateTime FirstOwnerStart = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        public int Id { get; set; }
+
+        [Required]
+        public required string UserId { get; set; }
+
+        public int SensorId { get; set; }
+
+        public DateTime StartedAt { get; set; }
+
+        public DateTime? EndedAt { get; set; }
+
+        [ForeignKey(nameof(UserId))]
+        public User? User { get; set; }
+
+        [ForeignKey(nameof(SensorId))]
+        public Sensor? Sensor { get; set; }
+    }
+}

--- a/garge-api.Tests/SensorOwnershipWindowTests.cs
+++ b/garge-api.Tests/SensorOwnershipWindowTests.cs
@@ -1,0 +1,165 @@
+using garge_api.Controllers;
+using garge_api.Dtos.Sensor;
+using garge_api.Hubs;
+using garge_api.Models;
+using garge_api.Models.Sensor;
+using garge_api.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace garge_api.Tests;
+
+/// <summary>
+/// Verifies the ownership-window read filter: a user only sees telemetry recorded inside their own
+/// ownership period(s), so a new owner of a re-claimed/resold sensor never sees the previous owner's
+/// history. Also covers period lifecycle on claim/unclaim.
+/// </summary>
+public class SensorOwnershipWindowTests : ControllerTestBase
+{
+    private const int SensorId = 1;
+    private static readonly DateTime ACancel = new(2020, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    private SensorController CreateController(ApplicationDbContext db, string userId, bool isAdmin)
+    {
+        var ownership = new Mock<IDeviceOwnershipService>();
+        ownership.Setup(o => o.CanUserAccessSensorAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var proxy = new Mock<IClientProxy>();
+        proxy.Setup(p => p.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var clients = new Mock<IHubClients>();
+        clients.Setup(c => c.Group(It.IsAny<string>())).Returns(proxy.Object);
+        var hub = new Mock<IHubContext<DeviceHub>>();
+        hub.SetupGet(h => h.Clients).Returns(clients.Object);
+
+        var controller = new SensorController(
+            db, MockMapper.Object, NullLogger<SensorController>.Instance, ownership.Object, hub.Object);
+        controller.ControllerContext = MakeControllerContext(userId, isAdmin);
+        return controller;
+    }
+
+    /// <summary>Sensor owned first by A [..,ACancel), then resold to C [ACancel,..). 3 readings in A's window, 2 in C's.</summary>
+    private static void SeedResaleHistory(ApplicationDbContext db)
+    {
+        db.Sensors.Add(new Sensor
+        {
+            Id = SensorId, Name = "garge_volt", Type = "voltage", Role = "sensor",
+            RegistrationCode = "rc-1", DefaultName = "Battery", ParentName = "garge_test"
+        });
+
+        db.SensorOwnershipPeriods.Add(new SensorOwnershipPeriod
+        {
+            UserId = "user-A", SensorId = SensorId,
+            StartedAt = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc), EndedAt = ACancel
+        });
+        db.SensorOwnershipPeriods.Add(new SensorOwnershipPeriod
+        {
+            UserId = "user-C", SensorId = SensorId, StartedAt = ACancel, EndedAt = null
+        });
+
+        db.SensorData.AddRange(
+            new SensorData { SensorId = SensorId, Value = "10", Timestamp = new DateTime(2020, 2, 1, 0, 0, 0, DateTimeKind.Utc) },
+            new SensorData { SensorId = SensorId, Value = "11", Timestamp = new DateTime(2020, 3, 1, 0, 0, 0, DateTimeKind.Utc) },
+            new SensorData { SensorId = SensorId, Value = "12", Timestamp = new DateTime(2020, 4, 1, 0, 0, 0, DateTimeKind.Utc) },
+            new SensorData { SensorId = SensorId, Value = "13", Timestamp = new DateTime(2020, 7, 1, 0, 0, 0, DateTimeKind.Utc) },
+            new SensorData { SensorId = SensorId, Value = "14", Timestamp = new DateTime(2020, 8, 1, 0, 0, 0, DateTimeKind.Utc) });
+        db.SaveChanges();
+    }
+
+    private static int TotalCount(IActionResult result)
+    {
+        var ok = Assert.IsType<OkObjectResult>(result);
+        return (int)ok.Value!.GetType().GetProperty("TotalCount")!.GetValue(ok.Value)!;
+    }
+
+    [Fact]
+    public async Task GetSensorData_ResaleOwner_SeesOnlyOwnWindow()
+    {
+        using var db = CreateDbContext();
+        SeedResaleHistory(db);
+        var controller = CreateController(db, "user-C", isAdmin: false);
+
+        var result = await controller.GetSensorData(SensorId, null, null, null, groupBy: "");
+
+        // C must NOT see A's 3 pre-resale readings — only their own 2.
+        Assert.Equal(2, TotalCount(result));
+    }
+
+    [Fact]
+    public async Task GetSensorData_Admin_SeesAllWindows()
+    {
+        using var db = CreateDbContext();
+        SeedResaleHistory(db);
+        var controller = CreateController(db, "admin-1", isAdmin: true);
+
+        var result = await controller.GetSensorData(SensorId, null, null, null, groupBy: "");
+
+        Assert.Equal(5, TotalCount(result));
+    }
+
+    [Fact]
+    public async Task GetLatestSensorData_ResaleOwner_GetsLatestInOwnWindow()
+    {
+        using var db = CreateDbContext();
+        SeedResaleHistory(db);
+        MockMapper.Setup(m => m.Map<SensorDataDto>(It.IsAny<SensorData>()))
+            .Returns((SensorData s) => new SensorDataDto { Id = s.Id, SensorId = s.SensorId, Value = s.Value, Timestamp = s.Timestamp });
+        var controller = CreateController(db, "user-C", isAdmin: false);
+
+        var result = await controller.GetLatestSensorData(SensorId);
+
+        var dto = Assert.IsType<SensorDataDto>(Assert.IsType<OkObjectResult>(result).Value);
+        Assert.Equal("14", dto.Value); // C's latest, not A's old readings
+    }
+
+    [Fact]
+    public async Task ClaimSensor_FirstEverOwner_OpensPeriodAtEpochSentinel()
+    {
+        using var db = CreateDbContext();
+        db.Sensors.Add(new Sensor
+        {
+            Id = SensorId, Name = "garge_volt", Type = "voltage", Role = "sensor",
+            RegistrationCode = "rc-1", DefaultName = "Battery", ParentName = "garge_test"
+        });
+        db.Users.Add(MakeUser("user-A"));
+        await db.SaveChangesAsync();
+        var controller = CreateController(db, "user-A", isAdmin: false);
+
+        await controller.ClaimSensor(new ClaimSensorDto { RegistrationCode = "rc-1" });
+
+        var period = Assert.Single(db.SensorOwnershipPeriods.Where(p => p.UserId == "user-A"));
+        Assert.Equal(SensorOwnershipPeriod.FirstOwnerStart, period.StartedAt);
+        Assert.Null(period.EndedAt);
+    }
+
+    [Fact]
+    public async Task ClaimAfterResale_NewOwner_StartsAtClaimTimeNotEpoch()
+    {
+        using var db = CreateDbContext();
+        db.Sensors.Add(new Sensor
+        {
+            Id = SensorId, Name = "garge_volt", Type = "voltage", Role = "sensor",
+            RegistrationCode = "rc-1", DefaultName = "Battery", ParentName = "garge_test"
+        });
+        db.Users.Add(MakeUser("user-A"));
+        db.Users.Add(MakeUser("user-B", "b@example.com"));
+        await db.SaveChangesAsync();
+
+        var before = DateTime.UtcNow;
+        await CreateController(db, "user-A", isAdmin: false).ClaimSensor(new ClaimSensorDto { RegistrationCode = "rc-1" });
+        await CreateController(db, "user-A", isAdmin: false).UnclaimSensor(SensorId);
+        await CreateController(db, "user-B", isAdmin: false).ClaimSensor(new ClaimSensorDto { RegistrationCode = "rc-1" });
+
+        var aPeriod = Assert.Single(db.SensorOwnershipPeriods.Where(p => p.UserId == "user-A"));
+        Assert.NotNull(aPeriod.EndedAt); // closed on unclaim
+
+        var bPeriod = Assert.Single(db.SensorOwnershipPeriods.Where(p => p.UserId == "user-B"));
+        Assert.NotEqual(SensorOwnershipPeriod.FirstOwnerStart, bPeriod.StartedAt);
+        Assert.True(bPeriod.StartedAt >= before); // resale owner starts at claim time
+        Assert.Null(bPeriod.EndedAt);
+    }
+}


### PR DESCRIPTION
## Summary

Sensor telemetry reads were filtered only by `SensorId` with a binary access check, so a new owner of a re-claimed or resold sensor could read the **previous owner's entire history**. The same leak existed on the battery-health endpoints and the GDPR data export.

This adds an ownership-window model and bounds every telemetry read to the caller's own ownership period(s):

- New `SensorOwnershipPeriod(Id, UserId, SensorId, StartedAt, EndedAt?)` — one row per user/sensor ownership stint.
- A user sees telemetry only inside their **own** period(s) (an allowlist), so removing one ex-owner never widens another user's view.
- First-ever owner starts at an epoch sentinel (1970-01-01) → keeps full history; every later (resale) owner starts at claim time → never sees the previous owner's readings.
- Periods open on claim, close on unclaim. Admins are unaffected.
- Read sites bounded: `SensorController` (`GetSensorData`, `GetMultipleSensorsData`, `GetLatestSensorData`, the raw-SQL averaged path), `BatteryHealthController` (latest health, charge events, calibration read), and `UserController.ExportData` (readings + battery health).
- **Backfill:** existing ownerships become open epoch-start periods, so current users see no behaviour change at rollout — the boundary only takes effect for future re-claims.

5 new tests cover resale isolation, admin bypass, latest-in-window, and period lifecycle on claim/unclaim/re-claim. Full suite: 281 passing.

Follow-up (separate PR): same ownership-window for switch data (`SwitchData`, `SwitchesController`).
