### PR TITLE
fix: resolve subscription-bypass from the DB in the claim authz handler

### DIFF
--- a/Authorization/ActiveSubscriptionHandler.cs
+++ b/Authorization/ActiveSubscriptionHandler.cs
@@ -1,4 +1,3 @@
-using garge_api.Constants;
 using garge_api.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
@@ -35,14 +34,18 @@ namespace garge_api.Authorization
             var userId = context.User.UserId();
             if (userId == null) return;
 
-            if (RoleNames.SubscriptionBypassRoles.Any(r => context.User.IsInRole(r)))
+            using var scope = _scopeFactory.CreateScope();
+            var capacityService = scope.ServiceProvider.GetRequiredService<ISubscriptionCapacityService>();
+
+            // Subscription-bypass roles (complimentary / service-account / admin) have no capacity
+            // limit. Resolve from the DB — not the JWT (context.User.IsInRole) — so this matches
+            // GET /sensors/capacity exactly and works even when the role was granted after the
+            // user's token was issued (otherwise the meter shows access but the claim 403s).
+            if (await capacityService.HasSubscriptionBypassAsync(userId))
             {
                 context.Succeed(requirement);
                 return;
             }
-
-            using var scope = _scopeFactory.CreateScope();
-            var capacityService = scope.ServiceProvider.GetRequiredService<ISubscriptionCapacityService>();
 
             var capacity = await capacityService.GetCapacityAsync(userId);
             var activeOwned = await capacityService.GetActiveOwnedSensorCountAsync(userId);

--- a/garge-api.Tests/ActiveSubscriptionHandlerTests.cs
+++ b/garge-api.Tests/ActiveSubscriptionHandlerTests.cs
@@ -5,6 +5,7 @@ using garge_api.Services;
 using garge_api.Models.Sensor;
 using garge_api.Models.Subscription;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
@@ -46,13 +47,19 @@ public class ActiveSubscriptionHandlerTests
         return (handler, db);
     }
 
-    private static AuthorizationHandlerContext MakeContext(string userId, params string[] roles)
+    private static AuthorizationHandlerContext MakeContext(string userId)
     {
         var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, userId) };
-        foreach (var role in roles)
-            claims.Add(new(ClaimTypes.Role, role));
         var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
         return new AuthorizationHandlerContext([new ActiveSubscriptionRequirement()], principal, null);
+    }
+
+    // Bypass is resolved from the DB (UserRoles), not the JWT — seed the role the same way.
+    private static void GrantRole(ApplicationDbContext db, string userId, string roleName)
+    {
+        var roleId = $"role-{roleName}";
+        db.Roles.Add(new IdentityRole { Id = roleId, Name = roleName, NormalizedName = roleName.ToUpperInvariant() });
+        db.UserRoles.Add(new IdentityUserRole<string> { UserId = userId, RoleId = roleId });
     }
 
     private static Subscription Primary(string userId, SubscriptionStatus status = SubscriptionStatus.Active, int quantity = 1, bool isTest = false)
@@ -76,11 +83,17 @@ public class ActiveSubscriptionHandlerTests
     [InlineData("Admin")]
     [InlineData("SensorAdmin")]
     [InlineData("MqttAdmin")]
-    public async Task BypassRole_Succeeds_WithoutCheckingDb(string role)
+    [InlineData("ComplimentaryUser")]
+    public async Task BypassRole_Succeeds(string role)
     {
-        var (handler, _) = Create();
-        var ctx = MakeContext("user-1", role);
+        // A subscription-bypass role grants claim access with no capacity. The role lives in the DB
+        // and is NOT in the token (MakeContext adds no role claim) — proving the handler resolves
+        // bypass from the DB, so a freshly granted role works without forcing a re-login.
+        var (handler, db) = Create();
+        GrantRole(db, "user-1", role);
+        await db.SaveChangesAsync();
 
+        var ctx = MakeContext("user-1");
         await Handle(handler, ctx);
 
         Assert.True(ctx.HasSucceeded);


### PR DESCRIPTION
## Summary

`ActiveSubscriptionHandler` (gates sensor/switch **claim**) resolved subscription-bypass roles via `context.User.IsInRole`, which reads the **JWT**. A role granted *after* the user's token was issued — e.g. making an existing, already-logged-in user a `ComplimentaryUser` — stayed invisible to the claim until the token refreshed or they logged in again.

`GET /sensors/capacity` (#263) already resolves bypass from the **DB** (`HasSubscriptionBypassAsync`). So the capacity meter showed *"Complimentary access"* while the actual claim returned **403** — the bug reported for complimentary users.

This resolves bypass in the handler from the same DB-backed source, so both agree and the role takes effect immediately (no re-login). Other role-gated endpoints stay token-based; complimentary is the role toggled for already-logged-in users.

Test `BypassRole_Succeeds` now seeds the role in the DB (no role claim in the token) to prove the handler is DB-backed, and adds a `ComplimentaryUser` case.
