### PR TITLE
feat: data-retention opt-out + suspension cap purge

### DIFF
--- a/Controllers/BatteryHealthController.cs
+++ b/Controllers/BatteryHealthController.cs
@@ -51,31 +51,13 @@ namespace garge_api.Controllers
         // Bound derived battery data to the caller's own ownership window(s) so a new owner of a
         // re-claimed/resold sensor never sees the previous owner's history. Admins see everything.
         private IQueryable<BatteryHealth> WithinOwnershipWindow(IQueryable<BatteryHealth> query)
-        {
-            if (IsAdmin()) return query;
-            var userId = User.UserId();
-            return query.Where(bh => _context.SensorOwnershipPeriods.Any(p =>
-                p.UserId == userId && p.SensorId == bh.SensorId
-                && bh.Timestamp >= p.StartedAt && (p.EndedAt == null || bh.Timestamp < p.EndedAt)));
-        }
+            => query.WithinSensorOwnership(_context, User.UserId(), IsAdmin());
 
         private IQueryable<BatteryChargeEvent> WithinOwnershipWindow(IQueryable<BatteryChargeEvent> query)
-        {
-            if (IsAdmin()) return query;
-            var userId = User.UserId();
-            return query.Where(e => _context.SensorOwnershipPeriods.Any(p =>
-                p.UserId == userId && p.SensorId == e.SensorId
-                && e.StartedAt >= p.StartedAt && (p.EndedAt == null || e.StartedAt < p.EndedAt)));
-        }
+            => query.WithinSensorOwnership(_context, User.UserId(), IsAdmin());
 
         private IQueryable<SensorData> WithinOwnershipWindow(IQueryable<SensorData> query)
-        {
-            if (IsAdmin()) return query;
-            var userId = User.UserId();
-            return query.Where(sd => _context.SensorOwnershipPeriods.Any(p =>
-                p.UserId == userId && p.SensorId == sd.SensorId
-                && sd.Timestamp >= p.StartedAt && (p.EndedAt == null || sd.Timestamp < p.EndedAt)));
-        }
+            => query.WithinSensorOwnership(_context, User.UserId(), IsAdmin());
 
         /// <summary>True when the caller has this owned sensor suspended (turned off / over quota). Admins are never suspended.</summary>
         private async Task<bool> IsSensorSuspendedForCallerAsync(int sensorId)

--- a/Controllers/SensorController.cs
+++ b/Controllers/SensorController.cs
@@ -1,6 +1,7 @@
 using garge_api.Constants;
 using garge_api.Controllers.Common;
 using garge_api.Dtos.Common;
+using garge_api.Helpers;
 using garge_api.Dtos.Sensor;
 using garge_api.Hubs;
 using garge_api.Models;
@@ -65,15 +66,7 @@ namespace garge_api.Controllers
         /// whether the sensor is visible at all; this bounds the time window of the data returned.
         /// </summary>
         private IQueryable<SensorData> WithinOwnershipWindow(IQueryable<SensorData> query)
-        {
-            if (IsAdmin()) return query;
-            var userId = User.UserId();
-            return query.Where(sd => _context.SensorOwnershipPeriods.Any(p =>
-                p.UserId == userId
-                && p.SensorId == sd.SensorId
-                && sd.Timestamp >= p.StartedAt
-                && (p.EndedAt == null || sd.Timestamp < p.EndedAt)));
-        }
+            => query.WithinSensorOwnership(_context, User.UserId(), IsAdmin());
 
         /// <summary>
         /// True when the caller has this owned sensor suspended (turned off / over quota). Suspended

--- a/Controllers/SensorController.cs
+++ b/Controllers/SensorController.cs
@@ -690,6 +690,12 @@ namespace garge_api.Controllers
                 _context.UserSensorCustomNames.Remove(customName);
             }
 
+            // Remove the user's remaining personal rows for this sensor so unclaim leaves nothing
+            // orphaned (same per-sensor set the account-deletion and 6-month purge paths clean up).
+            _context.SensorActivities.RemoveRange(_context.SensorActivities.Where(a => a.UserId == userId && a.SensorId == id));
+            _context.SensorPhotos.RemoveRange(_context.SensorPhotos.Where(p => p.UserId == userId && p.SensorId == id));
+            _context.SensorOfflineNotifications.RemoveRange(_context.SensorOfflineNotifications.Where(n => n.UserId == userId && n.SensorId == id));
+
             await _context.SaveChangesAsync();
 
             _logger.LogInformation("Sensor unclaimed by user {@LogData}", new { CallerUserId = User.UserId(), id });

--- a/Controllers/SwitchesController.cs
+++ b/Controllers/SwitchesController.cs
@@ -732,6 +732,10 @@ namespace garge_api.Controllers
                 foreach (var period in openPeriods)
                     period.EndedAt = DateTime.UtcNow;
 
+                // Remove any custom name the user set for this switch so unclaim leaves nothing orphaned.
+                _context.UserSwitchCustomNames.RemoveRange(
+                    _context.UserSwitchCustomNames.Where(x => x.UserId == userId && x.SwitchId == id));
+
                 await _context.SaveChangesAsync();
                 _ownership.InvalidateSwitch(id);
             }

--- a/Controllers/SwitchesController.cs
+++ b/Controllers/SwitchesController.cs
@@ -1,4 +1,5 @@
 ﻿using garge_api.Dtos.Switch;
+using garge_api.Helpers;
 using garge_api.Hubs;
 using garge_api.Models;
 using Microsoft.AspNetCore.Authorization;
@@ -63,18 +64,7 @@ namespace garge_api.Controllers
         /// owner's history. Admins see everything; the access check still gates visibility overall.
         /// </summary>
         private IQueryable<SwitchData> WithinOwnershipWindow(IQueryable<SwitchData> query)
-        {
-            if (IsSwitchAdmin()) return query;
-            var userId = User.UserId();
-            return query.Where(sd =>
-                _context.SwitchOwnershipPeriods.Any(p => p.UserId == userId && p.SwitchId == sd.SwitchId
-                    && sd.Timestamp >= p.StartedAt && (p.EndedAt == null || sd.Timestamp < p.EndedAt))
-                || _context.Switches.Any(sw => sw.Id == sd.SwitchId
-                    && _context.DiscoveredDevices.Any(dd => dd.Target == sw.Name
-                        && _context.Sensors.Any(s => s.ParentName == dd.DiscoveredBy
-                            && _context.SensorOwnershipPeriods.Any(p => p.UserId == userId && p.SensorId == s.Id
-                                && sd.Timestamp >= p.StartedAt && (p.EndedAt == null || sd.Timestamp < p.EndedAt))))));
-        }
+            => query.WithinSwitchOwnership(_context, User.UserId(), IsSwitchAdmin());
 
         /// <summary>
         /// Retrieves all available switches.

--- a/Controllers/UserController.cs
+++ b/Controllers/UserController.cs
@@ -570,11 +570,7 @@ namespace garge_api.Controllers
             if (user == null || user.IsDeleted)
                 return NotFound(new { message = "User not found!" });
 
-            return Ok(new DataRetentionDto
-            {
-                OptOut = user.DataRetentionOptOutAt != null,
-                OptedOutAt = user.DataRetentionOptOutAt
-            });
+            return Ok(DataRetentionDto.From(user.DataRetentionOptOutAt));
         }
 
         /// <summary>
@@ -609,11 +605,7 @@ namespace garge_api.Controllers
             }
 
             _logger.LogInformation("Data-retention opt-out set to {OptOut} for user {UserId}", dto.OptOut, LogSanitizer.Sanitize(id));
