### PR TITLE
feat: enforce sensor suspension - read-gating + toggle

### DIFF
--- a/Authorization/ActiveSubscriptionHandler.cs
+++ b/Authorization/ActiveSubscriptionHandler.cs
@@ -1,40 +1,31 @@
 using garge_api.Constants;
-using garge_api.Models;
-using garge_api.Models.Sensor;
-using garge_api.Models.Subscription;
+using garge_api.Services;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Memory;
-using System.Security.Claims;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace garge_api.Authorization
 {
     /// <summary>
     /// Allows a claim when the user has room for one more owned sensor under their current subscriptions.
     ///
-    /// Capacity model:
+    /// Capacity model (see <see cref="ISubscriptionCapacityService"/> for the single source of truth):
     ///   - An active Primary subscription grants a base allowance of 1 owned sensor.
     ///   - Each active AddOn subscription contributes its Quantity to the allowance.
     ///   - Without an active Primary, capacity is 0 — AddOns alone are not enough.
+    ///   - A cancelled subscription still counts during its paid-period grace (future NextChargeDate).
+    ///   - Only ACTIVE (non-suspended) owned sensors consume capacity.
     ///
-    /// A claim is allowed when ownedSensorCount &lt; capacity. Shared access (UserSensor.IsOwner = false)
-    /// is not counted toward ownedSensorCount, so the owner's subscription covers shared viewers.
-    ///
-    /// This handler only runs on the few endpoints that take new ownership (sensor/switch claim). Reads,
-    /// unclaim, profile, and account deletion are gated by [Authorize] alone so a user who drops out of
-    /// quota can still see their account and unclaim sensors to recover.
+    /// A claim is allowed when active owned sensors &lt; capacity. This handler only runs on the few
+    /// endpoints that take new ownership (sensor/switch claim). Reads, unclaim, profile, and account
+    /// deletion are gated by [Authorize] alone so a user who drops out of quota can still recover.
     /// </summary>
     public class ActiveSubscriptionHandler : AuthorizationHandler<ActiveSubscriptionRequirement>
     {
         private readonly IServiceScopeFactory _scopeFactory;
-        private readonly IMemoryCache _cache;
 
-        private const string TestModeCacheKey = "vipps_test_mode";
-
-        public ActiveSubscriptionHandler(IServiceScopeFactory scopeFactory, IMemoryCache cache)
+        public ActiveSubscriptionHandler(IServiceScopeFactory scopeFactory)
         {
             _scopeFactory = scopeFactory;
-            _cache = cache;
         }
 
         protected override async Task HandleRequirementAsync(
@@ -51,40 +42,12 @@ namespace garge_api.Authorization
             }
 
             using var scope = _scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var capacityService = scope.ServiceProvider.GetRequiredService<ISubscriptionCapacityService>();
 
-            if (!_cache.TryGetValue(TestModeCacheKey, out bool isTestMode))
-            {
-                var settings = await db.AppSettings.FindAsync(1);
-                isTestMode = settings?.VippsTestMode ?? false;
-                _cache.Set(TestModeCacheKey, isTestMode, TimeSpan.FromSeconds(30));
-            }
+            var capacity = await capacityService.GetCapacityAsync(userId);
+            var activeOwned = await capacityService.GetActiveOwnedSensorCountAsync(userId);
 
-            // Only ACTIVE (non-suspended) owned sensors consume capacity: turning a sensor off frees
-            // a slot, and over-quota sensors are suspended rather than counted.
-            var ownedSensorCount = await db.UserSensors.CountAsync(us => us.UserId == userId && us.IsOwner && us.SuspendedAt == null);
-
-            // A subscription contributes to capacity while Active, OR during the paid-period grace
-            // after cancel/lapse — i.e. a Stopped/Expired sub whose NextChargeDate is still in the
-            // future. The user paid through that date, so access continues until then.
-            var now = DateTime.UtcNow;
-            var activeSubs = await db.Subscriptions
-                .Where(s => s.UserId == userId
-                         && (!s.IsTest || isTestMode)
-                         && (s.Status == SubscriptionStatus.Active
-                             || ((s.Status == SubscriptionStatus.Stopped || s.Status == SubscriptionStatus.Expired)
-                                 && s.NextChargeDate != null && s.NextChargeDate > now)))
-                .Select(s => new { Type = s.Product!.Type, s.Quantity })
-                .ToListAsync();
-
-            var primaryActive = activeSubs.Any(s => s.Type == ProductType.Primary);
-            var addOnCapacity = activeSubs
-                .Where(s => s.Type == ProductType.AddOn)
-                .Sum(s => s.Quantity);
-
-            var capacity = primaryActive ? 1 + addOnCapacity : 0;
-
-            if (ownedSensorCount < capacity)
+            if (activeOwned < capacity)
                 context.Succeed(requirement);
         }
     }

