### PR TITLE
fix: exempt subscription-bypass roles from auto-suspend and ML purge

### DIFF
--- a/Controllers/SensorController.cs
+++ b/Controllers/SensorController.cs
@@ -69,6 +69,33 @@ namespace garge_api.Controllers
             => query.WithinSensorOwnership(_context, User.UserId(), IsAdmin());
 
         /// <summary>
+        /// Returns the caller's sensor capacity and whether they can claim another sensor — the single
+        /// source of truth for the claim button and capacity meter, so the client never re-derives
+        /// capacity or the subscription-bypass role list.
+        /// </summary>
+        [HttpGet("capacity")]
+        [Authorize]
+        [SwaggerOperation(Summary = "Gets the caller's sensor capacity and claim eligibility.")]
+        [SwaggerResponse(200, "Capacity returned.", typeof(SensorCapacityDto))]
+        public async Task<IActionResult> GetMyCapacity()
+        {
+            var userId = User.UserId();
+            if (string.IsNullOrEmpty(userId)) return Unauthorized();
+
+            var bypass = await _capacity.HasSubscriptionBypassAsync(userId);
+            var capacity = await _capacity.GetCapacityAsync(userId);
+            var used = await _capacity.GetActiveOwnedSensorCountAsync(userId);
+
+            return Ok(new SensorCapacityDto
+            {
+                Capacity = capacity,
+                Used = used,
+                Bypass = bypass,
+                CanClaim = bypass || used < capacity,
+            });
+        }
+
+        /// <summary>
         /// True when the caller has this owned sensor suspended (turned off / over quota). Suspended
         /// sensors stay visible in the list but their dashboard/history reads are blocked. Admins are
         /// never suspended. Export and unclaim/delete must never use this gate (GDPR rights).

--- a/Dtos/Sensor/SensorCapacityDto.cs
+++ b/Dtos/Sensor/SensorCapacityDto.cs
@@ -1,0 +1,18 @@
+namespace garge_api.Dtos.Sensor
+{
+    /// <summary>The caller's sensor capacity and whether they may claim another sensor.</summary>
+    public sealed class SensorCapacityDto
+    {
+        /// <summary>Sensors covered by the active subscription (1 Primary + add-on quantities); 0 without one.</summary>
+        public int Capacity { get; set; }
+
+        /// <summary>Active (non-suspended) owned sensors currently consuming capacity.</summary>
+        public int Used { get; set; }
+
+        /// <summary>True when a role grants service access without a subscription (e.g. ComplimentaryUser) — no capacity limit.</summary>
+        public bool Bypass { get; set; }
+
+        /// <summary>True when the caller may claim another sensor.</summary>
+        public bool CanClaim { get; set; }
+    }
+}

