### PR TITLE
feat: brand the auth code emails (verification + password reset)

### DIFF
--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -2,7 +2,9 @@
 using garge_api.Dtos.Auth;
 using garge_api.Helpers;
 using garge_api.Models;
+using garge_api.Models.Admin;
 using garge_api.Models.Auth;
+using garge_api.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Identity;
@@ -118,7 +120,9 @@ namespace garge_api.Controllers
                 user.EmailVerificationCodeExpiration = DateTime.UtcNow.AddHours(1);
                 await _userManager.UpdateAsync(user);
 
-                await _emailService.SendEmailAsync(user.Email!, "Confirm your email", $"Your verification code is: {verificationCode}");
+                var settings = await _context.AppSettings.FindAsync(1) ?? new AppSettings();
+                await _emailService.SendEmailAsync(user.Email!, "Confirm your email",
+                    AuthEmailTemplates.VerificationCode(settings, user.FirstName, verificationCode));
 
                 _logger.LogInformation("User registered successfully {UserId}", user.Id);
                 return Ok(new { message = genericResponse });
@@ -194,7 +198,9 @@ namespace garge_api.Controllers
                 user.EmailVerificationCodeHash = HashText(verificationCode);
                 user.EmailVerificationCodeExpiration = DateTime.UtcNow.AddHours(1);
                 await _userManager.UpdateAsync(user);
-                await _emailService.SendEmailAsync(user.Email!, "Verify your email", $"Your verification code is: {verificationCode}");
+                var settings = await _context.AppSettings.FindAsync(1) ?? new AppSettings();
+                await _emailService.SendEmailAsync(user.Email!, "Verify your email",
+                    AuthEmailTemplates.VerificationCode(settings, user.FirstName, verificationCode));
                 _logger.LogInformation("Verification code resent for user {UserId}", user.Id);
             }
 
@@ -407,7 +413,9 @@ namespace garge_api.Controllers
                 user.PasswordResetCodeExpiration = DateTime.UtcNow.AddMinutes(30);
                 user.PasswordResetAttempts = 0;
                 await _userManager.UpdateAsync(user);
-                await _emailService.SendEmailAsync(user.Email!, "Password Reset Code", $"Your password reset code is: {code}");
+                var settings = await _context.AppSettings.FindAsync(1) ?? new AppSettings();
+                await _emailService.SendEmailAsync(user.Email!, "Password Reset Code",
+                    AuthEmailTemplates.PasswordReset(settings, user.FirstName, code));
                 _logger.LogInformation("Password reset code sent for user {UserId}", user.Id);
             }
 

--- a/Services/AuthEmailTemplates.cs
+++ b/Services/AuthEmailTemplates.cs
@@ -12,7 +12,9 @@ namespace garge_api.Services
     {
         public static string VerificationCode(AppSettings s, string? firstName, string code) =>
             Build(s,
-                subtitle: "EMAIL VERIFICATION",
+                metaWord: "VERIFY",
+                subtitleLabel: "EMAIL VERIFICATION",
+                codeLabel: "Verification code",
                 heading: "Confirm your email",
                 intro: $"welcome to {H(s.CompanyName)}. Enter the code below to verify your email address and activate your account.",
                 firstName: firstName,
@@ -22,7 +24,9 @@ namespace garge_api.Services
 
         public static string PasswordReset(AppSettings s, string? firstName, string code) =>
             Build(s,
-                subtitle: "PASSWORD RESET",
+                metaWord: "RESET",
+                subtitleLabel: "PASSWORD RESET",
+                codeLabel: "Reset code",
                 heading: "Reset your password",
                 intro: $"we received a request to reset your {H(s.CompanyName)} password. Enter the code below to continue.",
                 firstName: firstName,
@@ -33,21 +37,26 @@ namespace garge_api.Services
         private static string H(string? v) => HttpUtility.HtmlEncode(v ?? string.Empty);
 
         private static string Build(
-            AppSettings s, string subtitle, string heading, string intro,
-            string? firstName, string code, string expiry, string ignoreNote)
+            AppSettings s, string metaWord, string subtitleLabel, string codeLabel, string heading,
+            string intro, string? firstName, string code, string expiry, string ignoreNote)
         {
             var greeting = string.IsNullOrWhiteSpace(firstName) ? "Hi there," : $"Hi {H(firstName)},";
 
             var body = $$"""
                 <h1>{{H(heading)}}</h1>
                 <p>{{greeting}} {{intro}}</p>
+                <div class="code-label">{{H(codeLabel)}}</div>
                 <div class="code-box">{{H(code)}}</div>
                 <div class="footer">
                   <p>This code expires in {{expiry}}. {{ignoreNote}}</p>
                 </div>
                 """;
 
-            return EmailLayout.Render(s, new EmailLayout.Meta { Subtitle = subtitle }, body);
+            return EmailLayout.Render(s, new EmailLayout.Meta
+            {
+                Number = metaWord,
+                Subtitle = $"{subtitleLabel}  ·  {DateTime.UtcNow:yyyy-MM-dd}"
+            }, body);
         }
     }
 }