--- a/Controllers/BatteryHealthController.cs
+++ b/Controllers/BatteryHealthController.cs
@@ -77,6 +77,14 @@ namespace garge_api.Controllers
                 && sd.Timestamp >= p.StartedAt && (p.EndedAt == null || sd.Timestamp < p.EndedAt)));
         }
 
+        /// <summary>True when the caller has this owned sensor suspended (turned off / over quota). Admins are never suspended.</summary>
+        private async Task<bool> IsSensorSuspendedForCallerAsync(int sensorId)
+        {
+            if (IsAdmin()) return false;
+            var userId = User.UserId();
+            return await _context.UserSensors.AnyAsync(us => us.UserId == userId && us.SensorId == sensorId && us.SuspendedAt != null);
+        }
+
         /// <summary>
         /// Returns the latest battery health record for the voltage sensor identified by name.
         /// </summary>
@@ -101,6 +109,9 @@ namespace garge_api.Controllers
                 _logger.LogWarning("GetLatestBatteryHealth forbidden for {@LogData}", new { CallerUserId = User.UserId(), SensorName = LogSanitizer.Sanitize(sensorName) });
                 return Forbid();
             }
+
+            if (await IsSensorSuspendedForCallerAsync(sensor.Id))
+                return StatusCode(403, new { message = "Sensor is suspended. Re-subscribe or turn it back on to view its data.", suspended = true });
 
             var latest = await WithinOwnershipWindow(
                     _context.BatteryHealthData.Where(bh => bh.SensorId == sensor.Id))
@@ -127,6 +138,8 @@ namespace garge_api.Controllers
             var sensor = await _context.Sensors.FirstOrDefaultAsync(s => s.Name == sensorName);
             if (sensor == null) return NotFound(new { message = "Sensor not found!" });
             if (!await UserCanAccessSensorAsync(sensor.Id)) return Forbid();
+            if (await IsSensorSuspendedForCallerAsync(sensor.Id))
+                return StatusCode(403, new { message = "Sensor is suspended. Re-subscribe or turn it back on to view its data.", suspended = true });
 
             var query = WithinOwnershipWindow(_context.BatteryChargeEvents.Where(e => e.SensorId == sensor.Id));
             if (since.HasValue) query = query.Where(e => e.StartedAt >= since.Value);

--- a/Controllers/SensorController.cs
+++ b/Controllers/SensorController.cs
@@ -30,15 +30,17 @@ namespace garge_api.Controllers
         private readonly ILogger<SensorController> _logger;
         private readonly IDeviceOwnershipService _ownership;
         private readonly IHubContext<DeviceHub> _hub;
+        private readonly ISubscriptionCapacityService _capacity;
         private static readonly List<string> AdminRoles = new() { "SensorAdmin", "admin" };
 
-        public SensorController(ApplicationDbContext context, IMapper mapper, ILogger<SensorController> logger, IDeviceOwnershipService ownership, IHubContext<DeviceHub> hub)
+        public SensorController(ApplicationDbContext context, IMapper mapper, ILogger<SensorController> logger, IDeviceOwnershipService ownership, IHubContext<DeviceHub> hub, ISubscriptionCapacityService capacity)
         {
             _context = context;
             _mapper = mapper;
             _logger = logger;
             _ownership = ownership;
             _hub = hub;
+            _capacity = capacity;
         }
 
         private bool IsAdmin()