--- a/Services/QuotaReconciliationService.cs
+++ b/Services/QuotaReconciliationService.cs
@@ -62,6 +62,9 @@ namespace garge_api.Services
 
             foreach (var userId in ownerIds)
             {
+                // Complimentary / service-account / admin roles have no capacity limit — never suspend them.
+                if (await capacity.HasSubscriptionBypassAsync(userId, ct)) continue;
+
                 var cap = await capacity.GetCapacityAsync(userId, ct);
 
                 var activeOwned = await db.UserSensors

--- a/Services/SubscriptionCapacityService.cs
+++ b/Services/SubscriptionCapacityService.cs
@@ -1,3 +1,4 @@
+using garge_api.Constants;
 using garge_api.Models;
 using garge_api.Models.Sensor;
 using garge_api.Models.Subscription;
@@ -18,6 +19,13 @@ namespace garge_api.Services
     {
         Task<int> GetCapacityAsync(string userId, CancellationToken ct = default);
         Task<int> GetActiveOwnedSensorCountAsync(string userId, CancellationToken ct = default);
+
+        /// <summary>
+        /// True when the user holds a role that grants service access without a subscription
+        /// (see <see cref="RoleNames.SubscriptionBypassRoles"/>, e.g. ComplimentaryUser, DeviceBridge,
+        /// admins). Such users have no capacity limit and must never be auto-suspended or purged.
+        /// </summary>
+        Task<bool> HasSubscriptionBypassAsync(string userId, CancellationToken ct = default);
     }
 
     public class SubscriptionCapacityService : ISubscriptionCapacityService
@@ -34,6 +42,14 @@ namespace garge_api.Services
 
         public Task<int> GetActiveOwnedSensorCountAsync(string userId, CancellationToken ct = default)
             => _db.UserSensors.CountAsync(us => us.UserId == userId && us.IsOwner && us.SuspendedAt == null, ct);
+
+        public Task<bool> HasSubscriptionBypassAsync(string userId, CancellationToken ct = default)
+        {
+            var roleIds = _db.UserRoles.Where(ur => ur.UserId == userId).Select(ur => ur.RoleId);
+            return _db.Roles
+                .Where(r => roleIds.Contains(r.Id) && r.Name != null && RoleNames.SubscriptionBypassRoles.Contains(r.Name))
+                .AnyAsync(ct);
+        }
 
         public async Task<int> GetCapacityAsync(string userId, CancellationToken ct = default)
         {

--- a/Services/SuspendedSensorPurgeService.cs
+++ b/Services/SuspendedSensorPurgeService.cs
@@ -79,11 +79,13 @@ namespace garge_api.Services
             var purged = 0;
             foreach (var item in expired)
             {
-                // A paying user (active or paid-period grace) keeps their data even if opted out — the
-                // opt-out only takes effect once there is no subscription left to honour.
+                // A paying user (active or paid-period grace), or one with a subscription-bypass role
+                // (complimentary, service account, admin), keeps their data even if opted out — the
+                // opt-out only takes effect once there is no coverage left to honour.
                 if (!coverageCache.TryGetValue(item.UserId, out var hasCoverage))
                 {
-                    hasCoverage = await capacity.GetCapacityAsync(item.UserId, ct) > 0;
+                    hasCoverage = await capacity.HasSubscriptionBypassAsync(item.UserId, ct)
+                        || await capacity.GetCapacityAsync(item.UserId, ct) > 0;
                     coverageCache[item.UserId] = hasCoverage;
                 }
                 if (hasCoverage)

--- a/garge-api.Tests/QuotaReconciliationServiceTests.cs
+++ b/garge-api.Tests/QuotaReconciliationServiceTests.cs
@@ -3,6 +3,7 @@ using garge_api.Models.Admin;
 using garge_api.Models.Sensor;
 using garge_api.Models.Subscription;
 using garge_api.Services;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Caching.Memory;
 using Xunit;
 
@@ -74,5 +75,29 @@ public class QuotaReconciliationServiceTests : ControllerTestBase
 
         Assert.Equal(2, suspended);
         Assert.All(db.UserSensors.ToList(), us => Assert.NotNull(us.SuspendedAt));
+    }
+
+    [Fact]
+    public async Task Reconcile_SubscriptionBypassRole_DoesNotSuspend()
+    {
+        // A ComplimentaryUser (or service account / admin) has no capacity limit, even with no subscription.
+        using var db = CreateDbContext();
+        db.AppSettings.Add(new AppSettings { Id = 1 }); // no Primary → capacity 0
+        GrantRole(db, "u", "ComplimentaryUser");
+        var t0 = new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        db.UserSensors.AddRange(Owned("u", 1, t0), Owned("u", 2, t0.AddDays(1)));
+        await db.SaveChangesAsync();
+
+        var suspended = await QuotaReconciliationService.ReconcileAsync(db, Capacity(db));
+
+        Assert.Equal(0, suspended);
+        Assert.All(db.UserSensors.ToList(), us => Assert.Null(us.SuspendedAt));
+    }
+
+    private static void GrantRole(ApplicationDbContext db, string userId, string roleName)
+    {
+        var roleId = $"role-{roleName}";
+        db.Roles.Add(new IdentityRole { Id = roleId, Name = roleName, NormalizedName = roleName.ToUpperInvariant() });
+        db.UserRoles.Add(new IdentityUserRole<string> { UserId = userId, RoleId = roleId });
     }
 }

--- a/garge-api.Tests/SensorCapacityEndpointTests.cs
+++ b/garge-api.Tests/SensorCapacityEndpointTests.cs
@@ -1,0 +1,90 @@
+using garge_api.Controllers;
+using garge_api.Dtos.Sensor;
+using garge_api.Hubs;
+using garge_api.Models;
+using garge_api.Models.Admin;
+using garge_api.Models.Sensor;
+using garge_api.Models.Subscription;
+using garge_api.Services;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace garge_api.Tests;
+
+public class SensorCapacityEndpointTests : ControllerTestBase
+{
+    private SensorController CreateController(ApplicationDbContext db, string userId)
+    {
+        var hub = new Mock<IHubContext<DeviceHub>>();
+        var capacity = new SubscriptionCapacityService(db, new MemoryCache(new MemoryCacheOptions()));
+        var controller = new SensorController(
+            db, MockMapper.Object, NullLogger<SensorController>.Instance,
+            new Mock<IDeviceOwnershipService>().Object, hub.Object, capacity);
+        controller.ControllerContext = MakeControllerContext(userId);
+        return controller;
+    }
+
+    private static void GrantRole(ApplicationDbContext db, string userId, string roleName)
+    {
+        var roleId = $"role-{roleName}";
+        db.Roles.Add(new IdentityRole { Id = roleId, Name = roleName, NormalizedName = roleName.ToUpperInvariant() });
+        db.UserRoles.Add(new IdentityUserRole<string> { UserId = userId, RoleId = roleId });
+    }
+
+    private static void AddActivePrimary(ApplicationDbContext db, string userId)
+    {
+        db.Products.Add(new Product { Id = 1, Name = "Primary", PriceInOre = 0, Interval = BillingInterval.Monthly, Type = ProductType.Primary });
+        db.Subscriptions.Add(new Subscription { UserId = userId, ProductId = 1, VippsAgreementId = "a", Status = SubscriptionStatus.Active, Quantity = 1 });
+    }
+
+    [Fact]
+    public async Task GetMyCapacity_NoSubscription_ZeroAndCannotClaim()
+    {
+        using var db = CreateDbContext();
+        db.AppSettings.Add(new AppSettings { Id = 1 });
+        await db.SaveChangesAsync();
+
+        var result = await CreateController(db, "u").GetMyCapacity();
+
+        var dto = Assert.IsType<SensorCapacityDto>(Assert.IsType<OkObjectResult>(result).Value);
+        Assert.Equal(0, dto.Capacity);
+        Assert.False(dto.Bypass);
+        Assert.False(dto.CanClaim);
+    }
+
+    [Fact]
+    public async Task GetMyCapacity_ActivePrimaryWithRoom_CanClaim()
+    {
+        using var db = CreateDbContext();
+        db.AppSettings.Add(new AppSettings { Id = 1 });
+        AddActivePrimary(db, "u"); // capacity 1
+        await db.SaveChangesAsync();
+
+        var result = await CreateController(db, "u").GetMyCapacity();
+
+        var dto = Assert.IsType<SensorCapacityDto>(Assert.IsType<OkObjectResult>(result).Value);
+        Assert.Equal(1, dto.Capacity);
+        Assert.Equal(0, dto.Used);
+        Assert.True(dto.CanClaim);
+    }
+
+    [Fact]
+    public async Task GetMyCapacity_ComplimentaryUser_BypassesWithNoSubscription()
+    {
+        using var db = CreateDbContext();
+        db.AppSettings.Add(new AppSettings { Id = 1 });
+        GrantRole(db, "u", "ComplimentaryUser");
+        await db.SaveChangesAsync();
+
+        var result = await CreateController(db, "u").GetMyCapacity();
+
+        var dto = Assert.IsType<SensorCapacityDto>(Assert.IsType<OkObjectResult>(result).Value);
+        Assert.True(dto.Bypass);
+        Assert.True(dto.CanClaim); // claims allowed despite capacity 0 + no subscription
+    }
+}

--- a/garge-api.Tests/SuspendedSensorPurgeServiceTests.cs
+++ b/garge-api.Tests/SuspendedSensorPurgeServiceTests.cs
@@ -3,6 +3,7 @@ using garge_api.Models.Admin;
 using garge_api.Models.Sensor;
 using garge_api.Models.Subscription;
 using garge_api.Services;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -131,5 +132,30 @@ public class SuspendedSensorPurgeServiceTests : ControllerTestBase
 
         Assert.Equal(0, purged);
         Assert.Single(db.UserSensors);
+    }
+
+    [Fact]
+    public async Task Purge_OptedOutBypassRole_PastCap_LeftAlone()
+    {
+        // A ComplimentaryUser (or service account / admin) has coverage by role — never purged,
+        // even opted out, with no subscription, past the cap.
+        using var db = CreateDbContext();
+        AddUser(db, "u", optedOut: true);
+        GrantRole(db, "u", "ComplimentaryUser");
+        db.Sensors.Add(MakeSensor(1));
+        db.UserSensors.Add(new UserSensor { UserId = "u", SensorId = 1, IsOwner = true, SuspendedAt = DateTime.UtcNow.AddDays(-200) });
+        await db.SaveChangesAsync();
+
+        var purged = await SuspendedSensorPurgeService.PurgeExpiredAsync(db, Anonymizer(db), Ownership(), Capacity(db), SixMonths);
+
+        Assert.Equal(0, purged);
+        Assert.Single(db.UserSensors);
+    }
+
+    private static void GrantRole(ApplicationDbContext db, string userId, string roleName)
+    {
+        var roleId = $"role-{roleName}";
+        db.Roles.Add(new IdentityRole { Id = roleId, Name = roleName, NormalizedName = roleName.ToUpperInvariant() });
+        db.UserRoles.Add(new IdentityUserRole<string> { UserId = userId, RoleId = roleId });
     }
 }