--- a/Services/AuthEmailTemplates.cs
+++ b/Services/AuthEmailTemplates.cs
@@ -1,0 +1,53 @@
+using garge_api.Models.Admin;
+using System.Web;
+
+namespace garge_api.Services
+{
+    /// <summary>
+    /// Builds the branded HTML for auth code emails (email verification, password
+    /// reset) on the shared <see cref="EmailLayout"/>, so they match the order /
+    /// invoice / subscription mails instead of being plain text.
+    /// </summary>
+    public static class AuthEmailTemplates
+    {
+        public static string VerificationCode(AppSettings s, string? firstName, string code) =>
+            Build(s,
+                subtitle: "EMAIL VERIFICATION",
+                heading: "Confirm your email",
+                intro: $"welcome to {H(s.CompanyName)}. Enter the code below to verify your email address and activate your account.",
+                firstName: firstName,
+                code: code,
+                expiry: "1 hour",
+                ignoreNote: $"If you didn't create a {H(s.CompanyName)} account, you can ignore this email.");
+
+        public static string PasswordReset(AppSettings s, string? firstName, string code) =>
+            Build(s,
+                subtitle: "PASSWORD RESET",
+                heading: "Reset your password",
+                intro: $"we received a request to reset your {H(s.CompanyName)} password. Enter the code below to continue.",
+                firstName: firstName,
+                code: code,
+                expiry: "30 minutes",
+                ignoreNote: "If you didn't request a password reset, you can ignore this email — your password won't change.");
+
+        private static string H(string? v) => HttpUtility.HtmlEncode(v ?? string.Empty);
+
+        private static string Build(
+            AppSettings s, string subtitle, string heading, string intro,
+            string? firstName, string code, string expiry, string ignoreNote)
+        {
+            var greeting = string.IsNullOrWhiteSpace(firstName) ? "Hi there," : $"Hi {H(firstName)},";
+
+            var body = $$"""
+                <h1>{{H(heading)}}</h1>
+                <p>{{greeting}} {{intro}}</p>
+                <div class="code-box">{{H(code)}}</div>
+                <div class="footer">
+                  <p>This code expires in {{expiry}}. {{ignoreNote}}</p>
+                </div>
+                """;
+
+            return EmailLayout.Render(s, new EmailLayout.Meta { Subtitle = subtitle }, body);
+        }
+    }
+}