@@ -74,6 +76,30 @@ namespace garge_api.Controllers
         }
 
         /// <summary>
+        /// True when the caller has this owned sensor suspended (turned off / over quota). Suspended
+        /// sensors stay visible in the list but their dashboard/history reads are blocked. Admins are
+        /// never suspended. Export and unclaim/delete must never use this gate (GDPR rights).
+        /// </summary>
+        private async Task<bool> IsSensorSuspendedForCallerAsync(int sensorId)
+        {
+            if (IsAdmin()) return false;
+            var userId = User.UserId();
+            return await _context.UserSensors.AnyAsync(us => us.UserId == userId && us.SensorId == sensorId && us.SuspendedAt != null);
+        }
+
+        /// <summary>Of the given sensor ids, the subset the caller has suspended (empty for admins).</summary>
+        private async Task<HashSet<int>> CallerSuspendedSensorIdsAsync(IEnumerable<int> sensorIds)
+        {
+            if (IsAdmin()) return new HashSet<int>();
+            var userId = User.UserId();
+            var ids = await _context.UserSensors
+                .Where(us => us.UserId == userId && us.SuspendedAt != null && sensorIds.Contains(us.SensorId))
+                .Select(us => us.SensorId)
+                .ToListAsync();
+            return ids.ToHashSet();
+        }
+
+        /// <summary>
         /// Retrieves all sensors the user has access to.
         /// </summary>
         /// <returns>A list of sensors the user has access to.</returns>
@@ -103,12 +129,15 @@ namespace garge_api.Controllers
                 .Where(x => x.UserId == currentUserId)
                 .ToDictionaryAsync(x => x.SensorId, x => x.CustomName);
 
-            // Map sensors and inject the user-specific custom name
+            var suspendedIds = await CallerSuspendedSensorIdsAsync(sensors.Select(s => s.Id).ToList());
+
+            // Map sensors and inject the user-specific custom name + suspended state
             var dtos = sensors.Select(sensor =>
             {
                 var dto = _mapper.Map<SensorDto>(sensor);
                 if (customNames.TryGetValue(sensor.Id, out var customName))
                     dto.CustomName = customName;
+                dto.Suspended = suspendedIds.Contains(sensor.Id);
                 return dto;
             }).ToList();
 
@@ -154,6 +183,8 @@ namespace garge_api.Controllers
             if (!string.IsNullOrEmpty(customName))
                 dto.CustomName = customName;
 
+            dto.Suspended = await IsSensorSuspendedForCallerAsync(id);
+
             _logger.LogInformation("Returning sensor {@LogData}", new { id, CallerUserId = User.UserId() });
             return Ok(dto);
         }
@@ -193,6 +224,9 @@ namespace garge_api.Controllers
                 _logger.LogWarning("GetSensorData forbidden for {@LogData}", new { CallerUserId = User.UserId(), sensorId });
                 return Forbid();
             }
+
+            if (await IsSensorSuspendedForCallerAsync(sensor.Id))
+                return StatusCode(403, new { message = "Sensor is suspended. Re-subscribe or turn it back on to view its data.", suspended = true });
 
             var query = WithinOwnershipWindow(
                 _context.SensorData.Where(sd => sd.SensorId == sensorId));
@@ -287,8 +321,12 @@ namespace garge_api.Controllers
                 }
             }
 
+            // Suspended sensors stay out of the batch (the caller can't read their data while off).
+            var suspendedIds = await CallerSuspendedSensorIdsAsync(sensorIds);
+            var visibleSensorIds = sensorIds.Where(sid => !suspendedIds.Contains(sid)).ToList();
+
             var query = WithinOwnershipWindow(
-                _context.SensorData.Where(sd => sensorIds.Contains(sd.SensorId)));
+                _context.SensorData.Where(sd => visibleSensorIds.Contains(sd.SensorId)));
 
             DateTime? effectiveStart = null;
             DateTime? effectiveEnd = null;
