### PR TITLE
feat: anonymized telemetry store + anonymization routine

### DIFF
--- a/Migrations/20260520175425_AddAnonymizedTelemetry.Designer.cs
+++ b/Migrations/20260520175425_AddAnonymizedTelemetry.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260520175425_AddAnonymizedTelemetry")]
+    partial class AddAnonymizedTelemetry
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260520175425_AddAnonymizedTelemetry.cs
+++ b/Migrations/20260520175425_AddAnonymizedTelemetry.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAnonymizedTelemetry : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AnonymizedSeries",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    SourceType = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    CalibrationOffsetV = table.Column<float>(type: "real", nullable: true),
+                    AnonymizedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AnonymizedSeries", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AnonymizedReadings",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    SeriesId = table.Column<long>(type: "bigint", nullable: false),
+                    Value = table.Column<double>(type: "double precision", nullable: false),
+                    Timestamp = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AnonymizedReadings", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AnonymizedReadings_AnonymizedSeries_SeriesId",
+                        column: x => x.SeriesId,
+                        principalTable: "AnonymizedSeries",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AnonymizedReadings_SeriesId_Timestamp",
+                table: "AnonymizedReadings",
+                columns: new[] { "SeriesId", "Timestamp" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AnonymizedReadings");
+
+            migrationBuilder.DropTable(
+                name: "AnonymizedSeries");
+        }
+    }
+}

--- a/Models/Anonymized/AnonymizedReading.cs
+++ b/Models/Anonymized/AnonymizedReading.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace garge_api.Models.Anonymized
+{
+    /// <summary>
+    /// One anonymized reading belonging to an <see cref="AnonymizedSeries"/>. Numeric for every
+    /// source type: sensor values are parsed from their string form; switch on/off maps to 1/0.
+    /// Carries no device or user identifier — only the surrogate <see cref="SeriesId"/>.
+    /// </summary>
+    public class AnonymizedReading
+    {
+        public long Id { get; set; }
+
+        public long SeriesId { get; set; }
+
+        [ForeignKey(nameof(SeriesId))]
+        public AnonymizedSeries? Series { get; set; }
+
+        public double Value { get; set; }
+
+        public DateTime Timestamp { get; set; }
+    }
+}