### PR DESCRIPTION
## Summary
`ComplimentaryUser`, `DeviceBridge`, and admin roles are allowed to use the service **without a subscription** — the claim gate already honors this via `RoleNames.SubscriptionBypassRoles`. But the retention/quota lifecycle didn't: it only asked `SubscriptionCapacityService`, which returns capacity **0** for a sub-free user.

Result: a complimentary user could claim a sensor, then have it **auto-suspended that night** by `QuotaReconciliationService` and — if opted out of retention — **anonymized into the ML store after 180 days** by `SuspendedSensorPurgeService`. Same exposure for the `DeviceBridge` service account.

### Changes
- `ISubscriptionCapacityService.HasSubscriptionBypassAsync(userId)` — looks up whether the user holds any `SubscriptionBypassRoles`.
- `QuotaReconciliationService` skips bypass-role owners (no capacity limit → never suspended).
- `SuspendedSensorPurgeService` treats a bypass role as coverage (`bypass || capacity > 0`) → never purged.
- **New `GET /api/sensors/capacity`** → `{ capacity, used, bypass, canClaim }`, computed server-side — the single source of truth for the claim button and capacity meter, so the frontend never re-derives capacity or duplicates the bypass-role list.
- Tests: reconcile/purge bypass cases + the capacity endpoint (no-subscription, active-primary, complimentary).

Frontend counterpart: garge-app #331 (consumes the endpoint). Merge + deploy this first.