-            return Ok(new DataRetentionDto
-            {
-                OptOut = user.DataRetentionOptOutAt != null,
-                OptedOutAt = user.DataRetentionOptOutAt
-            });
+            return Ok(DataRetentionDto.From(user.DataRetentionOptOutAt));
         }
     }
 }

--- a/Controllers/UserController.cs
+++ b/Controllers/UserController.cs
@@ -553,5 +553,67 @@ namespace garge_api.Controllers
             _logger.LogInformation("Profile updated for user {UserId}", LogSanitizer.Sanitize(id));
             return NoContent();
         }
+
+        /// <summary>
+        /// Gets the caller's sensor-data retention preference.
+        /// </summary>
+        [HttpGet("{id}/data-retention")]
+        [SwaggerOperation(Summary = "Gets the caller's sensor-data retention opt-out state.")]
+        [SwaggerResponse(200, "Retention preference.", typeof(DataRetentionDto))]
+        [SwaggerResponse(403, "Forbidden.")]
+        [SwaggerResponse(404, "User not found.")]
+        public async Task<IActionResult> GetDataRetention(string id)
+        {
+            if (!User.IsCallerOf(id)) return Forbid();
+
+            var user = await _userManager.FindByIdAsync(id);
+            if (user == null || user.IsDeleted)
+                return NotFound(new { message = "User not found!" });
+
+            return Ok(new DataRetentionDto
+            {
+                OptOut = user.DataRetentionOptOutAt != null,
+                OptedOutAt = user.DataRetentionOptOutAt
+            });
+        }
+
+        /// <summary>
+        /// Sets or clears the caller's sensor-data retention opt-out (GDPR Art. 21 objection). When
+        /// opted out, suspended sensors are purged after the 6-month cap once the user has no
+        /// subscription coverage; the default keeps history for the lifetime of the claim.
+        /// </summary>
+        [HttpPut("{id}/data-retention")]
+        [SwaggerOperation(Summary = "Sets or clears the caller's sensor-data retention opt-out.")]
+        [SwaggerResponse(200, "Updated retention preference.", typeof(DataRetentionDto))]
+        [SwaggerResponse(403, "Forbidden.")]
+        [SwaggerResponse(404, "User not found.")]
+        public async Task<IActionResult> UpdateDataRetention(string id, [FromBody] UpdateDataRetentionDto dto)
+        {
+            if (!User.IsCallerOf(id)) return Forbid();
+
+            var user = await _userManager.FindByIdAsync(id);
+            if (user == null || user.IsDeleted)
+                return NotFound(new { message = "User not found!" });
+
+            // Idempotent: only stamp when the state actually changes so the original opt-out time is kept.
+            if (dto.OptOut && user.DataRetentionOptOutAt == null)
+                user.DataRetentionOptOutAt = DateTime.UtcNow;
+            else if (!dto.OptOut)
+                user.DataRetentionOptOutAt = null;
+
+            var result = await _userManager.UpdateAsync(user);
+            if (!result.Succeeded)
+            {
+                _logger.LogWarning("UpdateDataRetention failed for {UserId}: {Errors}", LogSanitizer.Sanitize(id), result.Errors);
+                return BadRequest(result.Errors);
+            }
+
+            _logger.LogInformation("Data-retention opt-out set to {OptOut} for user {UserId}", dto.OptOut, LogSanitizer.Sanitize(id));
+            return Ok(new DataRetentionDto
+            {
+                OptOut = user.DataRetentionOptOutAt != null,
+                OptedOutAt = user.DataRetentionOptOutAt
+            });
+        }
     }
 }

--- a/Controllers/UserController.cs
+++ b/Controllers/UserController.cs
@@ -298,35 +298,25 @@ namespace garge_api.Controllers
                 .ToListAsync();
 
             // Bound to the user's own ownership window(s): they export the data from periods they
-            // owned, not a previous owner's readings on a re-claimed sensor.
+            // owned, not a previous owner's readings on a re-claimed device. Same boundary as the read
+            // endpoints — see OwnershipWindowQueryExtensions.
             var sensorReadings = await _context.SensorData
-                .Where(sd => sensorIds.Contains(sd.SensorId)
-                    && _context.SensorOwnershipPeriods.Any(p => p.UserId == id && p.SensorId == sd.SensorId
-                        && sd.Timestamp >= p.StartedAt && (p.EndedAt == null || sd.Timestamp < p.EndedAt)))
+                .Where(sd => sensorIds.Contains(sd.SensorId))
+                .WithinSensorOwnership(_context, id)
                 .OrderBy(sd => sd.Timestamp)
                 .Select(sd => new { sd.SensorId, sd.Value, sd.Timestamp })
                 .ToListAsync();
 
-            // Bound to the user's own switch ownership window(s): a direct ownership period, or — for
-            // indirect access via the discovered-device chain — the period of an owned sensor that
-            // maps to the switch. They export the data from windows they owned, not a previous owner's.
             var switchHistory = await _context.SwitchData
-                .Where(sd => switchIds.Contains(sd.SwitchId)
-                    && (_context.SwitchOwnershipPeriods.Any(p => p.UserId == id && p.SwitchId == sd.SwitchId
-                            && sd.Timestamp >= p.StartedAt && (p.EndedAt == null || sd.Timestamp < p.EndedAt))
-                        || _context.Switches.Any(sw => sw.Id == sd.SwitchId
-                            && _context.DiscoveredDevices.Any(dd => dd.Target == sw.Name
-                                && _context.Sensors.Any(s => s.ParentName == dd.DiscoveredBy
-                                    && _context.SensorOwnershipPeriods.Any(p => p.UserId == id && p.SensorId == s.Id
-                                        && sd.Timestamp >= p.StartedAt && (p.EndedAt == null || sd.Timestamp < p.EndedAt)))))))
+                .Where(sd => switchIds.Contains(sd.SwitchId))
+                .WithinSwitchOwnership(_context, id)
                 .OrderBy(sd => sd.Timestamp)
                 .Select(sd => new { sd.SwitchId, sd.Value, sd.Timestamp })
                 .ToListAsync();
 
             var batteryHealth = await _context.BatteryHealthData
-                .Where(bh => sensorIds.Contains(bh.SensorId)
-                    && _context.SensorOwnershipPeriods.Any(p => p.UserId == id && p.SensorId == bh.SensorId
-                        && bh.Timestamp >= p.StartedAt && (p.EndedAt == null || bh.Timestamp < p.EndedAt)))
+                .Where(bh => sensorIds.Contains(bh.SensorId))
+                .WithinSensorOwnership(_context, id)
                 .OrderBy(bh => bh.Timestamp)
                 .ToListAsync();
 

--- a/Dtos/User/DataRetentionDto.cs
+++ b/Dtos/User/DataRetentionDto.cs
@@ -1,0 +1,26 @@
+namespace garge_api.Dtos.User
+{
+    /// <summary>
+    /// The caller's current sensor-data retention preference.
+    /// </summary>
+    public class DataRetentionDto
+    {
+        /// <summary>
+        /// True when the user has opted out of keeping their sensor history after their subscription
+        /// lapses (GDPR Art. 21 objection). False (default) keeps history for the lifetime of the claim.
+        /// </summary>
+        public bool OptOut { get; set; }
+
+        /// <summary>When the opt-out was set, or null if the user has not opted out.</summary>
+        public DateTime? OptedOutAt { get; set; }
+    }
+
+    /// <summary>
+    /// Sets or clears the caller's sensor-data retention opt-out.
+    /// </summary>
+    public class UpdateDataRetentionDto
+    {
+        /// <summary>True to opt out of post-lapse retention; false to keep the default (retain).</summary>
+        public bool OptOut { get; set; }
+    }
+}