--- a/Models/Anonymized/AnonymizedSeries.cs
+++ b/Models/Anonymized/AnonymizedSeries.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace garge_api.Models.Anonymized
+{
+    /// <summary>
+    /// A single anonymized telemetry series: the readings from one device over one ownership stint,
+    /// retained indefinitely for ML once the personal copy passes its retention cap (or on erasure).
+    ///
+    /// <para><see cref="Id"/> is a fresh surrogate key with NO stored mapping back to the original
+    /// SensorId/SwitchId/UserId, so a later re-claim of the same physical device cannot rejoin this
+    /// data. Series are kept independent (never cross-linked by site/gateway) to avoid re-creating a
+    /// household fingerprint. This data is only anonymous while that holds — see the GDPR notes.</para>
+    /// </summary>
+    public class AnonymizedSeries
+    {
+        public long Id { get; set; }
+
+        /// <summary>voltage | temperature | humidity | socket</summary>
+        [Required]
+        [MaxLength(50)]
+        public required string SourceType { get; set; }
+
+        /// <summary>Per-sensor voltage calibration offset (voltage series only) so regenerated voltage matches.</summary>
+        public float? CalibrationOffsetV { get; set; }
+
+        public DateTime AnonymizedAt { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/Models/ApplicationDbContext.cs
+++ b/Models/ApplicationDbContext.cs
@@ -57,6 +57,8 @@ namespace garge_api.Models
         public DbSet<OrderItem> OrderItems { get; set; }
         public DbSet<Invoice> Invoices { get; set; }
         public DbSet<ProcessedWebhookEvent> ProcessedWebhookEvents { get; set; }
+        public DbSet<Anonymized.AnonymizedSeries> AnonymizedSeries { get; set; }
+        public DbSet<Anonymized.AnonymizedReading> AnonymizedReadings { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -229,6 +231,15 @@ namespace garge_api.Models
                 .HasOne(p => p.Switch)
                 .WithMany()
                 .HasForeignKey(p => p.SwitchId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<Anonymized.AnonymizedReading>()
+                .HasIndex(r => new { r.SeriesId, r.Timestamp });
+
+            modelBuilder.Entity<Anonymized.AnonymizedReading>()
+                .HasOne(r => r.Series)
+                .WithMany()
+                .HasForeignKey(r => r.SeriesId)
                 .OnDelete(DeleteBehavior.Cascade);
 
             modelBuilder.Entity<UserSwitch>()

--- a/Program.cs
+++ b/Program.cs
@@ -184,6 +184,7 @@ namespace garge_api
             builder.Services.AddSingleton<IAppSettingsCache, AppSettingsCache>();
             builder.Services.AddSingleton<IPdfRenderer, PuppeteerPdfRenderer>();
             builder.Services.AddScoped<IInvoiceService, InvoiceService>();
+            builder.Services.AddScoped<IAnonymizationService, AnonymizationService>();
             builder.Services.AddScoped<IOrderEmailService, OrderEmailService>();
             builder.Services.AddScoped<ISubscriptionEmailService, SubscriptionEmailService>();
             builder.Services.AddHttpClient<IVippsService, VippsService>();

--- a/Services/AnonymizationService.cs
+++ b/Services/AnonymizationService.cs
@@ -1,0 +1,157 @@
+using System.Globalization;
+using garge_api.Models;
+using garge_api.Models.Anonymized;
+using Microsoft.EntityFrameworkCore;
+
+namespace garge_api.Services
+{
+    /// <summary>
+    /// Moves a device's telemetry for one ownership stint into the anonymized ML store and deletes the
+    /// personal originals. Used by the retention cap, GDPR erasure, and account deletion. The new
+    /// <see cref="AnonymizedSeries"/> has no stored link back to the device or user, so the data leaves
+    /// GDPR scope and a future re-claim of the same physical device cannot rejoin it.
+    /// </summary>
+    public interface IAnonymizationService
+    {
+        /// <summary>Anonymize the telemetry exclusive to a sensor ownership period, then delete the period. Returns readings moved.</summary>
+        Task<int> AnonymizeSensorPeriodAsync(int periodId, CancellationToken ct = default);
+
+        /// <summary>Anonymize the telemetry exclusive to a switch ownership period, then delete the period. Returns readings moved.</summary>
+        Task<int> AnonymizeSwitchPeriodAsync(int periodId, CancellationToken ct = default);
+    }
+
+    public class AnonymizationService : IAnonymizationService
+    {
+        private readonly ApplicationDbContext _db;
+        private readonly ILogger<AnonymizationService> _logger;
+
+        public AnonymizationService(ApplicationDbContext db, ILogger<AnonymizationService> logger)
+        {
+            _db = db;
+            _logger = logger;
+        }
+
+        public async Task<int> AnonymizeSensorPeriodAsync(int periodId, CancellationToken ct = default)
+        {
+            var period = await _db.SensorOwnershipPeriods.FirstOrDefaultAsync(p => p.Id == periodId, ct);
+            if (period == null) return 0;
+
+            var sensorId = period.SensorId;
+            var start = period.StartedAt;
+            var end = period.EndedAt ?? DateTime.UtcNow;
+
+            // Telemetry exclusive to this period: inside [start, end) and not covered by any OTHER
+            // ownership period (an open period covers through the present). Co-owned ranges stay put.
+            var exclusive = await _db.SensorData
+                .Where(sd => sd.SensorId == sensorId && sd.Timestamp >= start && sd.Timestamp < end
+                    && !_db.SensorOwnershipPeriods.Any(q => q.Id != period.Id && q.SensorId == sensorId
+                        && sd.Timestamp >= q.StartedAt && (q.EndedAt == null || sd.Timestamp < q.EndedAt)))
+                .OrderBy(sd => sd.Timestamp)
+                .ToListAsync(ct);
+
+            var moved = 0;
+            if (exclusive.Count > 0)
+            {
+                var sensor = await _db.Sensors.FirstOrDefaultAsync(s => s.Id == sensorId, ct);
+                var series = new AnonymizedSeries
+                {
+                    SourceType = sensor?.Type ?? "unknown",
+                    CalibrationOffsetV = sensor?.Type == "voltage" ? sensor?.CalibrationOffsetV : null,
+                    AnonymizedAt = DateTime.UtcNow
+                };
+                _db.AnonymizedSeries.Add(series);
+                await _db.SaveChangesAsync(ct); // assigns series.Id
+
+                foreach (var sd in exclusive)
+                {
+                    if (!TryParseValue(sd.Value, out var value)) continue;
+                    _db.AnonymizedReadings.Add(new AnonymizedReading { SeriesId = series.Id, Value = value, Timestamp = sd.Timestamp });
+                    moved++;
+                }
+                _db.SensorData.RemoveRange(exclusive);
+            }
+
+            // Derived battery data in the exclusive range is regenerable from raw voltage — drop it.
+            var batteryHealth = await _db.BatteryHealthData
+                .Where(b => b.SensorId == sensorId && b.Timestamp >= start && b.Timestamp < end
+                    && !_db.SensorOwnershipPeriods.Any(q => q.Id != period.Id && q.SensorId == sensorId
+                        && b.Timestamp >= q.StartedAt && (q.EndedAt == null || b.Timestamp < q.EndedAt)))
+                .ToListAsync(ct);
+            _db.BatteryHealthData.RemoveRange(batteryHealth);
+
+            var chargeEvents = await _db.BatteryChargeEvents
+                .Where(e => e.SensorId == sensorId && e.StartedAt >= start && e.StartedAt < end
+                    && !_db.SensorOwnershipPeriods.Any(q => q.Id != period.Id && q.SensorId == sensorId
+                        && e.StartedAt >= q.StartedAt && (q.EndedAt == null || e.StartedAt < q.EndedAt)))
+                .ToListAsync(ct);
+            _db.BatteryChargeEvents.RemoveRange(chargeEvents);
+
+            _db.SensorOwnershipPeriods.Remove(period);
+            await _db.SaveChangesAsync(ct);
+
+            _logger.LogInformation("Anonymized sensor period {PeriodId} (sensor {SensorId}): moved {Moved} readings", periodId, sensorId, moved);
+            return moved;
+        }
+
+        public async Task<int> AnonymizeSwitchPeriodAsync(int periodId, CancellationToken ct = default)
+        {
+            var period = await _db.SwitchOwnershipPeriods.FirstOrDefaultAsync(p => p.Id == periodId, ct);
+            if (period == null) return 0;
+
+            var switchId = period.SwitchId;
+            var start = period.StartedAt;
+            var end = period.EndedAt ?? DateTime.UtcNow;
+
+            var exclusive = await _db.SwitchData
+                .Where(sd => sd.SwitchId == switchId && sd.Timestamp >= start && sd.Timestamp < end
+                    && !_db.SwitchOwnershipPeriods.Any(q => q.Id != period.Id && q.SwitchId == switchId
+                        && sd.Timestamp >= q.StartedAt && (q.EndedAt == null || sd.Timestamp < q.EndedAt)))
+                .OrderBy(sd => sd.Timestamp)
+                .ToListAsync(ct);
+
+            var moved = 0;
+            if (exclusive.Count > 0)
+            {
+                var switchEntity = await _db.Switches.FirstOrDefaultAsync(s => s.Id == switchId, ct);
+                var series = new AnonymizedSeries
+                {
+                    SourceType = switchEntity?.Type ?? "socket",
+                    AnonymizedAt = DateTime.UtcNow
+                };
+                _db.AnonymizedSeries.Add(series);
+                await _db.SaveChangesAsync(ct);
+
+                foreach (var sd in exclusive)
+                {
+                    if (!TryParseValue(sd.Value, out var value)) continue;
+                    _db.AnonymizedReadings.Add(new AnonymizedReading { SeriesId = series.Id, Value = value, Timestamp = sd.Timestamp });
+                    moved++;
+                }
+                _db.SwitchData.RemoveRange(exclusive);
+            }
+
+            _db.SwitchOwnershipPeriods.Remove(period);
+            await _db.SaveChangesAsync(ct);
+
+            _logger.LogInformation("Anonymized switch period {PeriodId} (switch {SwitchId}): moved {Moved} readings", periodId, switchId, moved);
+            return moved;
+        }
+
+        /// <summary>Numeric for every source: parses sensor numbers; maps switch on/true → 1, off/false → 0.</summary>
+        internal static bool TryParseValue(string? raw, out double value)
+        {
+            if (double.TryParse(raw, NumberStyles.Any, CultureInfo.InvariantCulture, out value)) return true;
+            switch (raw?.Trim().ToLowerInvariant())
+            {
+                case "on":
+                case "true":
+                    value = 1; return true;
+                case "off":
+                case "false":
+                    value = 0; return true;
+            }
+            value = 0;
+            return false;
+        }
+    }
+}

--- a/garge-api.Tests/AnonymizationServiceTests.cs
+++ b/garge-api.Tests/AnonymizationServiceTests.cs
@@ -1,0 +1,110 @@
+using garge_api.Models.Anonymized;
+using garge_api.Models.Sensor;
+using garge_api.Models.Switch;
+using garge_api.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace garge_api.Tests;
+
+/// <summary>
+/// Verifies the anonymize-to-ML-store routine: telemetry exclusive to an ownership period is copied
+/// into AnonymizedSeries/AnonymizedReading (no link back), originals + regenerable battery data are
+/// deleted, and co-owned ranges are preserved. Switch on/off maps to 1/0.
+/// </summary>
+public class AnonymizationServiceTests : ControllerTestBase
+{
+    private AnonymizationService Service(Models.ApplicationDbContext db) =>
+        new(db, NullLogger<AnonymizationService>.Instance);
+
+    private static readonly DateTime Jan = new(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime Mar = new(2020, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime Apr = new(2020, 4, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime Jun = new(2020, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime Jul = new(2020, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime Sep = new(2020, 9, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task AnonymizeSensorPeriod_MovesExclusiveReadings_DeletesOriginalsAndDerived()
+    {
+        using var db = CreateDbContext();
+        db.Sensors.Add(new Sensor { Id = 1, Name = "garge_volt", Type = "voltage", Role = "sensor", RegistrationCode = "rc", DefaultName = "Battery", ParentName = "gw", CalibrationOffsetV = 0.5f });
+        var period = new SensorOwnershipPeriod { UserId = "user-A", SensorId = 1, StartedAt = Jan, EndedAt = Jun };
+        db.SensorOwnershipPeriods.Add(period);
+        db.SensorData.AddRange(
+            new SensorData { SensorId = 1, Value = "12.5", Timestamp = new DateTime(2020, 2, 1, 0, 0, 0, DateTimeKind.Utc) },
+            new SensorData { SensorId = 1, Value = "12.6", Timestamp = Mar },
+            new SensorData { SensorId = 1, Value = "12.7", Timestamp = Apr },
+            new SensorData { SensorId = 1, Value = "13.0", Timestamp = Jul }); // outside the period window
+        db.BatteryHealthData.Add(new BatteryHealth { SensorId = 1, Status = "ok", Timestamp = Mar });
+        await db.SaveChangesAsync();
+
+        var moved = await Service(db).AnonymizeSensorPeriodAsync(period.Id);
+
+        Assert.Equal(3, moved);
+        var series = Assert.Single(db.AnonymizedSeries);
+        Assert.Equal("voltage", series.SourceType);
+        Assert.Equal(0.5f, series.CalibrationOffsetV);
+        Assert.Equal(3, db.AnonymizedReadings.Count());
+        Assert.Contains(db.AnonymizedReadings, r => r.Value == 12.5);
+        Assert.Single(db.SensorData); // only the out-of-window Jul row remains
+        Assert.Empty(db.BatteryHealthData); // derived data dropped (regenerable)
+        Assert.Empty(db.SensorOwnershipPeriods); // period consumed
+    }
+
+    [Fact]
+    public async Task AnonymizeSensorPeriod_KeepsCoOwnedRange()
+    {
+        using var db = CreateDbContext();
+        db.Sensors.Add(new Sensor { Id = 1, Name = "garge_volt", Type = "voltage", Role = "sensor", RegistrationCode = "rc", DefaultName = "Battery", ParentName = "gw" });
+        var pA = new SensorOwnershipPeriod { UserId = "user-A", SensorId = 1, StartedAt = Jan, EndedAt = Jun };
+        var pB = new SensorOwnershipPeriod { UserId = "user-B", SensorId = 1, StartedAt = Mar, EndedAt = Sep }; // overlaps Mar..Jun
+        db.SensorOwnershipPeriods.AddRange(pA, pB);
+        db.SensorData.AddRange(
+            new SensorData { SensorId = 1, Value = "1", Timestamp = new DateTime(2020, 2, 1, 0, 0, 0, DateTimeKind.Utc) }, // only A
+            new SensorData { SensorId = 1, Value = "2", Timestamp = Apr }); // A and B overlap
+        await db.SaveChangesAsync();
+
+        var moved = await Service(db).AnonymizeSensorPeriodAsync(pA.Id);
+
+        Assert.Equal(1, moved); // only the A-exclusive Feb row
+        Assert.Single(db.SensorData); // Feb moved out; the co-owned Apr row stays — B is still entitled
+        Assert.Equal(Apr, db.SensorData.Single().Timestamp);
+        Assert.Single(db.SensorOwnershipPeriods); // pB remains
+    }
+
+    [Fact]
+    public async Task AnonymizeSwitchPeriod_MapsOnOffToOneZero()
+    {
+        using var db = CreateDbContext();
+        db.Switches.Add(new Switch { Id = 1, Name = "garge_socket", Type = "socket", Role = "switch", RegistrationCode = "rc" });
+        var period = new SwitchOwnershipPeriod { UserId = "user-A", SwitchId = 1, StartedAt = Jan, EndedAt = Jun };
+        db.SwitchOwnershipPeriods.Add(period);
+        db.SwitchData.AddRange(
+            new SwitchData { SwitchId = 1, Value = "on", Timestamp = new DateTime(2020, 2, 1, 0, 0, 0, DateTimeKind.Utc) },
+            new SwitchData { SwitchId = 1, Value = "off", Timestamp = Mar },
+            new SwitchData { SwitchId = 1, Value = "garbage", Timestamp = Apr });
+        await db.SaveChangesAsync();
+
+        var moved = await Service(db).AnonymizeSwitchPeriodAsync(period.Id);
+
+        Assert.Equal(2, moved); // garbage dropped
+        var series = Assert.Single(db.AnonymizedSeries);
+        Assert.Equal("socket", series.SourceType);
+        Assert.Equal(new[] { 1.0, 0.0 }, db.AnonymizedReadings.OrderBy(r => r.Timestamp).Select(r => r.Value));
+        Assert.Empty(db.SwitchData);
+        Assert.Empty(db.SwitchOwnershipPeriods);
+    }
+
+    [Theory]
+    [InlineData("12.5", true, 12.5)]
+    [InlineData("on", true, 1)]
+    [InlineData("OFF", true, 0)]
+    [InlineData("true", true, 1)]
+    [InlineData("nonsense", false, 0)]
+    public void TryParseValue_HandlesNumbersAndOnOff(string raw, bool ok, double expected)
+    {
+        Assert.Equal(ok, AnonymizationService.TryParseValue(raw, out var value));
+        if (ok) Assert.Equal(expected, value);
+    }
+}


### PR DESCRIPTION
## Summary

First piece of the retention/ML pipeline: the forever-retained **anonymized telemetry store** and the routine that fills it. Callable, not yet triggered (wiring to account deletion, GDPR erasure, and the cap-purge come in follow-ups).

**Store (2 tables, device-agnostic):**
- `AnonymizedSeries(Id surrogate, SourceType [voltage/temperature/humidity/socket], CalibrationOffsetV?, AnonymizedAt)`
- `AnonymizedReading(Id, SeriesId, Value double, Timestamp)`
- No stored mapping back to `SensorId`/`SwitchId`/`UserId` → out of GDPR scope; a future re-claim of the same physical device cannot rejoin it. Series are independent (never cross-linked by site) to avoid re-creating a household fingerprint.

**`AnonymizationService`:** moves the telemetry **exclusive** to one ownership period into a new series, then deletes the personal originals plus the regenerable `BatteryHealth`/`BatteryChargeEvent` rows. Co-owned ranges (overlapping periods) are preserved. Sensor values parse as numbers; switch `on/off` → `1/0`. Battery health is **not** stored — regenerated from raw voltage on demand.

8 new tests: exclusive move + delete of originals/derived, co-owned range preserved, switch on/off mapping, value parsing. Full suite: 294 passing.

**Guardrail (per GDPR review):** keep-forever applies only to this anonymized copy — personal data is kept for the lifetime of the claim with a user opt-out (Art. 21) that triggers a 6-month cap once the subscription lapses (later PRs); series must stay un-cross-linked; absolute timestamps + per-device series require a DPO-signed re-identification assessment before launch.

> Stacked on #250 → #249. Retarget to `main` once those merge.
