### PR TITLE
fix: make account erasure succeed and run atomically

### DIFF
--- a/Controllers/UserController.cs
+++ b/Controllers/UserController.cs
@@ -117,7 +117,12 @@ namespace garge_api.Controllers
 
             // Soft-delete: scrub PII but keep the User row so Orders + Invoices retain
             // a valid FK for the 5-year retention window required by the Norwegian
-            // Bookkeeping Act (bokføringsloven §13).
+            // Bookkeeping Act (bokføringsloven §13). Anonymizing telemetry is irreversible
+            // and AnonymizeUserTelemetryAsync commits as it goes, so the whole sequence runs
+            // in one transaction: if the Identity update fails (e.g. validation), the
+            // anonymization and row removals roll back rather than leaving a half-deleted user.
+            await using var tx = await _context.Database.BeginTransactionAsync();
+
             await AnonymizeUserTelemetryAsync(id);
             ClearUserOwnedRows(id);
             await ScrubUserPiiAsync(user);
@@ -130,6 +135,7 @@ namespace garge_api.Controllers
             }
 
             await _context.SaveChangesAsync();
+            await tx.CommitAsync();
 
             await ForceDisconnectHubAsync(id);
 
@@ -211,8 +217,12 @@ namespace garge_api.Controllers
         {
             user.FirstName = "Deleted";
             user.LastName = "User";
-            user.Email = null;
-            user.NormalizedEmail = null;
+            // A valid, unique placeholder — not null. Identity is configured with
+            // RequireUniqueEmail, so UpdateAsync rejects a null/empty email (this previously
+            // made account deletion fail with InvalidEmail). The .invalid TLD (RFC 2606) is
+            // reserved and never routable, so this address carries no recoverable PII.
+            user.Email = $"deleted-{user.Id}@deleted.invalid";
+            user.NormalizedEmail = user.Email.ToUpperInvariant();
             user.PhoneNumber = null;
             user.UserName = $"deleted-{user.Id}";
             user.NormalizedUserName = $"DELETED-{user.Id}".ToUpperInvariant();

--- a/garge-api.Tests/UserControllerTests.cs
+++ b/garge-api.Tests/UserControllerTests.cs
@@ -71,8 +71,11 @@ public class UserControllerTests : ControllerTestBase
         Assert.NotNull(user.DeletedAt);
         Assert.Equal("Deleted", user.FirstName);
         Assert.Equal("User", user.LastName);
-        Assert.Null(user.Email);
-        Assert.Null(user.NormalizedEmail);
+        // Email must remain a valid, unique, non-PII value — Identity's RequireUniqueEmail
+        // rejects null/empty (regression: account deletion used to 400 with InvalidEmail).
+        Assert.Equal($"deleted-{user.Id}@deleted.invalid", user.Email);
+        Assert.Equal(user.Email!.ToUpperInvariant(), user.NormalizedEmail);
+        Assert.DoesNotContain("user@test.com", user.Email!);
         Assert.Null(user.PhoneNumber);
         Assert.False(user.EmailConfirmed);
         Assert.Equal(DateTimeOffset.MaxValue, user.LockoutEnd);
@@ -137,6 +140,33 @@ public class UserControllerTests : ControllerTestBase
         Assert.Empty(db.SensorPhotos);
         Assert.Empty(db.SensorOwnershipPeriods);
         Assert.Empty(db.UserSensors);
+    }
+
+    [Fact]
+    public async Task DeleteOwnAccount_ScrubbedUser_PassesRealIdentityValidation()
+    {
+        // Regression: ScrubUserPiiAsync used to null out the email, which Identity's
+        // RequireUniqueEmail validator rejects — DeleteOwnAccount then 400'd, and because
+        // anonymization had already committed it left the account half-deleted. Here the mock
+        // UpdateAsync delegates to the real UserValidator so the scrubbed user is genuinely
+        // validated: this fails (BadRequest) on a null email and passes on the placeholder.
+        using var db = CreateDbContext();
+        var user = MakeDbUser();
+        MockUserManager.Setup(m => m.FindByIdAsync(user.Id)).ReturnsAsync(user);
+        MockUserManager.Setup(m => m.UpdateSecurityStampAsync(user)).ReturnsAsync(IdentityResult.Success);
+        MockUserManager.Object.Options = new IdentityOptions { User = { RequireUniqueEmail = true } };
+        MockUserManager.Setup(m => m.GetUserNameAsync(user)).ReturnsAsync(() => user.UserName);
+        MockUserManager.Setup(m => m.GetEmailAsync(user)).ReturnsAsync(() => user.Email);
+        MockUserManager.Setup(m => m.FindByNameAsync(It.IsAny<string>())).ReturnsAsync((User?)null);
+        MockUserManager.Setup(m => m.FindByEmailAsync(It.IsAny<string>())).ReturnsAsync((User?)null);
+        MockUserManager.Setup(m => m.UpdateAsync(user))
+            .Returns(() => new UserValidator<User>().ValidateAsync(MockUserManager.Object, user));
+
+        var result = await CreateUserController(db, callerId: user.Id).DeleteOwnAccount(user.Id);
+
+        Assert.IsType<NoContentResult>(result);
+        Assert.True(user.IsDeleted);
+        Assert.EndsWith("@deleted.invalid", user.Email);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Self-service account deletion (`DELETE /users/{id}/account`) was broken and destructive. Found while verifying the ownership/retention PRs against dev.

`ScrubUserPiiAsync` set `Email` to null. Identity is configured with `RequireUniqueEmail`, so `UpdateAsync` rejected it with `InvalidEmail` and the endpoint always returned 400. Because `AnonymizeUserTelemetryAsync` commits per ownership period *before* that failure, each attempt irreversibly moved the user's telemetry into the anonymized store and deleted their ownership periods, while leaving the account undeleted and an orphaned `UserSensors` row behind.

### Changes
- Scrub `Email` to a valid, unique, non-PII placeholder (`deleted-{id}@deleted.invalid`; `.invalid` is an RFC 2606 reserved TLD) instead of null, so Identity validation passes.
- Wrap anonymize/clear/scrub/update in a single transaction so a later failure rolls back the anonymization instead of half-deleting the account.
- Tests: corrected the soft-delete assertions to expect the placeholder; added a regression test that runs the real `UserValidator` against the scrubbed user (fails on null email, passes on the placeholder).