### PR TITLE
feat: daily quota reconciliation job

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -184,6 +184,7 @@ namespace garge_api
             builder.Services.AddSingleton<IAppSettingsCache, AppSettingsCache>();
             builder.Services.AddSingleton<IPdfRenderer, PuppeteerPdfRenderer>();
             builder.Services.AddScoped<ISubscriptionCapacityService, SubscriptionCapacityService>();
+            builder.Services.AddHostedService<QuotaReconciliationService>();
             builder.Services.AddScoped<IInvoiceService, InvoiceService>();
             builder.Services.AddScoped<IAnonymizationService, AnonymizationService>();
             builder.Services.AddScoped<IOrderEmailService, OrderEmailService>();

--- a/Services/QuotaReconciliationService.cs
+++ b/Services/QuotaReconciliationService.cs
@@ -1,0 +1,86 @@
+using garge_api.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace garge_api.Services
+{
+    /// <summary>
+    /// Daily sweep that brings every owner back within their sensor capacity. When a subscription is
+    /// cancelled/downgraded and its paid-period grace lapses, capacity drops below the number of active
+    /// owned sensors; this job auto-suspends the newest excess (keeping the oldest by claim date) so the
+    /// owner stays within plan. The owner can re-pick which sensors are active afterward via the toggle.
+    /// </summary>
+    public class QuotaReconciliationService : BackgroundService
+    {
+        private static readonly TimeSpan Interval = TimeSpan.FromHours(24);
+
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly ILogger<QuotaReconciliationService> _logger;
+
+        public QuotaReconciliationService(IServiceScopeFactory scopeFactory, ILogger<QuotaReconciliationService> logger)
+        {
+            _scopeFactory = scopeFactory;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    using var scope = _scopeFactory.CreateScope();
+                    var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                    var capacity = scope.ServiceProvider.GetRequiredService<ISubscriptionCapacityService>();
+                    var suspended = await ReconcileAsync(db, capacity, stoppingToken);
+                    if (suspended > 0)
+                        _logger.LogInformation("Quota reconciliation auto-suspended {Count} over-quota sensors", suspended);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Quota reconciliation failed");
+                }
+
+                try { await Task.Delay(Interval, stoppingToken); }
+                catch (TaskCanceledException) { break; }
+            }
+        }
+
+        /// <summary>
+        /// Auto-suspends each owner's newest over-capacity sensors. Returns the number suspended.
+        /// Keeps the oldest <c>capacity</c> active sensors (by claim date); suspends the rest.
+        /// </summary>
+        internal static async Task<int> ReconcileAsync(ApplicationDbContext db, ISubscriptionCapacityService capacity, CancellationToken ct = default)
+        {
+            var ownerIds = await db.UserSensors
+                .Where(us => us.IsOwner && us.SuspendedAt == null)
+                .Select(us => us.UserId)
+                .Distinct()
+                .ToListAsync(ct);
+
+            var now = DateTime.UtcNow;
+            var totalSuspended = 0;
+
+            foreach (var userId in ownerIds)
+            {
+                var cap = await capacity.GetCapacityAsync(userId, ct);
+
+                var activeOwned = await db.UserSensors
+                    .Where(us => us.UserId == userId && us.IsOwner && us.SuspendedAt == null)
+                    .OrderBy(us => us.CreatedAt)
+                    .ToListAsync(ct);
+
+                if (activeOwned.Count <= cap) continue;
+
+                // Keep the oldest `cap`; suspend the newest excess.
+                foreach (var userSensor in activeOwned.Skip(cap))
+                {
+                    userSensor.SuspendedAt = now;
+                    totalSuspended++;
+                }
+                await db.SaveChangesAsync(ct);
+            }
+
+            return totalSuspended;
+        }
+    }
+}