@@ -315,7 +353,7 @@ namespace garge_api.Controllers
             var groupBySpan = !string.IsNullOrEmpty(groupBy) ? ParseTimeRange(groupBy) : null;
             if (groupBySpan.HasValue)
             {
-                var grouped = await GetAveragedDataAsync(sensorIds, (long)groupBySpan.Value.TotalSeconds, effectiveStart, effectiveEnd, User.UserId(), IsAdmin());
+                var grouped = await GetAveragedDataAsync(visibleSensorIds, (long)groupBySpan.Value.TotalSeconds, effectiveStart, effectiveEnd, User.UserId(), IsAdmin());
                 totalCount = grouped.Count;
                 result = grouped;
             }
@@ -663,6 +701,58 @@ namespace garge_api.Controllers
 
             _logger.LogInformation("Sensor unclaimed by user {@LogData}", new { CallerUserId = User.UserId(), id });
             return Ok(new { message = "Sensor removed from your account." });
+        }
+
+        /// <summary>Owner turns a sensor off: blocks its data reads and frees a quota slot. Always allowed.</summary>
+        [HttpPost("{id}/suspend")]
+        [Authorize]
+        [SwaggerOperation(Summary = "Suspend (turn off) an owned sensor.")]
+        [SwaggerResponse(200, "Sensor suspended.")]
+        [SwaggerResponse(404, "Sensor not owned by the caller.")]
+        public async Task<IActionResult> SuspendSensor(int id)
+        {
+            var userId = User.UserId();
+            var userSensor = await _context.UserSensors.FirstOrDefaultAsync(us => us.UserId == userId && us.SensorId == id && us.IsOwner);
+            if (userSensor == null)
+                return NotFound(new { message = "You do not own this sensor." });
+
+            if (userSensor.SuspendedAt == null)
+            {
+                userSensor.SuspendedAt = DateTime.UtcNow;
+                await _context.SaveChangesAsync();
+                _ownership.InvalidateSensor(id);
+                _logger.LogInformation("Sensor suspended by user {@LogData}", new { CallerUserId = User.UserId(), id });
+            }
+            return Ok(new { message = "Sensor turned off.", suspended = true });
+        }
+
+        /// <summary>Owner turns a sensor back on. Rejected if it would exceed the current plan capacity.</summary>
+        [HttpPost("{id}/activate")]
+        [Authorize]
+        [SwaggerOperation(Summary = "Activate (turn on) an owned sensor.")]
+        [SwaggerResponse(200, "Sensor activated.")]
+        [SwaggerResponse(400, "Activating would exceed the plan limit.")]
+        [SwaggerResponse(404, "Sensor not owned by the caller.")]
+        public async Task<IActionResult> ActivateSensor(int id)
+        {
+            var userId = User.UserId();
+            var userSensor = await _context.UserSensors.FirstOrDefaultAsync(us => us.UserId == userId && us.SensorId == id && us.IsOwner);
+            if (userSensor == null)
+                return NotFound(new { message = "You do not own this sensor." });
+
+            if (userSensor.SuspendedAt != null)
+            {
+                var capacity = await _capacity.GetCapacityAsync(userId!);
+                var activeOwned = await _capacity.GetActiveOwnedSensorCountAsync(userId!);
+                if (activeOwned >= capacity)
+                    return BadRequest(new { message = "Turning this on would exceed your plan. Turn off another sensor or upgrade your subscription." });
+
+                userSensor.SuspendedAt = null;
+                await _context.SaveChangesAsync();
+                _ownership.InvalidateSensor(id);
+                _logger.LogInformation("Sensor activated by user {@LogData}", new { CallerUserId = User.UserId(), id });
+            }
+            return Ok(new { message = "Sensor turned on.", suspended = false });
         }
 
         private static string GenerateDefaultName(string originalName)
@@ -1120,6 +1210,9 @@ namespace garge_api.Controllers
                 _logger.LogWarning("GetLatestSensorData forbidden for {@LogData}", new { CallerUserId = User.UserId(), sensorId });
                 return Forbid();
             }
+
+            if (await IsSensorSuspendedForCallerAsync(sensor.Id))
+                return StatusCode(403, new { message = "Sensor is suspended. Re-subscribe or turn it back on to view its data.", suspended = true });
 
             var latestData = await WithinOwnershipWindow(
                     _context.SensorData.Where(sd => sd.SensorId == sensorId))

