### PR TITLE
ci: allow on-demand dev deploy via workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: 🚀 Release
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -10,6 +11,7 @@ permissions: {}
 jobs:
   release-please:
     name: Release Please
+    if: ${{ github.event_name == 'push' }}
     uses: equinor/ops-actions/.github/workflows/release-please.yml@f52d0091e07205220002c7abd2c82cab44143d26 # v9.37.3
     permissions:
       contents: write


### PR DESCRIPTION
Adds `workflow_dispatch` to the release workflow so the dev image can be deployed **on demand** from the Actions tab.

`release-please` is gated to `push` events, so a manual run only triggers `deploy-dev` — the prod deploy + chart update stay gated on `release_created`.

> The **Run workflow** button appears once this is merged to `main`.
