### PR TITLE
feat: reflect user churn in admin stats + deleted-user toggle

### DIFF
--- a/Controllers/AdminController.cs
+++ b/Controllers/AdminController.cs
@@ -210,17 +210,21 @@ namespace garge_api.Controllers
         }
 
         /// <summary>
-        /// Gets all users with their roles.
+        /// Gets all users with their roles. Soft-deleted (scrubbed) accounts are hidden by default;
+        /// pass includeDeleted=true to include them (e.g. an admin "Show deleted" toggle).
         /// </summary>
+        /// <param name="includeDeleted">When true, also returns soft-deleted accounts.</param>
         /// <returns>A list of all users.</returns>
         [HttpGet("/api/users")]
         [SwaggerOperation(Summary = "Gets all users.")]
         [SwaggerResponse(200, "Users retrieved successfully.", typeof(IEnumerable<UserDto>))]
-        public async Task<IActionResult> GetUsers()
+        public async Task<IActionResult> GetUsers([FromQuery] bool includeDeleted = false)
         {
-            _logger.LogInformation("GetUsers called by {@LogData}", new { CallerUserId = User.UserId() });
+            _logger.LogInformation("GetUsers called by {@LogData}", new { CallerUserId = User.UserId(), IncludeDeleted = includeDeleted });
 
-            var users = _userManager.Users.ToList();
+            var query = _userManager.Users;
+            if (!includeDeleted) query = query.Where(u => !u.IsDeleted);
+            var users = query.ToList();
             var dtos = new List<UserDto>();
             foreach (var user in users)
             {
@@ -247,7 +251,7 @@ namespace garge_api.Controllers
             // Monday-start ISO week.
             var weekStart = today.AddDays(-(((int)today.DayOfWeek + 6) % 7));
 
-            var totalUsers = await _userManager.Users.CountAsync();
+            var totalUsers = await _userManager.Users.CountAsync(u => !u.IsDeleted);
             var totalSensors = await _context.Sensors.CountAsync();
             var totalSwitches = await _context.Switches.CountAsync();
             var activeAutomations = await _context.AutomationRules.CountAsync(r => r.IsEnabled);
@@ -349,6 +353,14 @@ namespace garge_api.Controllers
                 .Select(u => u.CreatedAt.Date)
                 .ToListAsync();
 
+            // Account deletions decrement the running total so the line dips on churn, not just climbs.
+            // Scrubbed (soft-deleted) rows keep CreatedAt, so they were counted on signup — subtract
+            // them again on their DeletedAt date.
+            var userDeletedDates = await _userManager.Users
+                .Where(u => u.IsDeleted && u.DeletedAt != null)
+                .Select(u => u.DeletedAt!.Value.Date)
+                .ToListAsync();
+
             var sensorDates = await _context.Sensors
                 .Select(s => s.CreatedAt.Date)
                 .ToListAsync();
@@ -375,7 +387,7 @@ namespace garge_api.Controllers
 
             for (var date = start; date <= today; date = date.AddDays(1))
             {
-                users += userDates.Count(d => d == date);
+                users += userDates.Count(d => d == date) - userDeletedDates.Count(d => d == date);
                 sensors += sensorDates.Count(d => d == date);
                 switches += switchDates.Count(d => d == date);
                 automations += automationDates.Count(d => d == date);

--- a/Dtos/Admin/UserDto.cs
+++ b/Dtos/Admin/UserDto.cs
@@ -7,6 +7,7 @@
         public required string FirstName { get; set; }
         public required string LastName { get; set; }
         public required string Email { get; set; }
+        public bool IsDeleted { get; set; }
         public IList<string> Roles { get; set; } = [];
     }
 }

--- a/garge-api.Tests/AdminControllerTests.cs
+++ b/garge-api.Tests/AdminControllerTests.cs
@@ -273,6 +273,109 @@ public class AdminControllerTests : ControllerTestBase
         Assert.Equal(1, dto.Subscriptions.StoppedThisMonth);
     }
 