--- a/Dtos/User/DataRetentionDto.cs
+++ b/Dtos/User/DataRetentionDto.cs
@@ -13,6 +13,13 @@ namespace garge_api.Dtos.User
 
         /// <summary>When the opt-out was set, or null if the user has not opted out.</summary>
         public DateTime? OptedOutAt { get; set; }
+
+        /// <summary>Builds the DTO from the user's stored opt-out timestamp (null = retaining).</summary>
+        public static DataRetentionDto From(DateTime? optedOutAt) => new()
+        {
+            OptOut = optedOutAt != null,
+            OptedOutAt = optedOutAt
+        };
     }
 
     /// <summary>

--- a/Helpers/OwnershipWindowQueryExtensions.cs
+++ b/Helpers/OwnershipWindowQueryExtensions.cs
@@ -1,0 +1,52 @@
+using garge_api.Models;
+using garge_api.Models.Sensor;
+using garge_api.Models.Switch;
+
+namespace garge_api.Helpers
+{
+    /// <summary>
+    /// Single source of truth for the resale-safe "ownership window" read boundary: a caller may only
+    /// see telemetry that falls inside one of their own ownership periods, so a new owner of a
+    /// re-claimed/resold device never sees the previous owner's history. The boundary rule is
+    /// <c>timestamp &gt;= period.StartedAt &amp;&amp; (period.EndedAt == null || timestamp &lt; period.EndedAt)</c>,
+    /// defined once here and reused by every read endpoint and the data export. All methods are plain
+    /// LINQ over <see cref="IQueryable{T}"/>, so EF Core translates them to SQL like an inline predicate.
+    /// Pass <paramref name="isAdmin"/> = true to bypass the window (admins see everything).
+    /// </summary>
+    public static class OwnershipWindowQueryExtensions
+    {
+        public static IQueryable<SensorData> WithinSensorOwnership(
+            this IQueryable<SensorData> query, ApplicationDbContext db, string userId, bool isAdmin = false)
+            => isAdmin ? query : query.Where(sd => db.SensorOwnershipPeriods.Any(p =>
+                p.UserId == userId && p.SensorId == sd.SensorId
+                && sd.Timestamp >= p.StartedAt && (p.EndedAt == null || sd.Timestamp < p.EndedAt)));
+
+        public static IQueryable<BatteryHealth> WithinSensorOwnership(
+            this IQueryable<BatteryHealth> query, ApplicationDbContext db, string userId, bool isAdmin = false)
+            => isAdmin ? query : query.Where(bh => db.SensorOwnershipPeriods.Any(p =>
+                p.UserId == userId && p.SensorId == bh.SensorId
+                && bh.Timestamp >= p.StartedAt && (p.EndedAt == null || bh.Timestamp < p.EndedAt)));
+
+        public static IQueryable<BatteryChargeEvent> WithinSensorOwnership(
+            this IQueryable<BatteryChargeEvent> query, ApplicationDbContext db, string userId, bool isAdmin = false)
+            => isAdmin ? query : query.Where(e => db.SensorOwnershipPeriods.Any(p =>
+                p.UserId == userId && p.SensorId == e.SensorId
+                && e.StartedAt >= p.StartedAt && (p.EndedAt == null || e.StartedAt < p.EndedAt)));
+
+        /// <summary>
+        /// Switch reads have two access paths: a direct <see cref="SwitchOwnershipPeriod"/>, or indirect
+        /// access via the discovered-device chain (switch name → DiscoveredDevice.Target, DiscoveredBy →
+        /// Sensor.ParentName → an owned sensor's period). Either path bounds the data to the caller's window.
+        /// </summary>
+        public static IQueryable<SwitchData> WithinSwitchOwnership(
+            this IQueryable<SwitchData> query, ApplicationDbContext db, string userId, bool isAdmin = false)
+            => isAdmin ? query : query.Where(sd =>
+                db.SwitchOwnershipPeriods.Any(p => p.UserId == userId && p.SwitchId == sd.SwitchId
+                    && sd.Timestamp >= p.StartedAt && (p.EndedAt == null || sd.Timestamp < p.EndedAt))
+                || db.Switches.Any(sw => sw.Id == sd.SwitchId
+                    && db.DiscoveredDevices.Any(dd => dd.Target == sw.Name
+                        && db.Sensors.Any(s => s.ParentName == dd.DiscoveredBy
+                            && db.SensorOwnershipPeriods.Any(p => p.UserId == userId && p.SensorId == s.Id
+                                && sd.Timestamp >= p.StartedAt && (p.EndedAt == null || sd.Timestamp < p.EndedAt))))));
+    }
+}

--- a/Migrations/20260521150140_AddDataRetentionOptOut.Designer.cs
+++ b/Migrations/20260521150140_AddDataRetentionOptOut.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260521150140_AddDataRetentionOptOut")]
+    partial class AddDataRetentionOptOut
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260521150140_AddDataRetentionOptOut.cs
+++ b/Migrations/20260521150140_AddDataRetentionOptOut.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDataRetentionOptOut : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DataRetentionOptOutAt",
+                table: "AspNetUsers",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DataRetentionOptOutAt",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/Models/Admin/User.cs
+++ b/Models/Admin/User.cs
@@ -24,4 +24,12 @@ public class User : IdentityUser
     public string? TermsVersion { get; set; }
     [MaxLength(45)]
     public string? TermsAcceptedIp { get; set; }
+
+    /// <summary>
+    /// When set, the user has objected (GDPR Art. 21) to retention of their sensor history after their
+    /// subscription lapses: once they have no subscription coverage, their suspended sensors become
+    /// eligible for the 6-month purge. Null (default) keeps history for the lifetime of the claim under
+    /// legitimate interest, so a returning seasonal user still has their year-over-year data.
+    /// </summary>
+    public DateTime? DataRetentionOptOutAt { get; set; }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -185,6 +185,7 @@ namespace garge_api
             builder.Services.AddSingleton<IPdfRenderer, PuppeteerPdfRenderer>();
             builder.Services.AddScoped<ISubscriptionCapacityService, SubscriptionCapacityService>();
             builder.Services.AddHostedService<QuotaReconciliationService>();
+            builder.Services.AddHostedService<SuspendedSensorPurgeService>();
             builder.Services.AddScoped<IInvoiceService, InvoiceService>();
             builder.Services.AddScoped<IAnonymizationService, AnonymizationService>();
             builder.Services.AddScoped<IOrderEmailService, OrderEmailService>();