--- a/Dtos/Sensor/SensorDto.cs
+++ b/Dtos/Sensor/SensorDto.cs
@@ -10,5 +10,8 @@ namespace garge_api.Dtos.Sensor
         public string? CustomName { get; set; }
         public required string DefaultName { get; set; }
         public required string ParentName { get; set; }
+
+        /// <summary>True when the caller has this owned sensor turned off / over-quota suspended. Data reads are blocked while suspended.</summary>
+        public bool Suspended { get; set; }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -183,6 +183,7 @@ namespace garge_api
             builder.Services.AddSingleton<IWebhookSecretProtector, WebhookSecretProtector>();
             builder.Services.AddSingleton<IAppSettingsCache, AppSettingsCache>();
             builder.Services.AddSingleton<IPdfRenderer, PuppeteerPdfRenderer>();
+            builder.Services.AddScoped<ISubscriptionCapacityService, SubscriptionCapacityService>();
             builder.Services.AddScoped<IInvoiceService, InvoiceService>();
             builder.Services.AddScoped<IAnonymizationService, AnonymizationService>();
             builder.Services.AddScoped<IOrderEmailService, OrderEmailService>();

--- a/Services/SubscriptionCapacityService.cs
+++ b/Services/SubscriptionCapacityService.cs
@@ -1,0 +1,62 @@
+using garge_api.Models;
+using garge_api.Models.Sensor;
+using garge_api.Models.Subscription;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace garge_api.Services
+{
+    /// <summary>
+    /// Computes a user's sensor capacity and how much of it is in use. Single source of truth shared
+    /// by the claim authorization handler, the suspend/activate toggle, and the reconciliation job.
+    ///
+    /// Capacity = 1 (an active Primary) + sum of active AddOn quantities. A subscription counts while
+    /// Active, or during the paid-period grace after cancel/lapse (Stopped/Expired with a future
+    /// NextChargeDate). Only ACTIVE (non-suspended) owned sensors consume capacity.
+    /// </summary>
+    public interface ISubscriptionCapacityService
+    {
+        Task<int> GetCapacityAsync(string userId, CancellationToken ct = default);
+        Task<int> GetActiveOwnedSensorCountAsync(string userId, CancellationToken ct = default);
+    }
+
+    public class SubscriptionCapacityService : ISubscriptionCapacityService
+    {
+        private readonly ApplicationDbContext _db;
+        private readonly IMemoryCache _cache;
+        private const string TestModeCacheKey = "vipps_test_mode";
+
+        public SubscriptionCapacityService(ApplicationDbContext db, IMemoryCache cache)
+        {
+            _db = db;
+            _cache = cache;
+        }
+
+        public Task<int> GetActiveOwnedSensorCountAsync(string userId, CancellationToken ct = default)
+            => _db.UserSensors.CountAsync(us => us.UserId == userId && us.IsOwner && us.SuspendedAt == null, ct);
+
+        public async Task<int> GetCapacityAsync(string userId, CancellationToken ct = default)
+        {
+            if (!_cache.TryGetValue(TestModeCacheKey, out bool isTestMode))
+            {
+                var settings = await _db.AppSettings.FindAsync([1], ct);
+                isTestMode = settings?.VippsTestMode ?? false;
+                _cache.Set(TestModeCacheKey, isTestMode, TimeSpan.FromSeconds(30));
+            }
+
+            var now = DateTime.UtcNow;
+            var subs = await _db.Subscriptions
+                .Where(s => s.UserId == userId
+                         && (!s.IsTest || isTestMode)
+                         && (s.Status == SubscriptionStatus.Active
+                             || ((s.Status == SubscriptionStatus.Stopped || s.Status == SubscriptionStatus.Expired)
+                                 && s.NextChargeDate != null && s.NextChargeDate > now)))
+                .Select(s => new { Type = s.Product!.Type, s.Quantity })
+                .ToListAsync(ct);
+
+            var primaryActive = subs.Any(s => s.Type == ProductType.Primary);
+            var addOnCapacity = subs.Where(s => s.Type == ProductType.AddOn).Sum(s => s.Quantity);
+            return primaryActive ? 1 + addOnCapacity : 0;
+        }
+    }
+}