+    private static User MakeUser(string id, DateTime createdAt, bool deleted = false, DateTime? deletedAt = null) => new()
+    {
+        Id = id, UserName = id, Email = $"{id}@test.com", FirstName = "Test", LastName = "User",
+        CreatedAt = createdAt, IsDeleted = deleted, DeletedAt = deletedAt,
+    };
+
+    private void SetupUserMapAndRoles()
+    {
+        MockMapper.Setup(m => m.Map<UserDto>(It.IsAny<User>()))
+            .Returns((User u) => new UserDto
+            {
+                Id = u.Id!, UserName = u.UserName ?? "", FirstName = u.FirstName, LastName = u.LastName,
+                Email = u.Email ?? "", IsDeleted = u.IsDeleted,
+            });
+        MockUserManager.Setup(m => m.GetRolesAsync(It.IsAny<User>())).ReturnsAsync(new List<string>());
+    }
+
+    private static int TotalUsersOn(List<object> rows, DateTime date)
+    {
+        var key = date.ToString("yyyy-MM-dd");
+        var row = rows.Single(r => (string)r.GetType().GetProperty("date")!.GetValue(r)! == key);
+        return (int)row.GetType().GetProperty("totalUsers")!.GetValue(row)!;
+    }
+
+    [Fact]
+    public async Task GetStats_TotalUsers_ExcludesDeleted()
+    {
+        var db = CreateDbContext();
+        MockUserManager.Setup(m => m.Users).Returns(db.Users);
+        db.Users.AddRange(
+            MakeUser("u1", DateTime.UtcNow),
+            MakeUser("u2", DateTime.UtcNow),
+            MakeUser("u3", DateTime.UtcNow, deleted: true, deletedAt: DateTime.UtcNow));
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await CreateAdminController(db).GetStats();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var dto = Assert.IsType<AdminStatsDto>(ok.Value);
+        Assert.Equal(2, dto.TotalUsers);
+    }
+
+    [Fact]
+    public async Task GetStatsHistory_SubtractsDeletionsOnDeletedDate()
+    {
+        // Three users sign up on d1; one deletes on d2. The running total climbs to 3, then dips to 2.
+        var db = CreateDbContext();
+        MockUserManager.Setup(m => m.Users).Returns(db.Users);
+        var today = DateTime.UtcNow.Date;
+        var d1 = today.AddDays(-3);
+        var d2 = today.AddDays(-2);
+        db.Users.AddRange(
+            MakeUser("u1", d1),
+            MakeUser("u2", d1),
+            MakeUser("u3", d1, deleted: true, deletedAt: d2));
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await CreateAdminController(db).GetStatsHistory();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var rows = Assert.IsType<List<object>>(ok.Value);
+        Assert.Equal(3, TotalUsersOn(rows, d1));
+        Assert.Equal(2, TotalUsersOn(rows, d2));
+        Assert.Equal(2, TotalUsersOn(rows, today));
+    }
+
+    [Fact]
+    public async Task GetUsers_HidesDeletedByDefault()
+    {
+        var db = CreateDbContext();
+        SetupUserMapAndRoles();
+        MockUserManager.Setup(m => m.Users).Returns(db.Users);
+        db.Users.AddRange(
+            MakeUser("u1", DateTime.UtcNow),
+            MakeUser("u2", DateTime.UtcNow, deleted: true, deletedAt: DateTime.UtcNow));
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await CreateAdminController(db).GetUsers();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var dtos = Assert.IsType<List<UserDto>>(ok.Value);
+        Assert.Equal("u1", Assert.Single(dtos).Id);
+    }
+
+    [Fact]
+    public async Task GetUsers_IncludeDeleted_ReturnsAllWithFlag()
+    {
+        var db = CreateDbContext();
+        SetupUserMapAndRoles();
+        MockUserManager.Setup(m => m.Users).Returns(db.Users);
+        db.Users.AddRange(
+            MakeUser("u1", DateTime.UtcNow),
+            MakeUser("u2", DateTime.UtcNow, deleted: true, deletedAt: DateTime.UtcNow));
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await CreateAdminController(db).GetUsers(includeDeleted: true);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var dtos = Assert.IsType<List<UserDto>>(ok.Value);
+        Assert.Equal(2, dtos.Count);
+        Assert.Contains(dtos, d => d.Id == "u2" && d.IsDeleted);
+    }
+
     [Fact]
     public async Task AssignPermission_UnknownPermission_Returns400()
     {


### PR DESCRIPTION
## Summary

Two admin-stats improvements around deleted users.

**User line dips on churn.** `GET /api/admin/stats/history` was cumulative on `CreatedAt`, so the user count could only climb. It now subtracts account deletions on their `DeletedAt` date, so the line dips when users leave. `TotalUsers` in `GET /api/admin/stats` counts only active users (`!IsDeleted`) instead of being inflated by scrubbed rows.

**Deleted-user toggle.** `GET /api/users` now hides soft-deleted (scrubbed) accounts by default and accepts `includeDeleted=true` for an admin "Show deleted" toggle. `UserDto` carries `IsDeleted` so the UI can badge them.

Frontend toggle: garge-app `feat/admin-stats-churn`.

## Tests
- `GetStats_TotalUsers_ExcludesDeleted`
- `GetStatsHistory_SubtractsDeletionsOnDeletedDate` (climbs to 3, dips to 2)
- `GetUsers_HidesDeletedByDefault`
- `GetUsers_IncludeDeleted_ReturnsAllWithFlag`