--- a/Services/SuspendedSensorPurgeService.cs
+++ b/Services/SuspendedSensorPurgeService.cs
@@ -1,0 +1,94 @@
+using garge_api.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace garge_api.Services
+{
+    /// <summary>
+    /// Enforces the retention cap on suspended sensors. A sensor an owner has kept suspended for more
+    /// than 6 months is force-unclaimed and its telemetry is moved into the anonymized ML store (or
+    /// deleted if nothing is exclusive). This is the storage-limitation safeguard required by the GDPR
+    /// review: personal data is not kept indefinitely just because the owner left a device off.
+    /// </summary>
+    public class SuspendedSensorPurgeService : BackgroundService
+    {
+        private static readonly TimeSpan Interval = TimeSpan.FromHours(24);
+        public static readonly TimeSpan Retention = TimeSpan.FromDays(180); // 6 months
+
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly ILogger<SuspendedSensorPurgeService> _logger;
+
+        public SuspendedSensorPurgeService(IServiceScopeFactory scopeFactory, ILogger<SuspendedSensorPurgeService> logger)
+        {
+            _scopeFactory = scopeFactory;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    using var scope = _scopeFactory.CreateScope();
+                    var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                    var anonymizer = scope.ServiceProvider.GetRequiredService<IAnonymizationService>();
+                    var ownership = scope.ServiceProvider.GetRequiredService<IDeviceOwnershipService>();
+                    var purged = await PurgeExpiredAsync(db, anonymizer, ownership, Retention, stoppingToken);
+                    if (purged > 0)
+                        _logger.LogInformation("Purged {Count} sensors suspended beyond the {Days}-day cap", purged, Retention.TotalDays);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Suspended-sensor purge failed");
+                }
+
+                try { await Task.Delay(Interval, stoppingToken); }
+                catch (TaskCanceledException) { break; }
+            }
+        }
+
+        /// <summary>
+        /// For every owned sensor suspended longer than <paramref name="retention"/>: anonymize the
+        /// owner's exclusive telemetry and force-unclaim the sensor (removing their ownership and
+        /// personal rows for it). Returns the number of sensors purged.
+        /// </summary>
+        internal static async Task<int> PurgeExpiredAsync(
+            ApplicationDbContext db,
+            IAnonymizationService anonymizer,
+            IDeviceOwnershipService ownership,
+            TimeSpan retention,
+            CancellationToken ct = default)
+        {
+            var cutoff = DateTime.UtcNow - retention;
+            var expired = await db.UserSensors
+                .Where(us => us.IsOwner && us.SuspendedAt != null && us.SuspendedAt < cutoff)
+                .Select(us => new { us.UserId, us.SensorId })
+                .ToListAsync(ct);
+
+            var purged = 0;
+            foreach (var item in expired)
+            {
+                // Move this owner's exclusive telemetry to the ML store and delete its period(s).
+                var periodIds = await db.SensorOwnershipPeriods
+                    .Where(p => p.UserId == item.UserId && p.SensorId == item.SensorId)
+                    .Select(p => p.Id)
+                    .ToListAsync(ct);
+                foreach (var periodId in periodIds)
+                    await anonymizer.AnonymizeSensorPeriodAsync(periodId, ct);
+
+                // Force-unclaim: remove ownership and the owner's personal rows for this sensor.
+                db.UserSensors.RemoveRange(db.UserSensors.Where(us => us.UserId == item.UserId && us.SensorId == item.SensorId));
+                db.UserSensorCustomNames.RemoveRange(db.UserSensorCustomNames.Where(x => x.UserId == item.UserId && x.SensorId == item.SensorId));
+                db.SensorActivities.RemoveRange(db.SensorActivities.Where(a => a.UserId == item.UserId && a.SensorId == item.SensorId));
+                db.SensorPhotos.RemoveRange(db.SensorPhotos.Where(p => p.UserId == item.UserId && p.SensorId == item.SensorId));
+                db.SensorOfflineNotifications.RemoveRange(db.SensorOfflineNotifications.Where(n => n.UserId == item.UserId && n.SensorId == item.SensorId));
+                await db.SaveChangesAsync(ct);
+
+                ownership.InvalidateSensor(item.SensorId);
+                purged++;
+            }
+
+            return purged;
+        }
+    }
+}

--- a/Services/SuspendedSensorPurgeService.cs
+++ b/Services/SuspendedSensorPurgeService.cs
@@ -4,10 +4,13 @@ using Microsoft.EntityFrameworkCore;
 namespace garge_api.Services
 {
     /// <summary>
-    /// Enforces the retention cap on suspended sensors. A sensor an owner has kept suspended for more
-    /// than 6 months is force-unclaimed and its telemetry is moved into the anonymized ML store (or
-    /// deleted if nothing is exclusive). This is the storage-limitation safeguard required by the GDPR
-    /// review: personal data is not kept indefinitely just because the owner left a device off.
+    /// Enforces the retention cap on suspended sensors of users who have opted out of long-term
+    /// retention. By default Garge keeps a claimed sensor's history for the lifetime of the claim
+    /// (legitimate interest, disclosed in the privacy policy) so a returning seasonal subscriber keeps
+    /// their year-over-year data. A user can object (GDPR Art. 21) via the data-retention opt-out; once
+    /// such a user has no subscription coverage, a sensor they have kept suspended for more than
+    /// 6 months is force-unclaimed and its telemetry is moved into the anonymized ML store (or deleted
+    /// if nothing is exclusive). Paying users are never purged here.
     /// </summary>
     public class SuspendedSensorPurgeService : BackgroundService
     {
@@ -33,7 +36,8 @@ namespace garge_api.Services
                     var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
                     var anonymizer = scope.ServiceProvider.GetRequiredService<IAnonymizationService>();
                     var ownership = scope.ServiceProvider.GetRequiredService<IDeviceOwnershipService>();
-                    var purged = await PurgeExpiredAsync(db, anonymizer, ownership, Retention, stoppingToken);
+                    var capacity = scope.ServiceProvider.GetRequiredService<ISubscriptionCapacityService>();
+                    var purged = await PurgeExpiredAsync(db, anonymizer, ownership, capacity, Retention, stoppingToken);
                     if (purged > 0)
                         _logger.LogInformation("Purged {Count} sensors suspended beyond the {Days}-day cap", purged, Retention.TotalDays);
                 }
@@ -48,26 +52,43 @@ namespace garge_api.Services
         }
 
         /// <summary>