--- a/garge-api.Tests/ActiveSubscriptionHandlerTests.cs
+++ b/garge-api.Tests/ActiveSubscriptionHandlerTests.cs
@@ -1,6 +1,7 @@
 using garge_api.Authorization;
 using garge_api.Models;
 using garge_api.Models.Admin;
+using garge_api.Services;
 using garge_api.Models.Sensor;
 using garge_api.Models.Subscription;
 using Microsoft.AspNetCore.Authorization;
@@ -29,8 +30,11 @@ public class ActiveSubscriptionHandlerTests
             new Product { Id = AddOnProductId,  Name = "AddOn",   PriceInOre = 0, Interval = BillingInterval.Monthly, Type = ProductType.AddOn });
         db.SaveChanges();
 
+        var capacityService = new SubscriptionCapacityService(db, new MemoryCache(new MemoryCacheOptions()));
+
         var serviceProvider = new Mock<IServiceProvider>();
         serviceProvider.Setup(sp => sp.GetService(typeof(ApplicationDbContext))).Returns(db);
+        serviceProvider.Setup(sp => sp.GetService(typeof(ISubscriptionCapacityService))).Returns(capacityService);
 
         var scope = new Mock<IServiceScope>();
         scope.SetupGet(s => s.ServiceProvider).Returns(serviceProvider.Object);
@@ -38,7 +42,7 @@ public class ActiveSubscriptionHandlerTests
         var scopeFactory = new Mock<IServiceScopeFactory>();
         scopeFactory.Setup(f => f.CreateScope()).Returns(scope.Object);
 
-        var handler = new ActiveSubscriptionHandler(scopeFactory.Object, new MemoryCache(new MemoryCacheOptions()));
+        var handler = new ActiveSubscriptionHandler(scopeFactory.Object);
         return (handler, db);
     }
 

--- a/garge-api.Tests/SensorControllerCreateTests.cs
+++ b/garge-api.Tests/SensorControllerCreateTests.cs
@@ -22,10 +22,12 @@ public class SensorControllerCreateTests : ControllerTestBase
         var hub = new Mock<IHubContext<DeviceHub>>();
         hub.SetupGet(h => h.Clients).Returns(clients.Object);
 
+        var capacity = new SubscriptionCapacityService(db, new Microsoft.Extensions.Caching.Memory.MemoryCache(new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions()));
+
         var controller = new SensorController(
             db, MockMapper.Object,
             NullLogger<SensorController>.Instance,
-            ownership, hub.Object);
+            ownership, hub.Object, capacity);
         controller.ControllerContext = MakeControllerContext("admin-1", isAdmin: true);
         return controller;
     }

--- a/garge-api.Tests/SensorOwnershipWindowTests.cs
+++ b/garge-api.Tests/SensorOwnershipWindowTests.cs
@@ -36,8 +36,10 @@ public class SensorOwnershipWindowTests : ControllerTestBase
         var hub = new Mock<IHubContext<DeviceHub>>();
         hub.SetupGet(h => h.Clients).Returns(clients.Object);
 
+        var capacity = new SubscriptionCapacityService(db, new Microsoft.Extensions.Caching.Memory.MemoryCache(new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions()));
+
         var controller = new SensorController(
-            db, MockMapper.Object, NullLogger<SensorController>.Instance, ownership.Object, hub.Object);
+            db, MockMapper.Object, NullLogger<SensorController>.Instance, ownership.Object, hub.Object, capacity);
         controller.ControllerContext = MakeControllerContext(userId, isAdmin);
         return controller;
     }