--- a/Services/EmailLayout.cs
+++ b/Services/EmailLayout.cs
@@ -114,6 +114,15 @@ namespace garge_api.Services
                   .body h1, .body h2 { color: #1a1a1a; margin-bottom: 8px; }
                   .body h1 { font-size: 18px; }
 
+                  .code-box {
+                    text-align: center;
+                    font-family: 'Courier New', Courier, monospace;
+                    font-size: 32px; font-weight: 700; letter-spacing: .3em;
+                    color: #182232; background: #f1f5f9;
+                    border: 1px solid #cbd5e1; border-radius: 8px;
+                    padding: 18px 12px; margin: 20px 0;
+                  }
+
                   table.parties { width: 100%; margin-bottom: 24px; border-collapse: separate; border-spacing: 0; }
                   table.parties td { width: 50%; padding: 0 20px 0 0; vertical-align: top; border: none; background: transparent; }
                   table.parties td.r { padding: 0 0 0 20px; text-align: right; }

--- a/Services/EmailLayout.cs
+++ b/Services/EmailLayout.cs
@@ -114,13 +114,18 @@ namespace garge_api.Services
                   .body h1, .body h2 { color: #1a1a1a; margin-bottom: 8px; }
                   .body h1 { font-size: 18px; }
 
+                  .code-label {
+                    text-align: center;
+                    font-size: 9px; font-weight: 700; text-transform: uppercase;
+                    letter-spacing: .1em; color: #0284c7; margin: 20px 0 6px;
+                  }
                   .code-box {
                     text-align: center;
                     font-family: 'Courier New', Courier, monospace;
                     font-size: 32px; font-weight: 700; letter-spacing: .3em;
                     color: #182232; background: #f1f5f9;
                     border: 1px solid #cbd5e1; border-radius: 8px;
-                    padding: 18px 12px; margin: 20px 0;
+                    padding: 18px 12px; margin: 0 0 20px;
                   }
 
                   table.parties { width: 100%; margin-bottom: 24px; border-collapse: separate; border-spacing: 0; }

--- a/garge-api.Tests/AuthEmailTemplatesTests.cs
+++ b/garge-api.Tests/AuthEmailTemplatesTests.cs
@@ -23,7 +23,9 @@ public class AuthEmailTemplatesTests
         Assert.Contains("<!DOCTYPE html>", html);     // shared layout shell, not plain text
         Assert.Contains("Test Co", html);             // brand header band (from settings)
         Assert.Contains("Confirm your email", html);  // heading
+        Assert.Contains("VERIFY", html);              // bold meta word in header
         Assert.Contains("EMAIL VERIFICATION", html);  // meta subtitle
+        Assert.Contains("Verification code", html);   // blue accent code label
         Assert.Contains("ABC123", html);              // the code
         Assert.Contains("Hi Sondre,", html);          // personalised greeting
         Assert.Contains("1 hour", html);              // verification expiry

--- a/garge-api.Tests/AuthEmailTemplatesTests.cs
+++ b/garge-api.Tests/AuthEmailTemplatesTests.cs
@@ -8,11 +8,11 @@ public class AuthEmailTemplatesTests
 {
     private static AppSettings Settings() => new()
     {
-        CompanyName = "Garge",
-        CompanyLegalName = "Sjølyst Innovations",
-        CompanyOrgNumber = "934 531 035",
-        CompanyAddress = "Mårvegen 21a, 4347 Lye",
-        CompanyEmail = "post@garge.example",
+        CompanyName = "Test Co",
+        CompanyLegalName = "Test Co AS",
+        CompanyOrgNumber = "000 000 000",
+        CompanyAddress = "1 Example Street, 0000 Testby",
+        CompanyEmail = "test@example.com",
     };
 
     [Fact]
@@ -21,7 +21,7 @@ public class AuthEmailTemplatesTests
         var html = AuthEmailTemplates.VerificationCode(Settings(), "Sondre", "ABC123");
 
         Assert.Contains("<!DOCTYPE html>", html);     // shared layout shell, not plain text
-        Assert.Contains("Garge", html);               // brand header band
+        Assert.Contains("Test Co", html);             // brand header band (from settings)
         Assert.Contains("Confirm your email", html);  // heading
         Assert.Contains("EMAIL VERIFICATION", html);  // meta subtitle
         Assert.Contains("ABC123", html);              // the code

--- a/garge-api.Tests/AuthEmailTemplatesTests.cs
+++ b/garge-api.Tests/AuthEmailTemplatesTests.cs
@@ -1,0 +1,61 @@
+using garge_api.Models.Admin;
+using garge_api.Services;
+using Xunit;
+
+namespace garge_api.Tests;
+
+public class AuthEmailTemplatesTests
+{
+    private static AppSettings Settings() => new()
+    {
+        CompanyName = "Garge",
+        CompanyLegalName = "Sjølyst Innovations",
+        CompanyOrgNumber = "934 531 035",
+        CompanyAddress = "Mårvegen 21a, 4347 Lye",
+        CompanyEmail = "post@garge.example",
+    };
+
+    [Fact]
+    public void VerificationCode_RendersBrandedHtml_WithCodeAndCompany()
+    {
+        var html = AuthEmailTemplates.VerificationCode(Settings(), "Sondre", "ABC123");
+
+        Assert.Contains("<!DOCTYPE html>", html);     // shared layout shell, not plain text
+        Assert.Contains("Garge", html);               // brand header band
+        Assert.Contains("Confirm your email", html);  // heading
+        Assert.Contains("EMAIL VERIFICATION", html);  // meta subtitle
+        Assert.Contains("ABC123", html);              // the code
+        Assert.Contains("Hi Sondre,", html);          // personalised greeting
+        Assert.Contains("1 hour", html);              // verification expiry
+    }
+
+    [Fact]
+    public void PasswordReset_RendersBrandedHtml_WithCodeAndExpiry()
+    {
+        var html = AuthEmailTemplates.PasswordReset(Settings(), "Sondre", "ZZ999");
+
+        Assert.Contains("<!DOCTYPE html>", html);
+        Assert.Contains("Reset your password", html);
+        Assert.Contains("PASSWORD RESET", html);
+        Assert.Contains("ZZ999", html);
+        Assert.Contains("30 minutes", html);          // reset code expiry (differs from verification)
+    }
+
+    [Fact]
+    public void VerificationCode_MissingFirstName_FallsBackToGenericGreeting()
+    {
+        var html = AuthEmailTemplates.VerificationCode(Settings(), null, "ABC123");
+
+        Assert.Contains("Hi there,", html);
+        Assert.DoesNotContain("Hi ,", html);
+    }
+
+    [Fact]
+    public void VerificationCode_HtmlEncodesFirstName()
+    {
+        var html = AuthEmailTemplates.VerificationCode(Settings(), "<b>x</b>", "ABC123");
+
+        Assert.DoesNotContain("<b>x</b>", html);
+        Assert.Contains("&lt;b&gt;x&lt;/b&gt;", html);
+    }
+}


### PR DESCRIPTION
## Summary
The auth code emails — "Confirm your email" (register), "Verify your email" (resend), and "Password Reset Code" — were sent as plain text and didn't match the branded order / invoice / subscription mails.

They now render on the shared `EmailLayout`, consistent with the other transactional emails:

- New `AuthEmailTemplates` builds the verification and password-reset bodies: a purpose-led heading, a "Hi {name}," intro (matching `SubscriptionEmailService`'s charge-failed mail), a prominent code box, and a footer note. Expiry text matches each flow (verification 1 hour, reset 30 minutes).
- **Header** carries the same weight as the others: a big bold action word (`VERIFY` / `RESET`) in the number slot plus a dated `TYPE · date` subtitle (auth has no order/invoice number to place there).
- **Body** uses the shared design language: a blue accent micro-label above the code (the same uppercase-blue accent as the parties / table headers), via reusable `.code-box` + `.code-label` styles added to `EmailLayout`.
- `AuthController` (register, resend-verification, request-password-reset) now sends the branded HTML.
- `AuthEmailTemplatesTests` cover the rendered code, header word, headings, expiry, greeting fallback, and HTML-encoding — using fictional company data, not real config.