-        /// For every owned sensor suspended longer than <paramref name="retention"/>: anonymize the
-        /// owner's exclusive telemetry and force-unclaim the sensor (removing their ownership and
-        /// personal rows for it). Returns the number of sensors purged.
+        /// For every owned sensor suspended longer than <paramref name="retention"/> whose owner has
+        /// opted out of retention AND no longer has subscription coverage: anonymize the owner's
+        /// exclusive telemetry and force-unclaim the sensor (removing their ownership and personal rows
+        /// for it). Sensors of users who have not opted out, or who still have an active/grace
+        /// subscription, are left untouched. Returns the number of sensors purged.
         /// </summary>
         internal static async Task<int> PurgeExpiredAsync(
             ApplicationDbContext db,
             IAnonymizationService anonymizer,
             IDeviceOwnershipService ownership,
+            ISubscriptionCapacityService capacity,
             TimeSpan retention,
             CancellationToken ct = default)
         {
             var cutoff = DateTime.UtcNow - retention;
+            // Only users who have actively objected to retention (Art. 21 opt-out) are in scope; the
+            // default is to keep history for the lifetime of the claim under legitimate interest.
             var expired = await db.UserSensors
-                .Where(us => us.IsOwner && us.SuspendedAt != null && us.SuspendedAt < cutoff)
+                .Where(us => us.IsOwner && us.SuspendedAt != null && us.SuspendedAt < cutoff
+                          && db.Users.Any(u => u.Id == us.UserId && u.DataRetentionOptOutAt != null))
                 .Select(us => new { us.UserId, us.SensorId })
                 .ToListAsync(ct);
 
+            var coverageCache = new Dictionary<string, bool>();
             var purged = 0;
             foreach (var item in expired)
             {
+                // A paying user (active or paid-period grace) keeps their data even if opted out — the
+                // opt-out only takes effect once there is no subscription left to honour.
+                if (!coverageCache.TryGetValue(item.UserId, out var hasCoverage))
+                {
+                    hasCoverage = await capacity.GetCapacityAsync(item.UserId, ct) > 0;
+                    coverageCache[item.UserId] = hasCoverage;
+                }
+                if (hasCoverage)
+                    continue;
+
                 // Move this owner's exclusive telemetry to the ML store and delete its period(s).
                 var periodIds = await db.SensorOwnershipPeriods
                     .Where(p => p.UserId == item.UserId && p.SensorId == item.SensorId)

--- a/garge-api.Tests/OwnershipWindowQueryExtensionsTests.cs
+++ b/garge-api.Tests/OwnershipWindowQueryExtensionsTests.cs
@@ -1,0 +1,152 @@
+using garge_api.Helpers;
+using garge_api.Models.Mqtt;
+using garge_api.Models.Sensor;
+using garge_api.Models.Switch;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace garge_api.Tests;
+
+/// <summary>
+/// Tests the shared resale-safe ownership-window boundary used by every read endpoint and the export.
+/// A caller sees telemetry only inside their own ownership period(s); admins bypass; switches resolve
+/// via a direct period or the discovered-device chain.
+/// </summary>
+public class OwnershipWindowQueryExtensionsTests : ControllerTestBase
+{
+    private const string U = "user-1";
+    private static readonly DateTime Jan = new(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    private static Sensor MakeSensor(int id, string parent = "gw") => new()
+    {
+        Id = id, Name = $"garge_volt_{id}", Type = "voltage", Role = "sensor",
+        RegistrationCode = $"rc{id}", DefaultName = "Battery", ParentName = parent
+    };
+
+    [Fact]
+    public async Task WithinSensorOwnership_ReturnsOnlyReadingsInsideTheWindow()
+    {
+        using var db = CreateDbContext();
+        db.Sensors.Add(MakeSensor(1));
+        db.SensorOwnershipPeriods.Add(new SensorOwnershipPeriod { UserId = U, SensorId = 1, StartedAt = Jan, EndedAt = Jan.AddDays(10) });
+        db.SensorData.AddRange(
+            new SensorData { SensorId = 1, Value = "before", Timestamp = Jan.AddDays(-1) },
+            new SensorData { SensorId = 1, Value = "inside", Timestamp = Jan.AddDays(5) },
+            new SensorData { SensorId = 1, Value = "after", Timestamp = Jan.AddDays(20) });
+        await db.SaveChangesAsync();
+
+        var result = await db.SensorData.WithinSensorOwnership(db, U).ToListAsync();
+
+        Assert.Single(result);
+        Assert.Equal("inside", result[0].Value);
+    }
+
+    [Fact]
+    public async Task WithinSensorOwnership_OpenPeriod_IncludesEverythingFromStart()
+    {
+        using var db = CreateDbContext();
+        db.Sensors.Add(MakeSensor(1));
+        db.SensorOwnershipPeriods.Add(new SensorOwnershipPeriod { UserId = U, SensorId = 1, StartedAt = Jan, EndedAt = null });
+        db.SensorData.AddRange(
+            new SensorData { SensorId = 1, Value = "before", Timestamp = Jan.AddDays(-1) },
+            new SensorData { SensorId = 1, Value = "now", Timestamp = Jan.AddDays(365) });
+        await db.SaveChangesAsync();
+
+        var result = await db.SensorData.WithinSensorOwnership(db, U).ToListAsync();
+
+        Assert.Single(result);
+        Assert.Equal("now", result[0].Value);
+    }
+
+    [Fact]
+    public async Task WithinSensorOwnership_DifferentUser_SeesNothing()
+    {
+        using var db = CreateDbContext();
+        db.Sensors.Add(MakeSensor(1));
+        db.SensorOwnershipPeriods.Add(new SensorOwnershipPeriod { UserId = U, SensorId = 1, StartedAt = Jan, EndedAt = null });
+        db.SensorData.Add(new SensorData { SensorId = 1, Value = "x", Timestamp = Jan.AddDays(1) });
+        await db.SaveChangesAsync();
+
+        var result = await db.SensorData.WithinSensorOwnership(db, "someone-else").ToListAsync();
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task WithinSensorOwnership_Admin_BypassesWindow()
+    {
+        using var db = CreateDbContext();
+        db.Sensors.Add(MakeSensor(1));
+        // No ownership period at all.
+        db.SensorData.Add(new SensorData { SensorId = 1, Value = "x", Timestamp = Jan });
+        await db.SaveChangesAsync();
+
+        var result = await db.SensorData.WithinSensorOwnership(db, U, isAdmin: true).ToListAsync();
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task WithinSensorOwnership_BatteryChargeEvent_BoundsByStartedAt()
+    {
+        using var db = CreateDbContext();
+        db.Sensors.Add(MakeSensor(1));
+        db.SensorOwnershipPeriods.Add(new SensorOwnershipPeriod { UserId = U, SensorId = 1, StartedAt = Jan, EndedAt = Jan.AddDays(10) });
+        db.BatteryChargeEvents.AddRange(
+            new BatteryChargeEvent { SensorId = 1, StartedAt = Jan.AddDays(-2), EndedAt = Jan.AddDays(-1), PeakVoltage = 13, RestingAtTime = 12, PeakRatio = 1.08f, DurationMinutes = 60 },
+            new BatteryChargeEvent { SensorId = 1, StartedAt = Jan.AddDays(3), EndedAt = Jan.AddDays(3), PeakVoltage = 13, RestingAtTime = 12, PeakRatio = 1.08f, DurationMinutes = 60 });
+        await db.SaveChangesAsync();
+
+        var result = await db.BatteryChargeEvents.WithinSensorOwnership(db, U).ToListAsync();
+
+        Assert.Single(result);
+        Assert.Equal(Jan.AddDays(3), result[0].StartedAt);
+    }
+
+    [Fact]
+    public async Task WithinSwitchOwnership_DirectPeriod_ReturnsInWindow()
+    {
+        using var db = CreateDbContext();
+        db.Switches.Add(new Switch { Id = 1, Name = "sw1", Type = "socket", Role = "switch" });
+        db.SwitchOwnershipPeriods.Add(new SwitchOwnershipPeriod { UserId = U, SwitchId = 1, StartedAt = Jan, EndedAt = null });
+        db.SwitchData.AddRange(
+            new SwitchData { SwitchId = 1, Value = "before", Timestamp = Jan.AddDays(-1) },
+            new SwitchData { SwitchId = 1, Value = "on", Timestamp = Jan.AddDays(2) });
+        await db.SaveChangesAsync();
+
+        var result = await db.SwitchData.WithinSwitchOwnership(db, U).ToListAsync();
+
+        Assert.Single(result);
+        Assert.Equal("on", result[0].Value);
+    }
+
+    [Fact]
+    public async Task WithinSwitchOwnership_IndirectViaSensorChain_ReturnsInWindow()
+    {
+        using var db = CreateDbContext();
+        // Switch name -> DiscoveredDevice.Target; DiscoveredBy -> Sensor.ParentName; that sensor's period grants access.
+        db.Switches.Add(new Switch { Id = 1, Name = "sw1", Type = "socket", Role = "switch" });
+        db.DiscoveredDevices.Add(new DiscoveredDevice { Id = 1, DiscoveredBy = "gw", Target = "sw1", Type = "socket", Timestamp = Jan });
+        db.Sensors.Add(MakeSensor(1, parent: "gw"));
+        db.SensorOwnershipPeriods.Add(new SensorOwnershipPeriod { UserId = U, SensorId = 1, StartedAt = Jan, EndedAt = null });
+        db.SwitchData.Add(new SwitchData { SwitchId = 1, Value = "on", Timestamp = Jan.AddDays(2) });
+        await db.SaveChangesAsync();
+
+        var result = await db.SwitchData.WithinSwitchOwnership(db, U).ToListAsync();
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task WithinSwitchOwnership_NoAccess_SeesNothing()
+    {
+        using var db = CreateDbContext();
+        db.Switches.Add(new Switch { Id = 1, Name = "sw1", Type = "socket", Role = "switch" });
+        db.SwitchData.Add(new SwitchData { SwitchId = 1, Value = "on", Timestamp = Jan });
+        await db.SaveChangesAsync();
+
+        var result = await db.SwitchData.WithinSwitchOwnership(db, U).ToListAsync();
+
+        Assert.Empty(result);
+    }
+}

--- a/garge-api.Tests/SensorOwnershipWindowTests.cs
+++ b/garge-api.Tests/SensorOwnershipWindowTests.cs
@@ -2,6 +2,7 @@ using garge_api.Controllers;
 using garge_api.Dtos.Sensor;
 using garge_api.Hubs;
 using garge_api.Models;
+using garge_api.Models.Push;
 using garge_api.Models.Sensor;
 using garge_api.Services;
 using Microsoft.AspNetCore.Mvc;
@@ -163,5 +164,38 @@ public class SensorOwnershipWindowTests : ControllerTestBase
         Assert.NotEqual(SensorOwnershipPeriod.FirstOwnerStart, bPeriod.StartedAt);
         Assert.True(bPeriod.StartedAt >= before); // resale owner starts at claim time
         Assert.Null(bPeriod.EndedAt);
+    }
+
+    [Fact]
+    public async Task UnclaimSensor_RemovesAllOfTheUsersPersonalRows()
+    {
+        using var db = CreateDbContext();
+        db.Sensors.Add(new Sensor
+        {
+            Id = SensorId, Name = "garge_volt", Type = "voltage", Role = "sensor",
+            RegistrationCode = "rc-1", DefaultName = "Battery", ParentName = "garge_test"
+        });
+        db.UserSensors.Add(new UserSensor { UserId = "user-A", SensorId = SensorId, IsOwner = true });
+        db.SensorOwnershipPeriods.Add(new SensorOwnershipPeriod
+        {
+            UserId = "user-A", SensorId = SensorId, StartedAt = SensorOwnershipPeriod.FirstOwnerStart, EndedAt = null
+        });
+        db.UserSensorCustomNames.Add(new UserSensorCustomName { UserId = "user-A", SensorId = SensorId, CustomName = "My Bike" });
+        db.SensorActivities.Add(new SensorActivity { UserId = "user-A", SensorId = SensorId, Title = "Oil change", ActivityDate = DateTime.UtcNow, CreatedAt = DateTime.UtcNow });
+        db.SensorPhotos.Add(new SensorPhoto { UserId = "user-A", SensorId = SensorId, Data = "AQID", ContentType = "image/png" });
+        db.SensorOfflineNotifications.Add(new SensorOfflineNotification { UserId = "user-A", SensorId = SensorId });
+        await db.SaveChangesAsync();
+
+        var result = await CreateController(db, "user-A", isAdmin: false).UnclaimSensor(SensorId);
+
+        Assert.IsType<OkObjectResult>(result);
+        // Nothing the user owned for this sensor is left orphaned...
+        Assert.Empty(db.UserSensors);
+        Assert.Empty(db.UserSensorCustomNames);
+        Assert.Empty(db.SensorActivities);
+        Assert.Empty(db.SensorPhotos);
+        Assert.Empty(db.SensorOfflineNotifications);
+        // ...but the period is closed (not deleted), so a future owner still can't see this history.
+        Assert.NotNull(db.SensorOwnershipPeriods.Single(p => p.UserId == "user-A").EndedAt);
     }
 }

--- a/garge-api.Tests/SuspendedSensorPurgeServiceTests.cs
+++ b/garge-api.Tests/SuspendedSensorPurgeServiceTests.cs
@@ -1,0 +1,77 @@
+using garge_api.Models;
+using garge_api.Models.Sensor;
+using garge_api.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace garge_api.Tests;
+
+/// <summary>
+/// Verifies the 6-month suspension cap: sensors suspended past the retention window are anonymized
+/// (telemetry moved to the ML store) and force-unclaimed; recently suspended or active ones are left alone.
+/// </summary>
+public class SuspendedSensorPurgeServiceTests : ControllerTestBase
+{
+    private static IAnonymizationService Anonymizer(ApplicationDbContext db) =>
+        new AnonymizationService(db, NullLogger<AnonymizationService>.Instance);
+
+    private static IDeviceOwnershipService Ownership() => new Mock<IDeviceOwnershipService>().Object;
+
+    private static readonly TimeSpan SixMonths = TimeSpan.FromDays(180);
+
+    private static Sensor MakeSensor(int id) => new()
+    {
+        Id = id, Name = $"garge_volt_{id}", Type = "voltage", Role = "sensor",
+        RegistrationCode = $"rc{id}", DefaultName = "Battery", ParentName = "gw"
+    };
+
+    [Fact]
+    public async Task Purge_SensorSuspendedPastCap_AnonymizesAndUnclaims()
+    {
+        using var db = CreateDbContext();
+        db.Sensors.Add(MakeSensor(1));
+        db.UserSensors.Add(new UserSensor { UserId = "u", SensorId = 1, IsOwner = true, SuspendedAt = DateTime.UtcNow.AddDays(-200) });
+        db.SensorOwnershipPeriods.Add(new SensorOwnershipPeriod { UserId = "u", SensorId = 1, StartedAt = SensorOwnershipPeriod.FirstOwnerStart, EndedAt = null });
+        db.SensorData.AddRange(
+            new SensorData { SensorId = 1, Value = "12.5", Timestamp = new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
+            new SensorData { SensorId = 1, Value = "12.6", Timestamp = new DateTime(2021, 1, 2, 0, 0, 0, DateTimeKind.Utc) });
+        await db.SaveChangesAsync();
+
+        var purged = await SuspendedSensorPurgeService.PurgeExpiredAsync(db, Anonymizer(db), Ownership(), SixMonths);
+
+        Assert.Equal(1, purged);
+        Assert.Empty(db.UserSensors);                 // force-unclaimed
+        Assert.Empty(db.SensorOwnershipPeriods);       // period consumed by anonymization
+        Assert.Empty(db.SensorData);                   // moved out of the personal store
+        Assert.Equal(2, db.AnonymizedReadings.Count()); // ...into the ML store
+    }
+
+    [Fact]
+    public async Task Purge_SensorSuspendedWithinCap_LeftAlone()
+    {
+        using var db = CreateDbContext();
+        db.Sensors.Add(MakeSensor(1));
+        db.UserSensors.Add(new UserSensor { UserId = "u", SensorId = 1, IsOwner = true, SuspendedAt = DateTime.UtcNow.AddDays(-10) });
+        await db.SaveChangesAsync();
+
+        var purged = await SuspendedSensorPurgeService.PurgeExpiredAsync(db, Anonymizer(db), Ownership(), SixMonths);
+
+        Assert.Equal(0, purged);
+        Assert.Single(db.UserSensors);
+    }
+
+    [Fact]
+    public async Task Purge_ActiveSensor_LeftAlone()
+    {
+        using var db = CreateDbContext();
+        db.Sensors.Add(MakeSensor(1));
+        db.UserSensors.Add(new UserSensor { UserId = "u", SensorId = 1, IsOwner = true, SuspendedAt = null });
+        await db.SaveChangesAsync();
+
+        var purged = await SuspendedSensorPurgeService.PurgeExpiredAsync(db, Anonymizer(db), Ownership(), SixMonths);
+
+        Assert.Equal(0, purged);
+        Assert.Single(db.UserSensors);
+    }
+}

--- a/garge-api.Tests/SuspendedSensorPurgeServiceTests.cs
+++ b/garge-api.Tests/SuspendedSensorPurgeServiceTests.cs
@@ -1,6 +1,9 @@
 using garge_api.Models;
+using garge_api.Models.Admin;
 using garge_api.Models.Sensor;
+using garge_api.Models.Subscription;
 using garge_api.Services;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
@@ -8,8 +11,10 @@ using Xunit;
 namespace garge_api.Tests;
 
 /// <summary>
-/// Verifies the 6-month suspension cap: sensors suspended past the retention window are anonymized
-/// (telemetry moved to the ML store) and force-unclaimed; recently suspended or active ones are left alone.
+/// Verifies the 6-month suspension cap. By default a claimed sensor's history is kept for the lifetime
+/// of the claim (legitimate interest), so the purge leaves it alone. Only when the owner has opted out
+/// of retention (Art. 21) AND has no subscription coverage is a sensor suspended past the window
+/// anonymized (telemetry moved to the ML store) and force-unclaimed.
 /// </summary>
 public class SuspendedSensorPurgeServiceTests : ControllerTestBase
 {
@@ -17,6 +22,9 @@ public class SuspendedSensorPurgeServiceTests : ControllerTestBase
         new AnonymizationService(db, NullLogger<AnonymizationService>.Instance);
 
     private static IDeviceOwnershipService Ownership() => new Mock<IDeviceOwnershipService>().Object;
+
+    private static ISubscriptionCapacityService Capacity(ApplicationDbContext db) =>
+        new SubscriptionCapacityService(db, new MemoryCache(new MemoryCacheOptions()));
 
     private static readonly TimeSpan SixMonths = TimeSpan.FromDays(180);
 
@@ -26,10 +34,25 @@ public class SuspendedSensorPurgeServiceTests : ControllerTestBase
         RegistrationCode = $"rc{id}", DefaultName = "Battery", ParentName = "gw"
     };
 
+    private static void AddUser(ApplicationDbContext db, string id, bool optedOut) =>
+        db.Users.Add(new User
+        {
+            Id = id, UserName = id, Email = $"{id}@test.com", FirstName = "A", LastName = "B",
+            DataRetentionOptOutAt = optedOut ? DateTime.UtcNow : null
+        });
+
+    private static void AddActivePrimary(ApplicationDbContext db, string userId)
+    {
+        db.AppSettings.Add(new AppSettings { Id = 1 });
+        db.Products.Add(new Product { Id = 1, Name = "Primary", PriceInOre = 0, Interval = BillingInterval.Monthly, Type = ProductType.Primary });
+        db.Subscriptions.Add(new Subscription { UserId = userId, ProductId = 1, VippsAgreementId = "a", Status = SubscriptionStatus.Active, Quantity = 1 });
+    }
+
     [Fact]
-    public async Task Purge_SensorSuspendedPastCap_AnonymizesAndUnclaims()
+    public async Task Purge_OptedOutNoCoverage_PastCap_AnonymizesAndUnclaims()
     {
         using var db = CreateDbContext();
+        AddUser(db, "u", optedOut: true);
         db.Sensors.Add(MakeSensor(1));
         db.UserSensors.Add(new UserSensor { UserId = "u", SensorId = 1, IsOwner = true, SuspendedAt = DateTime.UtcNow.AddDays(-200) });
         db.SensorOwnershipPeriods.Add(new SensorOwnershipPeriod { UserId = "u", SensorId = 1, StartedAt = SensorOwnershipPeriod.FirstOwnerStart, EndedAt = null });
@@ -38,7 +61,7 @@ public class SuspendedSensorPurgeServiceTests : ControllerTestBase
             new SensorData { SensorId = 1, Value = "12.6", Timestamp = new DateTime(2021, 1, 2, 0, 0, 0, DateTimeKind.Utc) });
         await db.SaveChangesAsync();
 
-        var purged = await SuspendedSensorPurgeService.PurgeExpiredAsync(db, Anonymizer(db), Ownership(), SixMonths);
+        var purged = await SuspendedSensorPurgeService.PurgeExpiredAsync(db, Anonymizer(db), Ownership(), Capacity(db), SixMonths);
 
         Assert.Equal(1, purged);
         Assert.Empty(db.UserSensors);                 // force-unclaimed
@@ -48,28 +71,63 @@ public class SuspendedSensorPurgeServiceTests : ControllerTestBase
     }
 
     [Fact]
-    public async Task Purge_SensorSuspendedWithinCap_LeftAlone()
+    public async Task Purge_NotOptedOut_PastCap_LeftAlone()
     {
+        // Default user keeps history for the lifetime of the claim — never purged, even past the cap.
         using var db = CreateDbContext();
+        AddUser(db, "u", optedOut: false);
         db.Sensors.Add(MakeSensor(1));
-        db.UserSensors.Add(new UserSensor { UserId = "u", SensorId = 1, IsOwner = true, SuspendedAt = DateTime.UtcNow.AddDays(-10) });
+        db.UserSensors.Add(new UserSensor { UserId = "u", SensorId = 1, IsOwner = true, SuspendedAt = DateTime.UtcNow.AddDays(-200) });
         await db.SaveChangesAsync();
 
-        var purged = await SuspendedSensorPurgeService.PurgeExpiredAsync(db, Anonymizer(db), Ownership(), SixMonths);
+        var purged = await SuspendedSensorPurgeService.PurgeExpiredAsync(db, Anonymizer(db), Ownership(), Capacity(db), SixMonths);
 
         Assert.Equal(0, purged);
         Assert.Single(db.UserSensors);
     }
 
     [Fact]
-    public async Task Purge_ActiveSensor_LeftAlone()
+    public async Task Purge_OptedOutButStillHasSubscription_PastCap_LeftAlone()
+    {
+        // A paying user is never purged here, even if opted out — the opt-out only bites after lapse.
+        using var db = CreateDbContext();
+        AddUser(db, "u", optedOut: true);
+        AddActivePrimary(db, "u");
+        db.Sensors.Add(MakeSensor(1));
+        db.UserSensors.Add(new UserSensor { UserId = "u", SensorId = 1, IsOwner = true, SuspendedAt = DateTime.UtcNow.AddDays(-200) });
+        await db.SaveChangesAsync();
+
+        var purged = await SuspendedSensorPurgeService.PurgeExpiredAsync(db, Anonymizer(db), Ownership(), Capacity(db), SixMonths);
+
+        Assert.Equal(0, purged);
+        Assert.Single(db.UserSensors);
+    }
+
+    [Fact]
+    public async Task Purge_OptedOut_SuspendedWithinCap_LeftAlone()
     {
         using var db = CreateDbContext();
+        AddUser(db, "u", optedOut: true);
+        db.Sensors.Add(MakeSensor(1));
+        db.UserSensors.Add(new UserSensor { UserId = "u", SensorId = 1, IsOwner = true, SuspendedAt = DateTime.UtcNow.AddDays(-10) });
+        await db.SaveChangesAsync();
+
+        var purged = await SuspendedSensorPurgeService.PurgeExpiredAsync(db, Anonymizer(db), Ownership(), Capacity(db), SixMonths);
+
+        Assert.Equal(0, purged);
+        Assert.Single(db.UserSensors);
+    }
+
+    [Fact]
+    public async Task Purge_OptedOut_ActiveSensor_LeftAlone()
+    {
+        using var db = CreateDbContext();
+        AddUser(db, "u", optedOut: true);
         db.Sensors.Add(MakeSensor(1));
         db.UserSensors.Add(new UserSensor { UserId = "u", SensorId = 1, IsOwner = true, SuspendedAt = null });
         await db.SaveChangesAsync();
 
-        var purged = await SuspendedSensorPurgeService.PurgeExpiredAsync(db, Anonymizer(db), Ownership(), SixMonths);
+        var purged = await SuspendedSensorPurgeService.PurgeExpiredAsync(db, Anonymizer(db), Ownership(), Capacity(db), SixMonths);
 
         Assert.Equal(0, purged);
         Assert.Single(db.UserSensors);

--- a/garge-api.Tests/SwitchOwnershipWindowTests.cs
+++ b/garge-api.Tests/SwitchOwnershipWindowTests.cs
@@ -147,4 +147,25 @@ public class SwitchOwnershipWindowTests : ControllerTestBase
         Assert.True(bPeriod.StartedAt >= before);
         Assert.Null(bPeriod.EndedAt);
     }
+
+    [Fact]
+    public async Task UnclaimSwitch_RemovesCustomName_AndClosesPeriod()
+    {
+        using var db = CreateDbContext();
+        db.Switches.Add(MakeSwitch());
+        db.UserSwitches.Add(new UserSwitch { UserId = "user-A", SwitchId = SwitchId });
+        db.SwitchOwnershipPeriods.Add(new SwitchOwnershipPeriod
+        {
+            UserId = "user-A", SwitchId = SwitchId, StartedAt = SwitchOwnershipPeriod.FirstOwnerStart, EndedAt = null
+        });
+        db.UserSwitchCustomNames.Add(new UserSwitchCustomName { UserId = "user-A", SwitchId = SwitchId, CustomName = "Heater" });
+        await db.SaveChangesAsync();
+
+        var result = await CreateController(db, "user-A", isAdmin: false).UnclaimSwitch(SwitchId);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Empty(db.UserSwitches);
+        Assert.Empty(db.UserSwitchCustomNames);              // no orphaned custom name
+        Assert.NotNull(db.SwitchOwnershipPeriods.Single(p => p.UserId == "user-A").EndedAt);
+    }
 }

--- a/garge-api.Tests/UserControllerTests.cs
+++ b/garge-api.Tests/UserControllerTests.cs
@@ -203,4 +203,64 @@ public class UserControllerTests : ControllerTestBase
 
         Assert.IsType<NotFoundObjectResult>(result);
     }
+
+    [Fact]
+    public async Task GetDataRetention_ReflectsOptOutState()
+    {
+        using var db = CreateDbContext();
+        var user = MakeDbUser();
+        user.DataRetentionOptOutAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        MockUserManager.Setup(m => m.FindByIdAsync(user.Id)).ReturnsAsync(user);
+
+        var result = await CreateUserController(db, callerId: user.Id).GetDataRetention(user.Id);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var dto = Assert.IsType<DataRetentionDto>(ok.Value);
+        Assert.True(dto.OptOut);
+        Assert.Equal(user.DataRetentionOptOutAt, dto.OptedOutAt);
+    }
+
+    [Fact]
+    public async Task UpdateDataRetention_OptOut_StampsTimestamp()
+    {
+        using var db = CreateDbContext();
+        var user = MakeDbUser();
+        MockUserManager.Setup(m => m.FindByIdAsync(user.Id)).ReturnsAsync(user);
+        MockUserManager.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+
+        var result = await CreateUserController(db, callerId: user.Id)
+            .UpdateDataRetention(user.Id, new UpdateDataRetentionDto { OptOut = true });
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var dto = Assert.IsType<DataRetentionDto>(ok.Value);
+        Assert.True(dto.OptOut);
+        Assert.NotNull(user.DataRetentionOptOutAt);
+    }
+
+    [Fact]
+    public async Task UpdateDataRetention_OptIn_ClearsTimestamp()
+    {
+        using var db = CreateDbContext();
+        var user = MakeDbUser();
+        user.DataRetentionOptOutAt = DateTime.UtcNow;
+        MockUserManager.Setup(m => m.FindByIdAsync(user.Id)).ReturnsAsync(user);
+        MockUserManager.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+
+        var result = await CreateUserController(db, callerId: user.Id)
+            .UpdateDataRetention(user.Id, new UpdateDataRetentionDto { OptOut = false });
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var dto = Assert.IsType<DataRetentionDto>(ok.Value);
+        Assert.False(dto.OptOut);
+        Assert.Null(user.DataRetentionOptOutAt);
+    }
+
+    [Fact]
+    public async Task UpdateDataRetention_OtherUser_ReturnsForbidden()
+    {
+        using var db = CreateDbContext();
+        var result = await CreateUserController(db, callerId: "user-1")
+            .UpdateDataRetention("user-2", new UpdateDataRetentionDto { OptOut = true });
+        Assert.IsType<ForbidResult>(result);
+    }
 }


### PR DESCRIPTION
## Summary

Final backend piece of the suspension/retention lifecycle. **Retention now defaults to the lifetime of the claim** (legitimate interest) rather than a fixed 6-month cap, with a user opt-out (GDPR Art. 21).

### Retention opt-out (Art. 21)
- `User.DataRetentionOptOutAt` (+ migration `AddDataRetentionOptOut`).
- `GET`/`PUT /users/{id}/data-retention` to read/set the opt-out — caller-gated, idempotent (keeps the original opt-out timestamp).

### Suspension cap purge
- `SuspendedSensorPurgeService` (daily `BackgroundService`): a suspended sensor is force-unclaimed and its exclusive telemetry moved to the anonymized ML store **only when** the owner has opted out **and** has no subscription coverage. Default (not opted out) keeps history for the lifetime of the claim, so a returning seasonal subscriber keeps year-over-year data. Paying users are never purged.
- `PurgeExpiredAsync(db, anonymizer, ownership, capacity, retention)` is a testable static.

### Also in this PR (review cleanup)
- **`OwnershipWindowQueryExtensions`** — extracts the resale-safe ownership-window read boundary that was copy-pasted ~10× (SensorController, SwitchesController, BatteryHealthController ×3, UserController.ExportData ×4) into one EF-safe helper; controllers keep one-line delegations. + direct unit tests.
- **`DataRetentionDto.From(DateTime?)`** factory — dedupes the DTO build in both retention endpoints.
- **Unclaim orphan fix** — `UnclaimSensor` now deletes the user's `SensorActivities`/`SensorPhotos`/`SensorOfflineNotifications`; `UnclaimSwitch` deletes `UserSwitchCustomNames` (it cleaned none before). The ownership period is still *closed* (not deleted), so resale history stays hidden.

326 tests passing.

> Stacked on #255 → … → #249. Retarget to `main` as the stack merges.
> Scope note: this PR carries the opt-out mechanism + two review refactors + the unclaim fix alongside the purge job. Happy to split any of them into separate PRs if preferred.