--- a/garge-api.Tests/SensorSuspensionTests.cs
+++ b/garge-api.Tests/SensorSuspensionTests.cs
@@ -1,0 +1,151 @@
+using garge_api.Controllers;
+using garge_api.Hubs;
+using garge_api.Models;
+using garge_api.Models.Admin;
+using garge_api.Models.Sensor;
+using garge_api.Models.Subscription;
+using garge_api.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace garge_api.Tests;
+
+/// <summary>
+/// Verifies suspension enforcement: suspended sensors block data reads (403 locked) and drop out of
+/// multi-reads, the suspend/activate toggle works, and activating is rejected when over plan capacity.
+/// </summary>
+public class SensorSuspensionTests : ControllerTestBase
+{
+    private SensorController CreateController(ApplicationDbContext db, string userId, bool isAdmin = false)
+    {
+        var ownership = new Mock<IDeviceOwnershipService>();
+        ownership.Setup(o => o.CanUserAccessSensorAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        var proxy = new Mock<IClientProxy>();
+        proxy.Setup(p => p.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        var clients = new Mock<IHubClients>();
+        clients.Setup(c => c.Group(It.IsAny<string>())).Returns(proxy.Object);
+        var hub = new Mock<IHubContext<DeviceHub>>();
+        hub.SetupGet(h => h.Clients).Returns(clients.Object);
+
+        var capacity = new SubscriptionCapacityService(db, new MemoryCache(new MemoryCacheOptions()));
+        var controller = new SensorController(db, MockMapper.Object, NullLogger<SensorController>.Instance, ownership.Object, hub.Object, capacity);
+        controller.ControllerContext = MakeControllerContext(userId, isAdmin);
+        return controller;
+    }
+
+    private static Sensor MakeSensor(int id) => new()
+    {
+        Id = id, Name = $"garge_volt_{id}", Type = "voltage", Role = "sensor",
+        RegistrationCode = $"rc{id}", DefaultName = "Battery", ParentName = "gw"
+    };
+
+    private static readonly DateTime Epoch = SensorOwnershipPeriod.FirstOwnerStart;
+
+    private static int TotalCount(IActionResult result)
+    {
+        var ok = Assert.IsType<OkObjectResult>(result);
+        return (int)ok.Value!.GetType().GetProperty("TotalCount")!.GetValue(ok.Value)!;
+    }
+
+    [Fact]
+    public async Task GetSensorData_SuspendedSensor_Returns403Locked()
+    {
+        using var db = CreateDbContext();
+        db.Sensors.Add(MakeSensor(1));
+        db.UserSensors.Add(new UserSensor { UserId = "u", SensorId = 1, IsOwner = true, SuspendedAt = DateTime.UtcNow });
+        await db.SaveChangesAsync();
+
+        var result = await CreateController(db, "u").GetSensorData(1, null, null, null, groupBy: "");
+
+        var obj = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(403, obj.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetMultipleSensorsData_ExcludesSuspendedSensors()
+    {
+        using var db = CreateDbContext();
+        db.Sensors.AddRange(MakeSensor(1), MakeSensor(2));
+        db.UserSensors.AddRange(
+            new UserSensor { UserId = "u", SensorId = 1, IsOwner = true },
+            new UserSensor { UserId = "u", SensorId = 2, IsOwner = true, SuspendedAt = DateTime.UtcNow });
+        db.SensorOwnershipPeriods.AddRange(
+            new SensorOwnershipPeriod { UserId = "u", SensorId = 1, StartedAt = Epoch, EndedAt = null },
+            new SensorOwnershipPeriod { UserId = "u", SensorId = 2, StartedAt = Epoch, EndedAt = null });
+        db.SensorData.AddRange(
+            new SensorData { SensorId = 1, Value = "1", Timestamp = new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
+            new SensorData { SensorId = 1, Value = "2", Timestamp = new DateTime(2021, 1, 2, 0, 0, 0, DateTimeKind.Utc) },
+            new SensorData { SensorId = 2, Value = "9", Timestamp = new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc) });
+        await db.SaveChangesAsync();
+
+        var result = await CreateController(db, "u").GetMultipleSensorsData(new List<int> { 1, 2 }, null, null, null, groupBy: "");
+
+        Assert.Equal(2, TotalCount(result)); // only sensor 1's rows; suspended sensor 2 excluded
+    }
+
+    [Fact]
+    public async Task SuspendSensor_SetsSuspendedAt()
+    {
+        using var db = CreateDbContext();
+        db.Sensors.Add(MakeSensor(1));
+        db.UserSensors.Add(new UserSensor { UserId = "u", SensorId = 1, IsOwner = true });
+        await db.SaveChangesAsync();
+
+        var result = await CreateController(db, "u").SuspendSensor(1);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.NotNull(db.UserSensors.Single().SuspendedAt);
+    }
+
+    [Fact]
+    public async Task SuspendSensor_NotOwner_Returns404()
+    {
+        using var db = CreateDbContext();
+        var result = await CreateController(db, "u").SuspendSensor(99);
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task ActivateSensor_WithinCapacity_ClearsSuspendedAt()
+    {
+        using var db = CreateDbContext();
+        SeedPrimary(db, "u");
+        db.Sensors.Add(MakeSensor(1));
+        db.UserSensors.Add(new UserSensor { UserId = "u", SensorId = 1, IsOwner = true, SuspendedAt = DateTime.UtcNow });
+        await db.SaveChangesAsync();
+
+        var result = await CreateController(db, "u").ActivateSensor(1);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Null(db.UserSensors.Single().SuspendedAt);
+    }
+
+    [Fact]
+    public async Task ActivateSensor_OverCapacity_Returns400_AndStaysSuspended()
+    {
+        using var db = CreateDbContext();
+        SeedPrimary(db, "u"); // capacity = 1
+        db.Sensors.AddRange(MakeSensor(1), MakeSensor(2));
+        db.UserSensors.AddRange(
+            new UserSensor { UserId = "u", SensorId = 2, IsOwner = true },                              // active -> uses the 1 slot
+            new UserSensor { UserId = "u", SensorId = 1, IsOwner = true, SuspendedAt = DateTime.UtcNow }); // wants to come back on
+        await db.SaveChangesAsync();
+
+        var result = await CreateController(db, "u").ActivateSensor(1);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        Assert.NotNull(db.UserSensors.Single(x => x.SensorId == 1).SuspendedAt); // still off
+    }
+
+    private static void SeedPrimary(ApplicationDbContext db, string userId)
+    {
+        db.AppSettings.Add(new AppSettings { Id = 1 });
+        db.Products.Add(new Product { Id = 1, Name = "Primary", PriceInOre = 0, Interval = BillingInterval.Monthly, Type = ProductType.Primary });
+        db.Subscriptions.Add(new Subscription { UserId = userId, ProductId = 1, VippsAgreementId = "a", Status = SubscriptionStatus.Active, Quantity = 1 });
+    }
+}


### PR DESCRIPTION
## Summary

Suspension PR 2a — enforces suspension (read-gating + owner toggle). Builds on the `SuspendedAt` columns from #253.

- **Capacity service:** extracts the capacity computation into `SubscriptionCapacityService` (single source of truth: active Primary + AddOn quantities, paid-period grace, only active/non-suspended owned sensors). `ActiveSubscriptionHandler` now delegates to it.
- **Read-gating:** suspended sensors block dashboard/history reads — `GetSensorData`, `GetLatestSensorData`, and the battery-health endpoints return **403 with `{ suspended: true }`**; `GetMultipleSensorsData` drops suspended sensors from the batch. The sensor list/detail DTO now carries a `Suspended` flag for the UI's locked state.
- **Toggle endpoints:** `POST /sensors/{id}/suspend` (always allowed — frees a quota slot) and `POST /sensors/{id}/activate` (returns **400** if it would exceed the current plan capacity).
- **GDPR preserved:** export and unclaim/delete are never gated by suspension.

6 new tests (403 on suspended read, multi-read exclusion, suspend sets flag, not-owner 404, activate within/over capacity) and the capacity-service refactor is covered by the existing 12 handler tests. Full suite: 304 passing.

Not included (PR 2b): the daily reconciliation job that auto-suspends the newest excess when a user goes over quota. Switch suspension toggle/gating is also a later follow-up (switches don't consume capacity).

> Stacked on #253 → #252 → #251 → #250 → #249. Retarget to `main` as the stack merges.