--- a/garge-api.Tests/QuotaReconciliationServiceTests.cs
+++ b/garge-api.Tests/QuotaReconciliationServiceTests.cs
@@ -1,0 +1,78 @@
+using garge_api.Models;
+using garge_api.Models.Admin;
+using garge_api.Models.Sensor;
+using garge_api.Models.Subscription;
+using garge_api.Services;
+using Microsoft.Extensions.Caching.Memory;
+using Xunit;
+
+namespace garge_api.Tests;
+
+/// <summary>
+/// Verifies the daily reconciliation sweep: over-quota owners get their newest excess sensors
+/// auto-suspended (oldest kept), within-quota owners are untouched.
+/// </summary>
+public class QuotaReconciliationServiceTests : ControllerTestBase
+{
+    private static ISubscriptionCapacityService Capacity(ApplicationDbContext db) =>
+        new SubscriptionCapacityService(db, new MemoryCache(new MemoryCacheOptions()));
+
+    private static UserSensor Owned(string userId, int sensorId, DateTime createdAt) =>
+        new() { UserId = userId, SensorId = sensorId, IsOwner = true, CreatedAt = createdAt, SuspendedAt = null };
+
+    private static void SeedPrimary(ApplicationDbContext db, string userId)
+    {
+        db.AppSettings.Add(new AppSettings { Id = 1 });
+        db.Products.Add(new Product { Id = 1, Name = "Primary", PriceInOre = 0, Interval = BillingInterval.Monthly, Type = ProductType.Primary });
+        db.Subscriptions.Add(new Subscription { UserId = userId, ProductId = 1, VippsAgreementId = "a", Status = SubscriptionStatus.Active, Quantity = 1 });
+    }
+
+    [Fact]
+    public async Task Reconcile_OverCapacity_SuspendsNewestExcess_KeepsOldest()
+    {
+        using var db = CreateDbContext();
+        SeedPrimary(db, "u"); // capacity = 1
+        var t0 = new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        db.UserSensors.AddRange(
+            Owned("u", 1, t0),
+            Owned("u", 2, t0.AddDays(1)),
+            Owned("u", 3, t0.AddDays(2)));
+        await db.SaveChangesAsync();
+
+        var suspended = await QuotaReconciliationService.ReconcileAsync(db, Capacity(db));
+
+        Assert.Equal(2, suspended);
+        Assert.Null(db.UserSensors.Single(x => x.SensorId == 1).SuspendedAt);   // oldest kept
+        Assert.NotNull(db.UserSensors.Single(x => x.SensorId == 2).SuspendedAt); // newest suspended
+        Assert.NotNull(db.UserSensors.Single(x => x.SensorId == 3).SuspendedAt);
+    }
+
+    [Fact]
+    public async Task Reconcile_WithinCapacity_DoesNothing()
+    {
+        using var db = CreateDbContext();
+        SeedPrimary(db, "u"); // capacity = 1
+        db.UserSensors.Add(Owned("u", 1, new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc)));
+        await db.SaveChangesAsync();
+
+        var suspended = await QuotaReconciliationService.ReconcileAsync(db, Capacity(db));
+
+        Assert.Equal(0, suspended);
+        Assert.Null(db.UserSensors.Single().SuspendedAt);
+    }
+
+    [Fact]
+    public async Task Reconcile_NoSubscription_SuspendsAllOwned()
+    {
+        using var db = CreateDbContext();
+        db.AppSettings.Add(new AppSettings { Id = 1 }); // capacity = 0 (no Primary)
+        var t0 = new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        db.UserSensors.AddRange(Owned("u", 1, t0), Owned("u", 2, t0.AddDays(1)));
+        await db.SaveChangesAsync();
+
+        var suspended = await QuotaReconciliationService.ReconcileAsync(db, Capacity(db));
+
+        Assert.Equal(2, suspended);
+        Assert.All(db.UserSensors.ToList(), us => Assert.NotNull(us.SuspendedAt));
+    }
+}


### PR DESCRIPTION
## Summary

Suspension PR 2b — the daily reconciliation sweep that actually enforces the over-quota → suspend behaviour.

- `QuotaReconciliationService` (daily `BackgroundService`): for each owner whose active owned sensors exceed their capacity (e.g. after a cancelled subscription's paid-period grace lapses), auto-suspends the **newest excess** and keeps the **oldest** by claim date.
- Owners can re-pick which sensors stay active afterward via the suspend/activate toggle (#254).
- Core `ReconcileAsync(db, capacity)` is a testable static.

3 new tests: over-capacity suspends newest excess (oldest kept), within-capacity is a no-op, no-subscription suspends all owned. Full suite: 307 passing.

> Stacked on #254 → #253 → #252 → #251 → #250 → #249. Retarget to `main` as the stack merges. With this, the over-quota suspension flow is complete server-side; remaining work is the 6-month-cap purge job (ML-3) and the app UI.
