### PR TITLE
fix: surface registration field errors (e.g. username taken)

### DIFF
--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -129,8 +129,22 @@ namespace garge_api.Controllers
             }
 
             _logger.LogError("Register failed: {@Errors}", result.Errors);
-            return BadRequest(result.Errors);
+
+            // Return the field-keyed shape the client parses (parseValidationErrors) so a
+            // server-only failure like a taken username surfaces on its field instead of a
+            // generic "failed to register". Identity emits username / email / password codes.
+            var fieldErrors = result.Errors
+                .GroupBy(e => RegisterErrorField(e.Code))
+                .ToDictionary(g => g.Key, g => g.Select(e => e.Description).ToArray());
+            return BadRequest(new { errors = fieldErrors });
         }
+
+        /// <summary>Maps an ASP.NET Identity error code to the registration form field it belongs to.</summary>
+        private static string RegisterErrorField(string code) =>
+            code.Contains("UserName", StringComparison.OrdinalIgnoreCase) ? "UserName"
+            : code.Contains("Email", StringComparison.OrdinalIgnoreCase) ? "Email"
+            : code.Contains("Password", StringComparison.OrdinalIgnoreCase) ? "Password"
+            : "UserName";
 
         /// <summary>
         /// Logs in a user.

--- a/garge-api.Tests/AuthControllerTests.cs
+++ b/garge-api.Tests/AuthControllerTests.cs
@@ -328,4 +328,32 @@ public class AuthControllerTests : ControllerTestBase
         Assert.IsType<OkObjectResult>(result);
         MockUserManager.Verify(m => m.CreateAsync(It.IsAny<User>(), It.IsAny<string>()), Times.Never);
     }
+
+    [Fact]
+    public async Task Register_DuplicateUserName_ReturnsFieldKeyedError()
+    {
+        MockUserManager.Setup(m => m.FindByEmailAsync(It.IsAny<string>())).ReturnsAsync((User?)null);
+        MockMapper.Setup(m => m.Map<User>(It.IsAny<RegisterUserDto>()))
+            .Returns((RegisterUserDto src) => new User
+            {
+                Id = "u", UserName = src.UserName, Email = src.Email,
+                FirstName = src.FirstName, LastName = src.LastName
+            });
+        MockUserManager.Setup(m => m.CreateAsync(It.IsAny<User>(), It.IsAny<string>()))
+            .ReturnsAsync(IdentityResult.Failed(new IdentityError
+            {
+                Code = "DuplicateUserName",
+                Description = "Username 'user' is already taken."
+            }));
+
+        var result = await CreateAuthController(CreateDbContext()).Register(MakeRegisterDto());
+
+        // Field-keyed shape the client can map to the username field (issue #75),
+        // not the raw Identity array that surfaced as a generic "failed to register".
+        var bad = Assert.IsType<BadRequestObjectResult>(result);
+        var errorsObj = bad.Value!.GetType().GetProperty("errors")!.GetValue(bad.Value);
+        var errors = Assert.IsAssignableFrom<IDictionary<string, string[]>>(errorsObj);
+        Assert.True(errors.ContainsKey("UserName"));
+        Assert.Contains("already taken", errors["UserName"][0]);
+    }
 }


### PR DESCRIPTION
## Summary
Fixes the registration error reported in sondresjolyst/garge-app#75: a taken username (and other server-only failures) showed a generic "Failed to register" instead of a useful message.

**Cause:** on `CreateAsync` failure, `Register` returned the raw ASP.NET Identity error array (`[{code, description}]`). The client's `parseValidationErrors` only understands the `{ errors: { Field: [...] } }` shape and `formatApiError` only reads a string / `{message}`, so neither could read the array → it fell back to the generic message. (Password-rule errors still showed because those are validated client-side by the zod schema, never via this path.)

**Fix:** map the Identity errors to the field-keyed shape the client already parses — username codes → `UserName`, email → `Email`, password → `Password`. The duplicate-username message now lands on the username field, and any other server-only registration error surfaces on its field too. No frontend change needed (the register form already renders `errors.userName`).

Added `Register_DuplicateUserName_ReturnsFieldKeyedError` covering the mapping.
