### PR TITLE
feat: device sharing (sensors + switches, Read/Edit) + docs

### DIFF
--- a/Controllers/AutomationController.cs
+++ b/Controllers/AutomationController.cs
@@ -37,9 +37,10 @@ namespace garge_api.Controllers
 
             var userId = User.UserId();
 
-            // Get accessible parent names from sensors the user owns
+            // Sensors the user can act on: owned, or shared with Edit. A read-only share must not let
+            // the recipient create or change automations on the owner's garage.
             var accessibleParentNames = await _context.UserSensors
-                .Where(us => us.UserId == userId)
+                .Where(us => us.UserId == userId && (us.IsOwner || us.Permission == garge_api.Models.SharePermission.Edit))
                 .Join(_context.Sensors, us => us.SensorId, s => s.Id, (us, s) => s.ParentName)
                 .ToListAsync();
 

--- a/Controllers/BatteryHealthController.cs
+++ b/Controllers/BatteryHealthController.cs
@@ -48,6 +48,19 @@ namespace garge_api.Controllers
             return await _context.UserSensors.AnyAsync(us => us.UserId == userId && us.SensorId == sensorId);
         }
 
+        /// <summary>
+        /// True when the caller may edit shared state on this sensor — owner, an Edit-tier share, or
+        /// admin. Calibration writes a global per-sensor offset, so a read-only share must not change it.
+        /// </summary>
+        private async Task<bool> UserCanEditSensorAsync(int sensorId)
+        {
+            if (IsAdmin()) return true;
+            var userId = User.UserId();
+            return await _context.UserSensors.AnyAsync(us =>
+                us.UserId == userId && us.SensorId == sensorId &&
+                (us.IsOwner || us.Permission == SharePermission.Edit));
+        }
+
         // Bound derived battery data to the caller's own ownership window(s) so a new owner of a
         // re-claimed/resold sensor never sees the previous owner's history. Admins see everything.
         private IQueryable<BatteryHealth> WithinOwnershipWindow(IQueryable<BatteryHealth> query)
@@ -137,7 +150,7 @@ namespace garge_api.Controllers
         {
             var sensor = await _context.Sensors.FirstOrDefaultAsync(s => s.Name == sensorName);
             if (sensor == null) return NotFound(new { message = "Sensor not found!" });
-            if (!await UserCanAccessSensorAsync(sensor.Id)) return Forbid();
+            if (!await UserCanEditSensorAsync(sensor.Id)) return Forbid();
 
             var latest = await WithinOwnershipWindow(
                     _context.SensorData.Where(sd => sd.SensorId == sensor.Id))
@@ -164,7 +177,7 @@ namespace garge_api.Controllers
         {
             var sensor = await _context.Sensors.FirstOrDefaultAsync(s => s.Name == sensorName);
             if (sensor == null) return NotFound(new { message = "Sensor not found!" });
-            if (!await UserCanAccessSensorAsync(sensor.Id)) return Forbid();
+            if (!await UserCanEditSensorAsync(sensor.Id)) return Forbid();
 
             sensor.CalibrationOffsetV = null;
             await _context.SaveChangesAsync();

--- a/Controllers/SensorController.cs
+++ b/Controllers/SensorController.cs
@@ -691,42 +691,180 @@ namespace garge_api.Controllers
                 return Forbid();
             }
 
-            var userId = User.UserId();
+            var userId = User.UserId()!;
 
-            var userSensor = await _context.UserSensors
+            var callerRow = await _context.UserSensors
                 .FirstOrDefaultAsync(us => us.UserId == userId && us.SensorId == id);
-            if (userSensor != null)
-            {
-                _context.UserSensors.Remove(userSensor);
-                _ownership.InvalidateSensor(id);
+            var callerWasOwner = callerRow?.IsOwner == true;
 
-                // Close this user's open ownership period so they no longer read new readings,
-                // and a future owner of the same sensor cannot see this user's history.
-                var openPeriods = await _context.SensorOwnershipPeriods
-                    .Where(p => p.UserId == userId && p.SensorId == id && p.EndedAt == null)
+            await CleanUserSensorDataAsync(id, userId);
+
+            // Owner unclaim cascades to every shared recipient — viewer access is tied to the owner's
+            // ownership, not their own (issue #245). A recipient unclaiming only removes themselves.
+            if (callerWasOwner)
+            {
+                var viewerIds = await _context.UserSensors
+                    .Where(us => us.SensorId == id && !us.IsOwner)
+                    .Select(us => us.UserId)
                     .ToListAsync();
-                foreach (var period in openPeriods)
-                    period.EndedAt = DateTime.UtcNow;
+                foreach (var viewerId in viewerIds)
+                    await CleanUserSensorDataAsync(id, viewerId);
             }
 
-            // Remove any custom name the user has set for this sensor
-            var customName = await _context.UserSensorCustomNames
-                .FirstOrDefaultAsync(x => x.UserId == userId && x.SensorId == id);
-            if (customName != null)
-            {
-                _context.UserSensorCustomNames.Remove(customName);
-            }
-
-            // Remove the user's remaining personal rows for this sensor so unclaim leaves nothing
-            // orphaned (same per-sensor set the account-deletion and 6-month purge paths clean up).
-            _context.SensorActivities.RemoveRange(_context.SensorActivities.Where(a => a.UserId == userId && a.SensorId == id));
-            _context.SensorPhotos.RemoveRange(_context.SensorPhotos.Where(p => p.UserId == userId && p.SensorId == id));
-            _context.SensorOfflineNotifications.RemoveRange(_context.SensorOfflineNotifications.Where(n => n.UserId == userId && n.SensorId == id));
-
+            _ownership.InvalidateSensor(id);
             await _context.SaveChangesAsync();
 
-            _logger.LogInformation("Sensor unclaimed by user {@LogData}", new { CallerUserId = User.UserId(), id });
+            _logger.LogInformation("Sensor unclaimed by user {@LogData}", new { CallerUserId = User.UserId(), id, CascadedViewers = callerWasOwner });
             return Ok(new { message = "Sensor removed from your account." });
+        }
+
+        /// <summary>
+        /// Removes one user's membership and personal rows for a sensor: the UserSensor row, any open
+        /// ownership period (closed now), and their custom name / activities / photos / offline
+        /// notifications. Does not save or invalidate the cache — the caller batches that.
+        /// </summary>
+        private async Task CleanUserSensorDataAsync(int sensorId, string userId)
+        {
+            var membership = await _context.UserSensors
+                .FirstOrDefaultAsync(us => us.UserId == userId && us.SensorId == sensorId);
+            if (membership != null)
+                _context.UserSensors.Remove(membership);
+
+            var openPeriods = await _context.SensorOwnershipPeriods
+                .Where(p => p.UserId == userId && p.SensorId == sensorId && p.EndedAt == null)
+                .ToListAsync();
+            foreach (var period in openPeriods)
+                period.EndedAt = DateTime.UtcNow;
+
+            var customName = await _context.UserSensorCustomNames
+                .FirstOrDefaultAsync(x => x.UserId == userId && x.SensorId == sensorId);
+            if (customName != null)
+                _context.UserSensorCustomNames.Remove(customName);
+
+            _context.SensorActivities.RemoveRange(_context.SensorActivities.Where(a => a.UserId == userId && a.SensorId == sensorId));
+            _context.SensorPhotos.RemoveRange(_context.SensorPhotos.Where(p => p.UserId == userId && p.SensorId == sensorId));
+            _context.SensorOfflineNotifications.RemoveRange(_context.SensorOfflineNotifications.Where(n => n.UserId == userId && n.SensorId == sensorId));
+        }
+
+        /// <summary>True when the caller owns this sensor (admins included). Only owners may share/revoke.</summary>
+        private async Task<bool> UserIsSensorOwnerAsync(int sensorId)
+        {
+            if (IsAdmin()) return true;
+            var userId = User.UserId();
+            return userId != null && await _context.UserSensors
+                .AnyAsync(us => us.UserId == userId && us.SensorId == sensorId && us.IsOwner);
+        }
+
+        /// <summary>True when the caller may edit shared state (owner, Edit-share, or admin).</summary>
+        private async Task<bool> UserCanEditSensorAsync(int sensorId)
+        {
+            if (IsAdmin()) return true;
+            var userId = User.UserId();
+            return userId != null && await _context.UserSensors.AnyAsync(us =>
+                us.UserId == userId && us.SensorId == sensorId &&
+                (us.IsOwner || us.Permission == SharePermission.Edit));
+        }
+
+        /// <summary>Shares a sensor with another Garge user (Read or Edit). Owner only.</summary>
+        [HttpPost("{id}/share")]
+        [Authorize]
+        [SwaggerOperation(Summary = "Shares a sensor with another user by email.")]
+        [SwaggerResponse(200, "Sensor shared.")]
+        [SwaggerResponse(403, "Only the owner can share.")]
+        [SwaggerResponse(404, "Sensor or recipient not found.")]
+        public async Task<IActionResult> ShareSensor(int id, [FromBody] ShareSensorDto dto)
+        {
+            var sensor = await _context.Sensors.FindAsync(id);
+            if (sensor == null) return NotFound(new { message = "Sensor not found." });
+            if (!await UserIsSensorOwnerAsync(id)) return Forbid();
+            if (string.IsNullOrWhiteSpace(dto.Email))
+                return BadRequest(new { message = "Recipient email is required." });
+
+            var normalized = dto.Email.Trim().ToUpperInvariant();
+            var target = await _context.Users
+                .FirstOrDefaultAsync(u => u.NormalizedEmail == normalized && !u.IsDeleted);
+            if (target == null)
+                return NotFound(new { message = "No Garge account with that email." });
+            if (target.Id == User.UserId())
+                return BadRequest(new { message = "You already own this sensor." });
+
+            var existing = await _context.UserSensors
+                .FirstOrDefaultAsync(us => us.UserId == target.Id && us.SensorId == id);
+            if (existing != null)
+            {
+                if (existing.IsOwner)
+                    return BadRequest(new { message = "That user already owns this sensor." });
+                existing.Permission = dto.Permission; // re-share updates the tier
+            }
+            else
+            {
+                _context.UserSensors.Add(new UserSensor
+                {
+                    UserId = target.Id, SensorId = id, IsOwner = false, Permission = dto.Permission,
+                });
+                // The recipient sees data from now on, not the owner's earlier private history.
+                _context.SensorOwnershipPeriods.Add(new SensorOwnershipPeriod
+                {
+                    UserId = target.Id, SensorId = id, StartedAt = DateTime.UtcNow, EndedAt = null,
+                });
+            }
+
+            await _context.SaveChangesAsync();
+            _ownership.InvalidateSensor(id);
+            await _hub.Clients.Group(DeviceHub.UserGroup(target.Id))
+                .SendAsync("device-created", new { kind = "sensor", id });
+
+            _logger.LogInformation("Sensor shared {@LogData}", new { id, OwnerUserId = User.UserId(), dto.Permission });
+            return Ok(new { message = "Sensor shared." });
+        }
+
+        /// <summary>Revokes a user's share of a sensor. Owner only.</summary>
+        [HttpDelete("{id}/share/{shareUserId}")]
+        [Authorize]
+        [SwaggerOperation(Summary = "Revokes a user's share of a sensor.")]
+        [SwaggerResponse(200, "Share revoked.")]
+        [SwaggerResponse(403, "Only the owner can revoke.")]
+        [SwaggerResponse(404, "Share not found.")]
+        public async Task<IActionResult> RevokeShare(int id, string shareUserId)
+        {
+            if (!await UserIsSensorOwnerAsync(id)) return Forbid();
+
+            var share = await _context.UserSensors
+                .FirstOrDefaultAsync(us => us.UserId == shareUserId && us.SensorId == id && !us.IsOwner);
+            if (share == null) return NotFound(new { message = "Share not found." });
+
+            await CleanUserSensorDataAsync(id, shareUserId);
+            await _context.SaveChangesAsync();
+            _ownership.InvalidateSensor(id);
+
+            _logger.LogInformation("Sensor share revoked {@LogData}", new { id, OwnerUserId = User.UserId(), shareUserId });
+            return Ok(new { message = "Share revoked." });
+        }
+
+        /// <summary>Lists the users a sensor is shared with. Owner only.</summary>
+        [HttpGet("{id}/shares")]
+        [Authorize]
+        [SwaggerOperation(Summary = "Lists who a sensor is shared with.")]
+        [SwaggerResponse(200, "Shares.", typeof(IEnumerable<SensorShareDto>))]
+        [SwaggerResponse(403, "Only the owner can view shares.")]
+        public async Task<IActionResult> ListShares(int id)
+        {
+            if (!await UserIsSensorOwnerAsync(id)) return Forbid();
+
+            var shares = await _context.UserSensors
+                .Where(us => us.SensorId == id && !us.IsOwner)
+                .Join(_context.Users, us => us.UserId, u => u.Id, (us, u) => new SensorShareDto
+                {
+                    UserId = u.Id,
+                    Email = u.Email!,
+                    FirstName = u.FirstName,
+                    LastName = u.LastName,
+                    Permission = us.Permission,
+                    SharedAt = us.CreatedAt,
+                })
+                .ToListAsync();
+
+            return Ok(shares);
         }
 
         /// <summary>Owner turns a sensor off: blocks its data reads and frees a quota slot. Always allowed.</summary>

--- a/Controllers/SensorController.cs
+++ b/Controllers/SensorController.cs
@@ -158,7 +158,7 @@ namespace garge_api.Controllers
                 : await _context.UserSensors
                     .Where(us => us.UserId == currentUserId && sensorIds.Contains(us.SensorId))
                     .ToListAsync();
-            var accessById = accessRows.ToDictionary(us => us.SensorId, us => AccessLabel(us.IsOwner, us.Permission));
+            var accessById = accessRows.ToDictionary(us => us.SensorId, us => DeviceAccess.From(us.IsOwner, us.Permission));
 
             // Map sensors and inject the user-specific custom name + suspended + access state
             var dtos = sensors.Select(sensor =>
@@ -167,7 +167,7 @@ namespace garge_api.Controllers
                 if (customNames.TryGetValue(sensor.Id, out var customName))
                     dto.CustomName = customName;
                 dto.Suspended = suspendedIds.Contains(sensor.Id);
-                dto.Access = IsAdmin() ? "owner" : (accessById.TryGetValue(sensor.Id, out var a) ? a : "owner");
+                dto.Access = IsAdmin() ? DeviceAccess.Owner : (accessById.TryGetValue(sensor.Id, out var a) ? a : DeviceAccess.Owner);
                 return dto;
             }).ToList();
 
@@ -776,20 +776,16 @@ namespace garge_api.Controllers
                 (us.IsOwner || us.Permission == SharePermission.Edit));
         }
 
-        /// <summary>Maps an owner flag + share permission to the SensorDto.Access label.</summary>
-        private static string AccessLabel(bool isOwner, SharePermission permission) =>
-            isOwner ? "owner" : permission == SharePermission.Edit ? "edit" : "read";
-
         /// <summary>The caller's relationship to a sensor for SensorDto.Access (admins count as owner).</summary>
         private async Task<string> CallerAccessAsync(int sensorId)
         {
-            if (IsAdmin()) return "owner";
+            if (IsAdmin()) return DeviceAccess.Owner;
             var userId = User.UserId();
             var row = await _context.UserSensors
                 .Where(us => us.UserId == userId && us.SensorId == sensorId)
                 .Select(us => new { us.IsOwner, us.Permission })
                 .FirstOrDefaultAsync();
-            return row == null ? "owner" : AccessLabel(row.IsOwner, row.Permission);
+            return row == null ? DeviceAccess.Owner : DeviceAccess.From(row.IsOwner, row.Permission);
         }
 
         /// <summary>Shares a sensor with another Garge user (Read or Edit). Owner only.</summary>

--- a/Controllers/SensorController.cs
+++ b/Controllers/SensorController.cs
@@ -725,8 +725,62 @@ namespace garge_api.Controllers
             _ownership.InvalidateSensor(id);
             await _context.SaveChangesAsync();
 
+            // Losing an owned sensor can leave a socket it discovered with no owner. Revoke any shares
+            // on now-ownerless sockets so socket access never outlives ownership (the discovery edge).
+            if (callerWasOwner)
+            {
+                await RevokeOrphanedSwitchSharesAsync(sensor.ParentName);
+                await _context.SaveChangesAsync();
+            }
+
             _logger.LogInformation("Sensor unclaimed by user {@LogData}", new { CallerUserId = User.UserId(), id, CascadedViewers = callerWasOwner });
             return Ok(new { message = "Sensor removed from your account." });
+        }
+
+        /// <summary>
+        /// After an owned sensor is removed, revoke shares on any socket its gateway discovered that now
+        /// has no remaining owner (no direct owner row, no other owned sensor under the gateway). Keeps
+        /// socket-share lifetime tied to ownership without needing to track who created each share.
+        /// </summary>
+        private async Task RevokeOrphanedSwitchSharesAsync(string? parentName)
+        {
+            if (string.IsNullOrEmpty(parentName)) return;
+
+            var socketNames = await _context.DiscoveredDevices
+                .Where(dd => dd.DiscoveredBy == parentName)
+                .Select(dd => dd.Target)
+                .Distinct()
+                .ToListAsync();
+            if (socketNames.Count == 0) return;
+
+            var switches = await _context.Switches.Where(s => socketNames.Contains(s.Name)).ToListAsync();
+            foreach (var sw in switches)
+            {
+                var hasDirectOwner = await _context.UserSwitches.AnyAsync(us => us.SwitchId == sw.Id && us.IsOwner);
+                var hasIndirectOwner = await _context.DiscoveredDevices
+                    .Where(dd => dd.Target == sw.Name)
+                    .Join(_context.Sensors, dd => dd.DiscoveredBy, s => s.ParentName, (dd, s) => s.Id)
+                    .Join(_context.UserSensors.Where(us => us.IsOwner), sid => sid, us => us.SensorId, (sid, us) => us.UserId)
+                    .AnyAsync();
+                if (hasDirectOwner || hasIndirectOwner) continue; // still owned — keep its shares
+
+                var viewers = await _context.UserSwitches
+                    .Where(us => us.SwitchId == sw.Id && !us.IsOwner)
+                    .ToListAsync();
+                if (viewers.Count == 0) continue;
+
+                foreach (var viewer in viewers)
+                {
+                    _context.UserSwitches.Remove(viewer);
+                    var periods = await _context.SwitchOwnershipPeriods
+                        .Where(p => p.UserId == viewer.UserId && p.SwitchId == sw.Id && p.EndedAt == null)
+                        .ToListAsync();
+                    foreach (var p in periods) p.EndedAt = DateTime.UtcNow;
+                    _context.UserSwitchCustomNames.RemoveRange(
+                        _context.UserSwitchCustomNames.Where(x => x.UserId == viewer.UserId && x.SwitchId == sw.Id));
+                }
+                _ownership.InvalidateSwitch(sw.Id);
+            }
         }
 
         /// <summary>

--- a/Controllers/SensorController.cs
+++ b/Controllers/SensorController.cs
@@ -149,15 +149,25 @@ namespace garge_api.Controllers
                 .Where(x => x.UserId == currentUserId)
                 .ToDictionaryAsync(x => x.SensorId, x => x.CustomName);
 
-            var suspendedIds = await CallerSuspendedSensorIdsAsync(sensors.Select(s => s.Id).ToList());
+            var sensorIds = sensors.Select(s => s.Id).ToList();
+            var suspendedIds = await CallerSuspendedSensorIdsAsync(sensorIds);
 
-            // Map sensors and inject the user-specific custom name + suspended state
+            // The caller's owner/edit/read relationship per sensor (admins are treated as owner).
+            var accessRows = IsAdmin()
+                ? new List<UserSensor>()
+                : await _context.UserSensors
+                    .Where(us => us.UserId == currentUserId && sensorIds.Contains(us.SensorId))
+                    .ToListAsync();
+            var accessById = accessRows.ToDictionary(us => us.SensorId, us => AccessLabel(us.IsOwner, us.Permission));
+
+            // Map sensors and inject the user-specific custom name + suspended + access state
             var dtos = sensors.Select(sensor =>
             {
                 var dto = _mapper.Map<SensorDto>(sensor);
                 if (customNames.TryGetValue(sensor.Id, out var customName))
                     dto.CustomName = customName;
                 dto.Suspended = suspendedIds.Contains(sensor.Id);
+                dto.Access = IsAdmin() ? "owner" : (accessById.TryGetValue(sensor.Id, out var a) ? a : "owner");
                 return dto;
             }).ToList();
 
@@ -204,6 +214,7 @@ namespace garge_api.Controllers
                 dto.CustomName = customName;
 
             dto.Suspended = await IsSensorSuspendedForCallerAsync(id);
+            dto.Access = await CallerAccessAsync(id);
 
             _logger.LogInformation("Returning sensor {@LogData}", new { id, CallerUserId = User.UserId() });
             return Ok(dto);
@@ -763,6 +774,22 @@ namespace garge_api.Controllers
             return userId != null && await _context.UserSensors.AnyAsync(us =>
                 us.UserId == userId && us.SensorId == sensorId &&
                 (us.IsOwner || us.Permission == SharePermission.Edit));
+        }
+
+        /// <summary>Maps an owner flag + share permission to the SensorDto.Access label.</summary>
+        private static string AccessLabel(bool isOwner, SharePermission permission) =>
+            isOwner ? "owner" : permission == SharePermission.Edit ? "edit" : "read";
+
+        /// <summary>The caller's relationship to a sensor for SensorDto.Access (admins count as owner).</summary>
+        private async Task<string> CallerAccessAsync(int sensorId)
+        {
+            if (IsAdmin()) return "owner";
+            var userId = User.UserId();
+            var row = await _context.UserSensors
+                .Where(us => us.UserId == userId && us.SensorId == sensorId)
+                .Select(us => new { us.IsOwner, us.Permission })
+                .FirstOrDefaultAsync();
+            return row == null ? "owner" : AccessLabel(row.IsOwner, row.Permission);
         }
 
         /// <summary>Shares a sensor with another Garge user (Read or Edit). Owner only.</summary>

--- a/Controllers/SwitchesController.cs
+++ b/Controllers/SwitchesController.cs
@@ -57,6 +57,69 @@ namespace garge_api.Controllers
         }
 
         /// <summary>
+        /// True when the user owns a sensor whose gateway discovered this switch — they own the parent
+        /// device, so they are treated as a switch owner (can share/control it).
+        /// </summary>
+        private async Task<bool> IsIndirectSwitchOwnerAsync(Switch sw, string userId) =>
+            await _context.DiscoveredDevices
+                .Where(dd => dd.Target == sw.Name)
+                .Join(_context.Sensors, dd => dd.DiscoveredBy, s => s.ParentName, (dd, s) => s.Id)
+                .Join(_context.UserSensors.Where(us => us.IsOwner && us.UserId == userId), sid => sid, us => us.SensorId, (sid, us) => us.UserId)
+                .AnyAsync();
+
+        /// <summary>Owner = admin, a direct owned row, or an indirect (parent-sensor) owner. Only owners may share.</summary>
+        private async Task<bool> UserOwnsSwitchAsync(Switch sw)
+        {
+            if (IsSwitchAdmin()) return true;
+            var userId = User.UserId();
+            if (string.IsNullOrEmpty(userId)) return false;
+            if (await _context.UserSwitches.AnyAsync(us => us.UserId == userId && us.SwitchId == sw.Id && us.IsOwner)) return true;
+            return await IsIndirectSwitchOwnerAsync(sw, userId);
+        }
+
+        /// <summary>True when the caller may edit shared state (owner or a direct Edit share).</summary>
+        private async Task<bool> UserCanEditSwitchAsync(Switch sw)
+        {
+            if (await UserOwnsSwitchAsync(sw)) return true;
+            var userId = User.UserId();
+            return userId != null && await _context.UserSwitches.AnyAsync(us =>
+                us.UserId == userId && us.SwitchId == sw.Id && us.Permission == SharePermission.Edit);
+        }
+
+        /// <summary>The caller's relationship to a switch for SwitchDto.Access.</summary>
+        private async Task<string> CallerSwitchAccessAsync(Switch sw)
+        {
+            if (await UserOwnsSwitchAsync(sw)) return DeviceAccess.Owner;
+            var userId = User.UserId();
+            var perm = await _context.UserSwitches
+                .Where(us => us.UserId == userId && us.SwitchId == sw.Id && !us.IsOwner)
+                .Select(us => (SharePermission?)us.Permission)
+                .FirstOrDefaultAsync();
+            return perm == SharePermission.Edit ? DeviceAccess.Edit : DeviceAccess.Read;
+        }
+
+        /// <summary>
+        /// Removes one user's direct membership + personal rows for a switch: the UserSwitch row, any
+        /// open ownership period (closed now), and their custom name. Does not save or invalidate cache.
+        /// </summary>
+        private async Task CleanUserSwitchDataAsync(int switchId, string userId)
+        {
+            var membership = await _context.UserSwitches
+                .FirstOrDefaultAsync(us => us.UserId == userId && us.SwitchId == switchId);
+            if (membership != null)
+                _context.UserSwitches.Remove(membership);
+
+            var openPeriods = await _context.SwitchOwnershipPeriods
+                .Where(p => p.UserId == userId && p.SwitchId == switchId && p.EndedAt == null)
+                .ToListAsync();
+            foreach (var period in openPeriods)
+                period.EndedAt = DateTime.UtcNow;
+
+            _context.UserSwitchCustomNames.RemoveRange(
+                _context.UserSwitchCustomNames.Where(x => x.UserId == userId && x.SwitchId == switchId));
+        }
+
+        /// <summary>
         /// Bounds switch telemetry to the caller's own ownership window(s): a direct ownership period
         /// OR — for indirect access via the discovered-device chain — the period of an owned sensor
         /// that maps to this switch (switch name -> DiscoveredDevice.Target, DiscoveredBy ->
@@ -95,12 +158,14 @@ namespace garge_api.Controllers
                 .Where(x => x.UserId == userId && switchIds.Contains(x.SwitchId))
                 .ToDictionaryAsync(x => x.SwitchId, x => x.CustomName);
 
-            var dtos = accessibleSwitches.Select(sw =>
+            var dtos = new List<SwitchDto>();
+            foreach (var sw in accessibleSwitches)
             {
                 var dto = _mapper.Map<SwitchDto>(sw);
                 dto.CustomName = customNames.TryGetValue(sw.Id, out var cn) ? cn : null;
-                return dto;
-            });
+                dto.Access = await CallerSwitchAccessAsync(sw);
+                dtos.Add(dto);
+            }
 
             _logger.LogInformation("Returning {@LogData}", new { Count = accessibleSwitches.Count, CallerUserId = User.UserId() });
             return Ok(dtos);
@@ -139,6 +204,7 @@ namespace garge_api.Controllers
 
             var dto = _mapper.Map<SwitchDto>(switchEntity);
             dto.CustomName = customName;
+            dto.Access = await CallerSwitchAccessAsync(switchEntity);
 
             _logger.LogInformation("Returning switch {@LogData}", new { id, CallerUserId = User.UserId() });
             return Ok(dto);
@@ -468,7 +534,7 @@ namespace garge_api.Controllers
                 return NotFound(new { message = "Switch not found!" });
             }
 
-            if (!await UserHasRequiredRoleAsync(switchEntity))
+            if (!await UserCanEditSwitchAsync(switchEntity))
             {
                 _logger.LogWarning("DeleteSwitchData forbidden for {@LogData}", new { CallerUserId = User.UserId(), switchId });
                 return Forbid();
@@ -718,30 +784,129 @@ namespace garge_api.Controllers
         {
             _logger.LogInformation("UnclaimSwitch called by {@LogData}", new { CallerUserId = User.UserId(), id });
 
-            var userId = User.UserId();
-            var userSwitch = await _context.UserSwitches.FirstOrDefaultAsync(us => us.UserId == userId && us.SwitchId == id);
-            if (userSwitch != null)
+            var userId = User.UserId()!;
+            var callerRow = await _context.UserSwitches.FirstOrDefaultAsync(us => us.UserId == userId && us.SwitchId == id);
+            var callerWasOwner = callerRow?.IsOwner == true;
+
+            await CleanUserSwitchDataAsync(id, userId);
+
+            // Owner unclaim cascades to every direct recipient; a recipient's unclaim removes only them.
+            if (callerWasOwner)
             {
-                _context.UserSwitches.Remove(userSwitch);
-
-                // Close this user's open direct ownership period so a future owner of the same switch
-                // cannot see this user's history.
-                var openPeriods = await _context.SwitchOwnershipPeriods
-                    .Where(p => p.UserId == userId && p.SwitchId == id && p.EndedAt == null)
+                var viewerIds = await _context.UserSwitches
+                    .Where(us => us.SwitchId == id && !us.IsOwner)
+                    .Select(us => us.UserId)
                     .ToListAsync();
-                foreach (var period in openPeriods)
-                    period.EndedAt = DateTime.UtcNow;
-
-                // Remove any custom name the user set for this switch so unclaim leaves nothing orphaned.
-                _context.UserSwitchCustomNames.RemoveRange(
-                    _context.UserSwitchCustomNames.Where(x => x.UserId == userId && x.SwitchId == id));
-
-                await _context.SaveChangesAsync();
-                _ownership.InvalidateSwitch(id);
+                foreach (var viewerId in viewerIds)
+                    await CleanUserSwitchDataAsync(id, viewerId);
             }
 
-            _logger.LogInformation("Switch unclaimed by user {@LogData}", new { CallerUserId = User.UserId(), id });
+            await _context.SaveChangesAsync();
+            _ownership.InvalidateSwitch(id);
+
+            _logger.LogInformation("Switch unclaimed by user {@LogData}", new { CallerUserId = User.UserId(), id, CascadedViewers = callerWasOwner });
             return Ok(new { message = "Switch removed from your account." });
+        }
+
+        /// <summary>Shares a switch with another Garge user (Read or Edit). Owner only.</summary>
+        [HttpPost("{id}/share")]
+        [SwaggerOperation(Summary = "Shares a switch with another user by email.")]
+        [SwaggerResponse(200, "Switch shared.")]
+        [SwaggerResponse(403, "Only the owner can share.")]
+        [SwaggerResponse(404, "Switch or recipient not found.")]
+        public async Task<IActionResult> ShareSwitch(int id, [FromBody] ShareSwitchDto dto)
+        {
+            var switchEntity = await _context.Switches.FindAsync(id);
+            if (switchEntity == null) return NotFound(new { message = "Switch not found." });
+            if (!await UserOwnsSwitchAsync(switchEntity)) return Forbid();
+            if (string.IsNullOrWhiteSpace(dto.Email))
+                return BadRequest(new { message = "Recipient email is required." });
+
+            var normalized = dto.Email.Trim().ToUpperInvariant();
+            var target = await _context.Users.FirstOrDefaultAsync(u => u.NormalizedEmail == normalized && !u.IsDeleted);
+            if (target == null)
+                return NotFound(new { message = "No Garge account with that email." });
+            if (target.Id == User.UserId())
+                return BadRequest(new { message = "You already own this switch." });
+
+            var existing = await _context.UserSwitches
+                .FirstOrDefaultAsync(us => us.UserId == target.Id && us.SwitchId == id);
+            if (existing != null)
+            {
+                if (existing.IsOwner)
+                    return BadRequest(new { message = "That user already owns this switch." });
+                existing.Permission = dto.Permission;
+            }
+            else
+            {
+                _context.UserSwitches.Add(new UserSwitch
+                {
+                    UserId = target.Id, SwitchId = id, IsOwner = false, Permission = dto.Permission,
+                });
+                _context.SwitchOwnershipPeriods.Add(new SwitchOwnershipPeriod
+                {
+                    UserId = target.Id, SwitchId = id, StartedAt = DateTime.UtcNow, EndedAt = null,
+                });
+            }
+
+            await _context.SaveChangesAsync();
+            _ownership.InvalidateSwitch(id);
+            await _hub.Clients.Group(DeviceHub.UserGroup(target.Id))
+                .SendAsync("device-created", new { kind = "switch", id });
+
+            _logger.LogInformation("Switch shared {@LogData}", new { id, OwnerUserId = User.UserId(), dto.Permission });
+            return Ok(new { message = "Switch shared." });
+        }
+
+        /// <summary>Revokes a user's share of a switch. Owner only.</summary>
+        [HttpDelete("{id}/share/{shareUserId}")]
+        [SwaggerOperation(Summary = "Revokes a user's share of a switch.")]
+        [SwaggerResponse(200, "Share revoked.")]
+        [SwaggerResponse(403, "Only the owner can revoke.")]
+        [SwaggerResponse(404, "Share not found.")]
+        public async Task<IActionResult> RevokeSwitchShare(int id, string shareUserId)
+        {
+            var switchEntity = await _context.Switches.FindAsync(id);
+            if (switchEntity == null) return NotFound(new { message = "Switch not found." });
+            if (!await UserOwnsSwitchAsync(switchEntity)) return Forbid();
+
+            var share = await _context.UserSwitches
+                .FirstOrDefaultAsync(us => us.UserId == shareUserId && us.SwitchId == id && !us.IsOwner);
+            if (share == null) return NotFound(new { message = "Share not found." });
+
+            await CleanUserSwitchDataAsync(id, shareUserId);
+            await _context.SaveChangesAsync();
+            _ownership.InvalidateSwitch(id);
+
+            _logger.LogInformation("Switch share revoked {@LogData}", new { id, OwnerUserId = User.UserId(), shareUserId });
+            return Ok(new { message = "Share revoked." });
+        }
+
+        /// <summary>Lists the users a switch is shared with. Owner only.</summary>
+        [HttpGet("{id}/shares")]
+        [SwaggerOperation(Summary = "Lists who a switch is shared with.")]
+        [SwaggerResponse(200, "Shares.", typeof(IEnumerable<SwitchShareDto>))]
+        [SwaggerResponse(403, "Only the owner can view shares.")]
+        public async Task<IActionResult> ListSwitchShares(int id)
+        {
+            var switchEntity = await _context.Switches.FindAsync(id);
+            if (switchEntity == null) return NotFound(new { message = "Switch not found." });
+            if (!await UserOwnsSwitchAsync(switchEntity)) return Forbid();
+
+            var shares = await _context.UserSwitches
+                .Where(us => us.SwitchId == id && !us.IsOwner)
+                .Join(_context.Users, us => us.UserId, u => u.Id, (us, u) => new SwitchShareDto
+                {
+                    UserId = u.Id,
+                    Email = u.Email!,
+                    FirstName = u.FirstName,
+                    LastName = u.LastName,
+                    Permission = us.Permission,
+                    SharedAt = us.CreatedAt,
+                })
+                .ToListAsync();
+
+            return Ok(shares);
         }
 
         private async Task<string> GenerateSwitchRegistrationCodeAsync(int length = 10)

--- a/Dtos/Sensor/SensorDto.cs
+++ b/Dtos/Sensor/SensorDto.cs
@@ -13,5 +13,11 @@ namespace garge_api.Dtos.Sensor
 
         /// <summary>True when the caller has this owned sensor turned off / over-quota suspended. Data reads are blocked while suspended.</summary>
         public bool Suspended { get; set; }
+
+        /// <summary>
+        /// The caller's relationship to this sensor: <c>owner</c> (or admin), <c>edit</c> (Edit share),
+        /// or <c>read</c> (Read share). Drives which controls the client shows.
+        /// </summary>
+        public string Access { get; set; } = "owner";
     }
 }

--- a/Dtos/Sensor/SensorDto.cs
+++ b/Dtos/Sensor/SensorDto.cs
@@ -1,3 +1,5 @@
+using garge_api.Models;
+
 namespace garge_api.Dtos.Sensor
 {
     public class SensorDto
@@ -18,6 +20,6 @@ namespace garge_api.Dtos.Sensor
         /// The caller's relationship to this sensor: <c>owner</c> (or admin), <c>edit</c> (Edit share),
         /// or <c>read</c> (Read share). Drives which controls the client shows.
         /// </summary>
-        public string Access { get; set; } = "owner";
+        public string Access { get; set; } = DeviceAccess.Owner;
     }
 }

--- a/Dtos/Sensor/ShareSensorDto.cs
+++ b/Dtos/Sensor/ShareSensorDto.cs
@@ -1,0 +1,24 @@
+using garge_api.Models;
+
+namespace garge_api.Dtos.Sensor
+{
+    /// <summary>Request to share a sensor with another Garge user (by their account email).</summary>
+    public class ShareSensorDto
+    {
+        public required string Email { get; set; }
+
+        /// <summary>Read (view only) or Edit (control switches, automations, calibration).</summary>
+        public SharePermission Permission { get; set; } = SharePermission.Read;
+    }
+
+    /// <summary>A single recipient of a shared sensor, returned to the owner.</summary>
+    public class SensorShareDto
+    {
+        public required string UserId { get; set; }
+        public required string Email { get; set; }
+        public required string FirstName { get; set; }
+        public required string LastName { get; set; }
+        public SharePermission Permission { get; set; }
+        public DateTime SharedAt { get; set; }
+    }
+}

--- a/Dtos/Switch/ShareSwitchDto.cs
+++ b/Dtos/Switch/ShareSwitchDto.cs
@@ -1,0 +1,24 @@
+using garge_api.Models;
+
+namespace garge_api.Dtos.Switch
+{
+    /// <summary>Request to share a switch with another Garge user (by their account email).</summary>
+    public class ShareSwitchDto
+    {
+        public required string Email { get; set; }
+
+        /// <summary>Read (view only) or Edit (also control/automate).</summary>
+        public SharePermission Permission { get; set; } = SharePermission.Read;
+    }
+
+    /// <summary>A single recipient of a shared switch, returned to the owner.</summary>
+    public class SwitchShareDto
+    {
+        public required string UserId { get; set; }
+        public required string Email { get; set; }
+        public required string FirstName { get; set; }
+        public required string LastName { get; set; }
+        public SharePermission Permission { get; set; }
+        public DateTime SharedAt { get; set; }
+    }
+}

--- a/Dtos/Switch/SwitchDto.cs
+++ b/Dtos/Switch/SwitchDto.cs
@@ -1,4 +1,6 @@
-﻿namespace garge_api.Dtos.Switch
+﻿using garge_api.Models;
+
+namespace garge_api.Dtos.Switch
 {
     public class SwitchDto
     {
@@ -8,5 +10,8 @@
         public string Role { get; set; } = string.Empty;
         public string? CustomName { get; set; }
         public string? RegistrationCode { get; set; }
+
+        /// <summary>The caller's relationship to this switch: owner (or admin), edit, or read.</summary>
+        public string Access { get; set; } = DeviceAccess.Owner;
     }
 }

--- a/Migrations/20260523065028_AddUserSensorSharePermission.Designer.cs
+++ b/Migrations/20260523065028_AddUserSensorSharePermission.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260523065028_AddUserSensorSharePermission")]
+    partial class AddUserSensorSharePermission
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260523065028_AddUserSensorSharePermission.cs
+++ b/Migrations/20260523065028_AddUserSensorSharePermission.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserSensorSharePermission : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Permission",
+                table: "UserSensors",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Permission",
+                table: "UserSensors");
+        }
+    }
+}

--- a/Migrations/20260523071802_AddUserSwitchSharePermission.Designer.cs
+++ b/Migrations/20260523071802_AddUserSwitchSharePermission.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260523071802_AddUserSwitchSharePermission")]
+    partial class AddUserSwitchSharePermission
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260523071802_AddUserSwitchSharePermission.cs
+++ b/Migrations/20260523071802_AddUserSwitchSharePermission.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserSwitchSharePermission : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Every existing UserSwitch row is an owner (sharing did not exist before), so backfill
+            // true. New shared rows set IsOwner=false explicitly.
+            migrationBuilder.AddColumn<bool>(
+                name: "IsOwner",
+                table: "UserSwitches",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Permission",
+                table: "UserSwitches",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsOwner",
+                table: "UserSwitches");
+
+            migrationBuilder.DropColumn(
+                name: "Permission",
+                table: "UserSwitches");
+        }
+    }
+}

--- a/Models/DeviceAccess.cs
+++ b/Models/DeviceAccess.cs
@@ -1,0 +1,17 @@
+namespace garge_api.Models
+{
+    /// <summary>
+    /// The caller's relationship to a device, surfaced as <c>SensorDto.Access</c>. Single source for the
+    /// labels and the owner/permission → label mapping; the client mirrors these strings.
+    /// </summary>
+    public static class DeviceAccess
+    {
+        public const string Owner = "owner";
+        public const string Edit = "edit";
+        public const string Read = "read";
+
+        /// <summary>Maps an owner flag + share permission to the access label.</summary>
+        public static string From(bool isOwner, SharePermission permission) =>
+            isOwner ? Owner : permission == SharePermission.Edit ? Edit : Read;
+    }
+}

--- a/Models/Sensor/UserSensor.cs
+++ b/Models/Sensor/UserSensor.cs
@@ -14,6 +14,12 @@ namespace garge_api.Models.Sensor
         public bool IsOwner { get; set; } = true;
 
         /// <summary>
+        /// For a shared row (<see cref="IsOwner"/> = false), what the recipient may do. Ignored for the
+        /// owner's own row, which always has full rights. Defaults to <see cref="SharePermission.Read"/>.
+        /// </summary>
+        public SharePermission Permission { get; set; } = SharePermission.Read;
+
+        /// <summary>
         /// When set, the owner has turned this sensor off (or it was auto-suspended for being over
         /// quota). Suspended owned sensors do not count toward subscription capacity and their
         /// dashboard/history reads are blocked, but telemetry keeps flowing. Null = active.

--- a/Models/SharePermission.cs
+++ b/Models/SharePermission.cs
@@ -1,0 +1,15 @@
+namespace garge_api.Models
+{
+    /// <summary>
+    /// Access level for a shared device row (where <c>IsOwner = false</c>). The owner always has full
+    /// rights implicitly; this only describes what a recipient of a share may do.
+    /// </summary>
+    public enum SharePermission
+    {
+        /// <summary>View data, history, battery health and live updates. No control or editing.</summary>
+        Read = 0,
+
+        /// <summary>Read, plus toggle switches, create/edit automations, and battery calibration.</summary>
+        Edit = 1,
+    }
+}

--- a/Models/Switch/UserSwitch.cs
+++ b/Models/Switch/UserSwitch.cs
@@ -11,6 +11,14 @@ namespace garge_api.Models.Switch
         [Required]
         public int SwitchId { get; set; }
 
+        public bool IsOwner { get; set; } = true;
+
+        /// <summary>
+        /// For a shared row (<see cref="IsOwner"/> = false), what the recipient may do. Ignored for the
+        /// owner's own row. Defaults to <see cref="SharePermission.Read"/>.
+        /// </summary>
+        public SharePermission Permission { get; set; } = SharePermission.Read;
+
         /// <summary>
         /// When set, the owner has turned this switch off (or it was auto-suspended for being over
         /// quota). Reads are blocked while suspended, but telemetry keeps flowing. Null = active.

--- a/Services/DeviceOwnershipService.cs
+++ b/Services/DeviceOwnershipService.cs
@@ -84,10 +84,13 @@ namespace garge_api.Services
             var indirectOwners = new List<string>();
             if (switchEntity != null)
             {
+                // Only sensor OWNERS gain switch access via the parent-device link. A read/edit share of
+                // a sensor does not grant control of the garage's switches — direct switch sharing is a
+                // separate feature (see docs/access-and-quota.md, phase 2).
                 indirectOwners = await db.DiscoveredDevices
                     .Where(dd => dd.Target == switchEntity.Name)
                     .Join(db.Sensors, dd => dd.DiscoveredBy, s => s.ParentName, (dd, s) => s.Id)
-                    .Join(db.UserSensors, sid => sid, us => us.SensorId, (sid, us) => us.UserId)
+                    .Join(db.UserSensors.Where(us => us.IsOwner), sid => sid, us => us.SensorId, (sid, us) => us.UserId)
                     .Distinct()
                     .ToListAsync(ct);
             }

--- a/docs/access-and-quota.md
+++ b/docs/access-and-quota.md
@@ -1,100 +1,100 @@
-# Access, quota & device sharing
+# Access, quota and device sharing
 
-How device access, subscription capacity, cancellation, and sharing behave. This is the product
-decision record referenced by issue #245.
+This document describes how device access is governed: subscription capacity, what happens when a
+subscription is cancelled, retention of suspended data, and how owners share devices with other users.
+
+Throughout, "switch" and "socket" refer to the same device — the API uses *switch*, the app presents it
+to users as *socket*.
 
 ## Subscription capacity
 
-- **Capacity** = 1 (one active **Primary** subscription) + the summed `Quantity` of every active
-  **AddOn**. Without an active Primary, capacity is 0 — AddOns alone grant nothing.
-- A cancelled subscription (`Stopped`/`Expired`) still counts during its **paid-period grace**: while
-  `NextChargeDate` is in the future, the user keeps the capacity they paid for.
-- Only **active, owned** sensors consume capacity: `UserSensor.IsOwner = true` and `SuspendedAt = null`.
-  Suspended sensors and shared (viewer) sensors do not count.
-- The single source of truth is `SubscriptionCapacityService`; clients read it via `GET /sensors/capacity`.
+Capacity is the number of sensors a user may keep active at once.
 
-### Subscription-bypass roles
-`Admin, SensorAdmin, MqttAdmin, AutomationAdmin, SwitchAdmin, ComplimentaryUser, DeviceBridge` use the
-service with **no capacity limit**. They are never auto-suspended and their data is never purged. The
-check is DB-backed (`HasSubscriptionBypassAsync`) so a role granted to a logged-in user takes effect
-immediately, with no re-login.
+- Capacity equals one active **Primary** subscription plus the combined `Quantity` of every active
+  **AddOn**. Without an active Primary, capacity is zero; AddOns alone grant nothing.
+- A cancelled subscription continues to count for the remainder of the period already paid for: while
+  its `NextChargeDate` is in the future, the user retains that capacity.
+- Only active, owned sensors count against capacity. Suspended sensors and sensors shared with the user
+  do not.
 
-## What happens when an owner cancels (issue #245)
+`SubscriptionCapacityService` is the authority for capacity, and clients read it from
+`GET /sensors/capacity`.
 
-The model is **suspension, not deletion** — data is never lost on cancellation.
+### Roles that bypass capacity
 
-- **New claims** are gated at claim time (`ActiveSubscriptionHandler`): blocked once active owned sensors
-  ≥ capacity (bypass roles exempt). Existing access is never blocked at request time.
-- **Owner cancels Primary** → capacity drops to 0. After the paid-period grace lapses, the nightly
-  `QuotaReconciliationService` auto-suspends the owner's sensors (keeps the oldest `capacity` by claim
-  date, suspends the newest excess). With capacity 0 that is all of them.
-- **Owner cancels an AddOn while over capacity** → only the newest excess is suspended; the oldest stay
-  active.
-- **Suspended sensor**: dashboard/history reads are blocked and the slot is freed, but telemetry keeps
-  flowing. The owner re-picks which sensors are active via the suspend/activate toggle.
-- **Re-subscribe**: capacity is restored, but suspended sensors stay suspended until the owner
-  re-activates them (the user chooses which to bring back).
+`Admin`, `SensorAdmin`, `MqttAdmin`, `AutomationAdmin`, `SwitchAdmin`, `ComplimentaryUser` and
+`DeviceBridge` use the service without a capacity limit. They are never auto-suspended and their data is
+never purged. The role is resolved from the database, so granting it to a signed-in user takes effect
+immediately.
+
+## Cancelling a subscription
+
+Cancellation suspends devices; it never deletes data.
+
+- **Adding devices** is blocked once a user's active owned sensors reach their capacity. Access to
+  devices they already have is never blocked.
+- **Cancelling the Primary** drops capacity to zero. When the paid period ends, the user's sensors are
+  automatically suspended.
+- **Cancelling an AddOn while over capacity** suspends only the excess, keeping the oldest sensors (by
+  claim date) active.
+- A **suspended sensor** stops showing data and frees its capacity slot, while telemetry keeps being
+  recorded. The owner chooses which sensors are active using the on/off toggle.
+- **Resubscribing** restores capacity. Suspended sensors remain off until the owner turns them back on,
+  so the owner decides which to resume.
 
 ### Retention of suspended data
-Suspended-sensor history is kept under legitimate interest so a returning seasonal user keeps their
-year-over-year data. A user may **opt out** (GDPR Art. 21); once opted out and without coverage, their
-suspended sensors become eligible for the 180-day purge (`SuspendedSensorPurgeService`), which moves the
-telemetry into the anonymized ML store and removes the personal rows.
+
+Data from a suspended sensor is retained so a returning seasonal user keeps their year-over-year
+history. A user may object to this retention; once they have opted out and have no remaining coverage,
+their suspended sensors become eligible for purge after six months. Purging moves the telemetry into the
+anonymised analytics store and removes the personal records.
 
 ## Device sharing
 
-An owner can share a device with another Garge user. Two tiers, set per share.
+An owner can share a device with another Garge user at one of two access levels.
 
-### Mechanism
-- Share by the recipient's **email**; they must already have a Garge account.
-- A share is a `UserSensor` row with `IsOwner = false` and a `Permission` of `Read` or `Edit`.
-- Sharing **does not consume the recipient's capacity** (only `IsOwner = true` rows count), and it does
-  not affect the owner's capacity.
+### How a share works
 
-### Permission matrix
+- The owner shares with the recipient's account email; the recipient must already have a Garge account.
+- Sharing does not affect either user's capacity. Only owned devices count against capacity, so a shared
+  device never consumes the recipient's allowance or the owner's.
+
+### Access levels
 
 | Action | Read | Edit | Owner |
 |---|:--:|:--:|:--:|
-| View data, history, battery health, live updates | ✓ | ✓ | ✓ |
-| Set own custom name / activities / photos / alert prefs (per-user, private) | ✓ | ✓ | ✓ |
-| Toggle switches | | ✓ | ✓ |
-| Create / edit automations | | ✓ | ✓ |
-| Battery calibration (global offset) | | ✓ | ✓ |
-| Suspend / activate (capacity) | | | ✓ |
-| Unclaim / delete | | | ✓ |
-| Share / revoke / transfer ownership | | | ✓ |
+| View data, history, battery health and live updates | ✓ | ✓ | ✓ |
+| Set a personal name, activities, photos and alert preferences | ✓ | ✓ | ✓ |
+| Control switches | | ✓ | ✓ |
+| Create and edit automations | | ✓ | ✓ |
+| Calibrate a battery sensor | | ✓ | ✓ |
+| Turn a device on or off (capacity) | | | ✓ |
+| Remove a device | | | ✓ |
+| Share, revoke a share, or transfer ownership | | | ✓ |
 
-Per-user data (custom name, activities, photos, offline-alert preferences) is keyed by user, so a viewer
-editing it only changes **their own** view — it never touches the owner's. That is why it needs no Edit
-tier.
+Personal details such as a custom name, activities, photos and alert preferences are stored per user.
+A recipient editing them changes only their own view, so these remain available at every access level.
 
-### History window
-A share opens an ownership period starting at share time, so the recipient sees data **from when it was
-shared onward** — not the owner's earlier private history (same model used for resold sensors).
+### History visible to a recipient
+
+A recipient sees data from the moment the device was shared with them onward. Earlier history, from
+before the share, stays private to the owner.
 
 ### Lifecycle
-- Viewer access is tied to the **owner's sensor existence**, not the owner's subscription. If the owner
-  unclaims the sensor, all shares are removed (cascade). A recipient can also leave a share themselves.
-- If the owner lets a sensor get suspended (over quota), reads are paused for everyone, including
-  recipients — there is simply no data being shown while it is off.
 
-### Switches and the discovery edge
-Switches (shown as "sockets" in the app) share the same model. A switch *owner* is a direct owner (who
-claimed it) **or** an indirect owner — a user who owns the parent sensor whose gateway discovered the
-switch. Either can share it; Edit gates the only user-reachable switch mutation (deleting telemetry),
-since toggling is admin/operator-only or via automations (already gated).
+- A recipient's access lasts as long as the owner keeps the device, independent of the owner's
+  subscription. When the owner removes the device, every share of it ends. A recipient may also remove
+  their own access at any time.
+- While a sensor is suspended, its data is hidden for everyone, including recipients, until it is turned
+  back on.
 
-When a sensor discovers a new socket, only the sensor's **owner** gains access to it automatically;
-people the sensor is *shared* with do not (a sensor share is not a switch share). Because indirect
-owners can share, unclaiming a sensor could leave a discovered socket with no owner — so sensor unclaim
-also revokes shares on any socket that is left ownerless, keeping socket-share lifetime tied to
-ownership.
+### Switches and discovery
 
-## Status / scope
+A switch may be owned directly, by the user who claimed it, or indirectly, by the owner of the sensor
+whose gateway discovered it. Both can share the switch. Switch control is performed through automations
+or the operator, so the only switch action gated to Edit is deleting telemetry.
 
-Implemented: capacity model, claim gating, auto-suspension, suspended-data retention + opt-out purge,
-the capacity endpoint, bypass-role handling, and **sensor + switch sharing** (Read/Edit tiers,
-share/revoke/list, viewer history window, owner-unclaim cascade, orphaned-socket-share cleanup, and
-Edit/owner gating of automations, calibration and switch-telemetry deletion).
-
-Remaining: the frontend share UI for switches/sockets (sensor share UI shipped first).
+When a sensor's gateway discovers a new socket, only the sensor's owner gains access to it. Sharing the
+sensor does not extend to the sockets behind it. Because an indirect owner can share a socket, removing
+the sensor that provided that ownership would otherwise leave the socket's shares without an owner;
+removing a sensor therefore also ends shares on any socket left without an owner.

--- a/docs/access-and-quota.md
+++ b/docs/access-and-quota.md
@@ -78,13 +78,23 @@ shared onward** — not the owner's earlier private history (same model used for
 - If the owner lets a sensor get suspended (over quota), reads are paused for everyone, including
   recipients — there is simply no data being shown while it is off.
 
+### Switches and the discovery edge
+Switches (shown as "sockets" in the app) share the same model. A switch *owner* is a direct owner (who
+claimed it) **or** an indirect owner — a user who owns the parent sensor whose gateway discovered the
+switch. Either can share it; Edit gates the only user-reachable switch mutation (deleting telemetry),
+since toggling is admin/operator-only or via automations (already gated).
+
+When a sensor discovers a new socket, only the sensor's **owner** gains access to it automatically;
+people the sensor is *shared* with do not (a sensor share is not a switch share). Because indirect
+owners can share, unclaiming a sensor could leave a discovered socket with no owner — so sensor unclaim
+also revokes shares on any socket that is left ownerless, keeping socket-share lifetime tied to
+ownership.
+
 ## Status / scope
 
 Implemented: capacity model, claim gating, auto-suspension, suspended-data retention + opt-out purge,
-the capacity endpoint, and bypass-role handling.
+the capacity endpoint, bypass-role handling, and **sensor + switch sharing** (Read/Edit tiers,
+share/revoke/list, viewer history window, owner-unclaim cascade, orphaned-socket-share cleanup, and
+Edit/owner gating of automations, calibration and switch-telemetry deletion).
 
-Sharing is delivered in phases:
-- **Phase 1 (this record):** sensor sharing — Read/Edit tiers, share/revoke/list, viewer read access +
-  history window, owner-unclaim cascade, and Edit/owner gating of automations and calibration. To avoid
-  leaking switch control, the indirect sensor→switch access path is restricted to owners until phase 2.
-- **Phase 2 (planned):** direct switch sharing with a read/control split, and the frontend share UI.
+Remaining: the frontend share UI for switches/sockets (sensor share UI shipped first).

--- a/docs/access-and-quota.md
+++ b/docs/access-and-quota.md
@@ -1,0 +1,90 @@
+# Access, quota & device sharing
+
+How device access, subscription capacity, cancellation, and sharing behave. This is the product
+decision record referenced by issue #245.
+
+## Subscription capacity
+
+- **Capacity** = 1 (one active **Primary** subscription) + the summed `Quantity` of every active
+  **AddOn**. Without an active Primary, capacity is 0 — AddOns alone grant nothing.
+- A cancelled subscription (`Stopped`/`Expired`) still counts during its **paid-period grace**: while
+  `NextChargeDate` is in the future, the user keeps the capacity they paid for.
+- Only **active, owned** sensors consume capacity: `UserSensor.IsOwner = true` and `SuspendedAt = null`.
+  Suspended sensors and shared (viewer) sensors do not count.
+- The single source of truth is `SubscriptionCapacityService`; clients read it via `GET /sensors/capacity`.
+
+### Subscription-bypass roles
+`Admin, SensorAdmin, MqttAdmin, AutomationAdmin, SwitchAdmin, ComplimentaryUser, DeviceBridge` use the
+service with **no capacity limit**. They are never auto-suspended and their data is never purged. The
+check is DB-backed (`HasSubscriptionBypassAsync`) so a role granted to a logged-in user takes effect
+immediately, with no re-login.
+
+## What happens when an owner cancels (issue #245)
+
+The model is **suspension, not deletion** — data is never lost on cancellation.
+
+- **New claims** are gated at claim time (`ActiveSubscriptionHandler`): blocked once active owned sensors
+  ≥ capacity (bypass roles exempt). Existing access is never blocked at request time.
+- **Owner cancels Primary** → capacity drops to 0. After the paid-period grace lapses, the nightly
+  `QuotaReconciliationService` auto-suspends the owner's sensors (keeps the oldest `capacity` by claim
+  date, suspends the newest excess). With capacity 0 that is all of them.
+- **Owner cancels an AddOn while over capacity** → only the newest excess is suspended; the oldest stay
+  active.
+- **Suspended sensor**: dashboard/history reads are blocked and the slot is freed, but telemetry keeps
+  flowing. The owner re-picks which sensors are active via the suspend/activate toggle.
+- **Re-subscribe**: capacity is restored, but suspended sensors stay suspended until the owner
+  re-activates them (the user chooses which to bring back).
+
+### Retention of suspended data
+Suspended-sensor history is kept under legitimate interest so a returning seasonal user keeps their
+year-over-year data. A user may **opt out** (GDPR Art. 21); once opted out and without coverage, their
+suspended sensors become eligible for the 180-day purge (`SuspendedSensorPurgeService`), which moves the
+telemetry into the anonymized ML store and removes the personal rows.
+
+## Device sharing
+
+An owner can share a device with another Garge user. Two tiers, set per share.
+
+### Mechanism
+- Share by the recipient's **email**; they must already have a Garge account.
+- A share is a `UserSensor` row with `IsOwner = false` and a `Permission` of `Read` or `Edit`.
+- Sharing **does not consume the recipient's capacity** (only `IsOwner = true` rows count), and it does
+  not affect the owner's capacity.
+
+### Permission matrix
+
+| Action | Read | Edit | Owner |
+|---|:--:|:--:|:--:|
+| View data, history, battery health, live updates | ✓ | ✓ | ✓ |
+| Set own custom name / activities / photos / alert prefs (per-user, private) | ✓ | ✓ | ✓ |
+| Toggle switches | | ✓ | ✓ |
+| Create / edit automations | | ✓ | ✓ |
+| Battery calibration (global offset) | | ✓ | ✓ |
+| Suspend / activate (capacity) | | | ✓ |
+| Unclaim / delete | | | ✓ |
+| Share / revoke / transfer ownership | | | ✓ |
+
+Per-user data (custom name, activities, photos, offline-alert preferences) is keyed by user, so a viewer
+editing it only changes **their own** view — it never touches the owner's. That is why it needs no Edit
+tier.
+
+### History window
+A share opens an ownership period starting at share time, so the recipient sees data **from when it was
+shared onward** — not the owner's earlier private history (same model used for resold sensors).
+
+### Lifecycle
+- Viewer access is tied to the **owner's sensor existence**, not the owner's subscription. If the owner
+  unclaims the sensor, all shares are removed (cascade). A recipient can also leave a share themselves.
+- If the owner lets a sensor get suspended (over quota), reads are paused for everyone, including
+  recipients — there is simply no data being shown while it is off.
+
+## Status / scope
+
+Implemented: capacity model, claim gating, auto-suspension, suspended-data retention + opt-out purge,
+the capacity endpoint, and bypass-role handling.
+
+Sharing is delivered in phases:
+- **Phase 1 (this record):** sensor sharing — Read/Edit tiers, share/revoke/list, viewer read access +
+  history window, owner-unclaim cascade, and Edit/owner gating of automations and calibration. To avoid
+  leaking switch control, the indirect sensor→switch access path is restricted to owners until phase 2.
+- **Phase 2 (planned):** direct switch sharing with a read/control split, and the frontend share UI.

--- a/garge-api.Tests/AutomationControllerTests.cs
+++ b/garge-api.Tests/AutomationControllerTests.cs
@@ -1,4 +1,5 @@
 using garge_api.Dtos.Automation;
+using garge_api.Models;
 using garge_api.Models.Automation;
 using garge_api.Models.Mqtt;
 using garge_api.Models.Sensor;
@@ -94,6 +95,54 @@ public class AutomationControllerTests : ControllerTestBase
         var rule = Assert.IsType<AutomationRuleDto>(ok.Value);
         Assert.Equal("on", rule.Action);
         Assert.Equal(25, rule.Threshold);
+        Assert.Single(db.AutomationRules);
+    }
+
+    private static void SeedAccessChain(ApplicationDbContext db, string userId, bool isOwner, SharePermission permission = SharePermission.Read)
+    {
+        db.Switches.Add(new Switch { Id = 10, Name = "switch-a", Type = "socket", Role = "switch" });
+        db.Sensors.Add(new Sensor
+        {
+            Id = 5, Name = "sensor-1", Type = "temperature", Role = "sensor",
+            RegistrationCode = "reg-1", DefaultName = "Sensor 1", ParentName = "hub-1"
+        });
+        db.UserSensors.Add(new UserSensor { UserId = userId, SensorId = 5, IsOwner = isOwner, Permission = permission });
+        db.DiscoveredDevices.Add(new DiscoveredDevice
+        {
+            DiscoveredBy = "hub-1", Target = "switch-a", Type = "socket", Timestamp = DateTime.UtcNow
+        });
+    }
+
+    private static CreateAutomationRuleDto MakeCreateDto() => new()
+    {
+        TargetType = "switch", TargetId = 10, SensorType = "sensor", SensorId = 5,
+        Condition = ">", Threshold = 25, Action = "on", IsEnabled = true
+    };
+
+    [Fact]
+    public async Task CreateRule_ReadShareViewer_Forbidden()
+    {
+        // A read-only share must not let the recipient create automations on the owner's garage.
+        var db = CreateDbContext();
+        SeedAccessChain(db, "viewer", isOwner: false, permission: SharePermission.Read);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await CreateAutomationController(db, userId: "viewer", isAdmin: false).CreateRule(MakeCreateDto());
+
+        Assert.IsType<ForbidResult>(result.Result);
+        Assert.Empty(db.AutomationRules);
+    }
+
+    [Fact]
+    public async Task CreateRule_EditShareViewer_Allowed()
+    {
+        var db = CreateDbContext();
+        SeedAccessChain(db, "viewer", isOwner: false, permission: SharePermission.Edit);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await CreateAutomationController(db, userId: "viewer", isAdmin: false).CreateRule(MakeCreateDto());
+
+        Assert.IsType<OkObjectResult>(result.Result);
         Assert.Single(db.AutomationRules);
     }
 

--- a/garge-api.Tests/SensorSharingTests.cs
+++ b/garge-api.Tests/SensorSharingTests.cs
@@ -2,7 +2,9 @@ using garge_api.Controllers;
 using garge_api.Dtos.Sensor;
 using garge_api.Hubs;
 using garge_api.Models;
+using garge_api.Models.Mqtt;
 using garge_api.Models.Sensor;
+using garge_api.Models.Switch;
 using garge_api.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
@@ -176,6 +178,49 @@ public class SensorSharingTests : ControllerTestBase
         Assert.IsType<OkObjectResult>(result);
         Assert.DoesNotContain(db.UserSensors, us => us.SensorId == 1);          // owner + viewer both gone
         Assert.All(db.SensorOwnershipPeriods.Where(p => p.SensorId == 1), p => Assert.NotNull(p.EndedAt));
+    }
+
+    [Fact]
+    public async Task UnclaimSensor_OrphansDiscoveredSocket_RevokesItsShares()
+    {
+        // Owner indirectly owns socket-a via sensor 1's gateway, and shared it. Unclaiming the sensor
+        // leaves socket-a with no owner, so its share must be revoked (the discovery edge).
+        using var db = CreateDbContext();
+        db.Users.AddRange(MakeUser("owner", "owner@x"), MakeUser("viewer", "viewer@x"));
+        db.Sensors.Add(MakeSensor(1)); // ParentName "gw"
+        db.UserSensors.Add(new UserSensor { UserId = "owner", SensorId = 1, IsOwner = true });
+        db.Switches.Add(new Switch { Id = 10, Name = "socket-a", Type = "socket", Role = "switch" });
+        db.DiscoveredDevices.Add(new DiscoveredDevice { DiscoveredBy = "gw", Target = "socket-a", Type = "socket", Timestamp = DateTime.UtcNow });
+        db.UserSwitches.Add(new UserSwitch { UserId = "viewer", SwitchId = 10, IsOwner = false, Permission = SharePermission.Read });
+        db.SwitchOwnershipPeriods.Add(new SwitchOwnershipPeriod { UserId = "viewer", SwitchId = 10, StartedAt = DateTime.UtcNow, EndedAt = null });
+        await db.SaveChangesAsync();
+
+        var result = await CreateController(db, "owner").UnclaimSensor(1);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.DoesNotContain(db.UserSwitches, us => us.SwitchId == 10);
+        Assert.NotNull(db.SwitchOwnershipPeriods.Single(p => p.SwitchId == 10).EndedAt);
+    }
+
+    [Fact]
+    public async Task UnclaimSensor_SocketStillOwned_KeepsItsShares()
+    {
+        // A second owner still owns the socket indirectly, so unclaiming one sensor keeps the share.
+        using var db = CreateDbContext();
+        db.Users.AddRange(MakeUser("owner", "owner@x"), MakeUser("other", "other@x"), MakeUser("viewer", "viewer@x"));
+        db.Sensors.Add(MakeSensor(1)); // gw
+        db.Sensors.Add(new Sensor { Id = 2, Name = "garge_volt_2", Type = "voltage", Role = "sensor", RegistrationCode = "rc2", DefaultName = "Battery", ParentName = "gw" });
+        db.UserSensors.AddRange(
+            new UserSensor { UserId = "owner", SensorId = 1, IsOwner = true },
+            new UserSensor { UserId = "other", SensorId = 2, IsOwner = true });
+        db.Switches.Add(new Switch { Id = 10, Name = "socket-a", Type = "socket", Role = "switch" });
+        db.DiscoveredDevices.Add(new DiscoveredDevice { DiscoveredBy = "gw", Target = "socket-a", Type = "socket", Timestamp = DateTime.UtcNow });
+        db.UserSwitches.Add(new UserSwitch { UserId = "viewer", SwitchId = 10, IsOwner = false, Permission = SharePermission.Read });
+        await db.SaveChangesAsync();
+
+        await CreateController(db, "owner").UnclaimSensor(1);
+
+        Assert.Contains(db.UserSwitches, us => us.SwitchId == 10 && us.UserId == "viewer"); // still owned by "other"
     }
 
     [Fact]

--- a/garge-api.Tests/SensorSharingTests.cs
+++ b/garge-api.Tests/SensorSharingTests.cs
@@ -1,0 +1,195 @@
+using garge_api.Controllers;
+using garge_api.Dtos.Sensor;
+using garge_api.Hubs;
+using garge_api.Models;
+using garge_api.Models.Sensor;
+using garge_api.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace garge_api.Tests;
+
+/// <summary>
+/// Verifies sensor sharing: an owner can share Read/Edit with another user by email; the recipient gets
+/// a viewer row + an ownership period from share time; revoke and re-share work; owner-unclaim cascades
+/// to recipients while a recipient's unclaim only removes themselves.
+/// </summary>
+public class SensorSharingTests : ControllerTestBase
+{
+    private SensorController CreateController(ApplicationDbContext db, string userId, bool isAdmin = false)
+    {
+        var ownership = new Mock<IDeviceOwnershipService>();
+        ownership.Setup(o => o.CanUserAccessSensorAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        var proxy = new Mock<IClientProxy>();
+        proxy.Setup(p => p.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        var clients = new Mock<IHubClients>();
+        clients.Setup(c => c.Group(It.IsAny<string>())).Returns(proxy.Object);
+        var hub = new Mock<IHubContext<DeviceHub>>();
+        hub.SetupGet(h => h.Clients).Returns(clients.Object);
+
+        var capacity = new SubscriptionCapacityService(db, new MemoryCache(new MemoryCacheOptions()));
+        var controller = new SensorController(db, MockMapper.Object, NullLogger<SensorController>.Instance, ownership.Object, hub.Object, capacity);
+        controller.ControllerContext = MakeControllerContext(userId, isAdmin);
+        return controller;
+    }
+
+    private static Sensor MakeSensor(int id = 1) => new()
+    {
+        Id = id, Name = $"garge_volt_{id}", Type = "voltage", Role = "sensor",
+        RegistrationCode = $"rc{id}", DefaultName = "Battery", ParentName = "gw"
+    };
+
+    private static User MakeUser(string id, string email) => new()
+    {
+        Id = id, UserName = id, Email = email, NormalizedEmail = email.ToUpperInvariant(),
+        FirstName = "F", LastName = "L"
+    };
+
+    private static async Task SeedOwnedSensorAsync(ApplicationDbContext db, string ownerId, int sensorId = 1)
+    {
+        db.Sensors.Add(MakeSensor(sensorId));
+        db.UserSensors.Add(new UserSensor { UserId = ownerId, SensorId = sensorId, IsOwner = true });
+        await db.SaveChangesAsync();
+    }
+
+    private static ShareSensorDto Share(string email, SharePermission p = SharePermission.Read) =>
+        new() { Email = email, Permission = p };
+
+    [Fact]
+    public async Task ShareSensor_CreatesViewerRowAndOwnershipPeriodFromShareTime()
+    {
+        using var db = CreateDbContext();
+        db.Users.AddRange(MakeUser("owner", "owner@x"), MakeUser("viewer", "viewer@x"));
+        await SeedOwnedSensorAsync(db, "owner");
+
+        var result = await CreateController(db, "owner").ShareSensor(1, Share("viewer@x", SharePermission.Edit));
+
+        Assert.IsType<OkObjectResult>(result);
+        var row = db.UserSensors.Single(us => us.UserId == "viewer" && us.SensorId == 1);
+        Assert.False(row.IsOwner);
+        Assert.Equal(SharePermission.Edit, row.Permission);
+        var period = db.SensorOwnershipPeriods.Single(p => p.UserId == "viewer" && p.SensorId == 1);
+        Assert.Null(period.EndedAt);
+        Assert.NotEqual(SensorOwnershipPeriod.FirstOwnerStart, period.StartedAt); // from now, not the full-history epoch
+    }
+
+    [Fact]
+    public async Task ShareSensor_NotOwner_Forbid()
+    {
+        using var db = CreateDbContext();
+        db.Users.AddRange(MakeUser("owner", "owner@x"), MakeUser("stranger", "stranger@x"), MakeUser("viewer", "viewer@x"));
+        await SeedOwnedSensorAsync(db, "owner");
+
+        var result = await CreateController(db, "stranger").ShareSensor(1, Share("viewer@x"));
+
+        Assert.IsType<ForbidResult>(result);
+    }
+
+    [Fact]
+    public async Task ShareSensor_UnknownEmail_NotFound()
+    {
+        using var db = CreateDbContext();
+        db.Users.Add(MakeUser("owner", "owner@x"));
+        await SeedOwnedSensorAsync(db, "owner");
+
+        var result = await CreateController(db, "owner").ShareSensor(1, Share("ghost@x"));
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task ShareSensor_Reshare_UpdatesPermission_NoDuplicateRowOrPeriod()
+    {
+        using var db = CreateDbContext();
+        db.Users.AddRange(MakeUser("owner", "owner@x"), MakeUser("viewer", "viewer@x"));
+        await SeedOwnedSensorAsync(db, "owner");
+
+        await CreateController(db, "owner").ShareSensor(1, Share("viewer@x", SharePermission.Read));
+        await CreateController(db, "owner").ShareSensor(1, Share("viewer@x", SharePermission.Edit));
+
+        var rows = db.UserSensors.Where(us => us.UserId == "viewer" && us.SensorId == 1).ToList();
+        Assert.Single(rows);
+        Assert.Equal(SharePermission.Edit, rows[0].Permission);
+        Assert.Single(db.SensorOwnershipPeriods.Where(p => p.UserId == "viewer" && p.SensorId == 1));
+    }
+
+    [Fact]
+    public async Task RevokeShare_RemovesViewerAndClosesPeriod()
+    {
+        using var db = CreateDbContext();
+        db.Users.AddRange(MakeUser("owner", "owner@x"), MakeUser("viewer", "viewer@x"));
+        await SeedOwnedSensorAsync(db, "owner");
+        await CreateController(db, "owner").ShareSensor(1, Share("viewer@x"));
+
+        var result = await CreateController(db, "owner").RevokeShare(1, "viewer");
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.DoesNotContain(db.UserSensors, us => us.UserId == "viewer" && us.SensorId == 1);
+        Assert.NotNull(db.SensorOwnershipPeriods.Single(p => p.UserId == "viewer" && p.SensorId == 1).EndedAt);
+    }
+
+    [Fact]
+    public async Task RevokeShare_NotOwner_Forbid()
+    {
+        using var db = CreateDbContext();
+        db.Users.AddRange(MakeUser("owner", "owner@x"), MakeUser("viewer", "viewer@x"), MakeUser("stranger", "s@x"));
+        await SeedOwnedSensorAsync(db, "owner");
+        await CreateController(db, "owner").ShareSensor(1, Share("viewer@x"));
+
+        var result = await CreateController(db, "stranger").RevokeShare(1, "viewer");
+
+        Assert.IsType<ForbidResult>(result);
+    }
+
+    [Fact]
+    public async Task ListShares_ReturnsRecipientsWithPermission()
+    {
+        using var db = CreateDbContext();
+        db.Users.AddRange(MakeUser("owner", "owner@x"), MakeUser("viewer", "viewer@x"));
+        await SeedOwnedSensorAsync(db, "owner");
+        await CreateController(db, "owner").ShareSensor(1, Share("viewer@x", SharePermission.Edit));
+
+        var result = await CreateController(db, "owner").ListShares(1);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var shares = Assert.IsAssignableFrom<IEnumerable<SensorShareDto>>(ok.Value);
+        var s = Assert.Single(shares);
+        Assert.Equal("viewer", s.UserId);
+        Assert.Equal(SharePermission.Edit, s.Permission);
+    }
+
+    [Fact]
+    public async Task UnclaimSensor_Owner_CascadesToViewers()
+    {
+        using var db = CreateDbContext();
+        db.Users.AddRange(MakeUser("owner", "owner@x"), MakeUser("viewer", "viewer@x"));
+        await SeedOwnedSensorAsync(db, "owner");
+        await CreateController(db, "owner").ShareSensor(1, Share("viewer@x"));
+
+        var result = await CreateController(db, "owner").UnclaimSensor(1);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.DoesNotContain(db.UserSensors, us => us.SensorId == 1);          // owner + viewer both gone
+        Assert.All(db.SensorOwnershipPeriods.Where(p => p.SensorId == 1), p => Assert.NotNull(p.EndedAt));
+    }
+
+    [Fact]
+    public async Task UnclaimSensor_Viewer_LeavesOnly_OwnerIntact()
+    {
+        using var db = CreateDbContext();
+        db.Users.AddRange(MakeUser("owner", "owner@x"), MakeUser("viewer", "viewer@x"));
+        await SeedOwnedSensorAsync(db, "owner");
+        await CreateController(db, "owner").ShareSensor(1, Share("viewer@x"));
+
+        var result = await CreateController(db, "viewer").UnclaimSensor(1);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.DoesNotContain(db.UserSensors, us => us.UserId == "viewer" && us.SensorId == 1);   // viewer left
+        Assert.Contains(db.UserSensors, us => us.UserId == "owner" && us.SensorId == 1 && us.IsOwner); // owner stays
+    }
+}

--- a/garge-api.Tests/SwitchSharingTests.cs
+++ b/garge-api.Tests/SwitchSharingTests.cs
@@ -1,0 +1,190 @@
+using garge_api.Controllers;
+using garge_api.Dtos.Switch;
+using garge_api.Hubs;
+using garge_api.Models;
+using garge_api.Models.Switch;
+using garge_api.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace garge_api.Tests;
+
+/// <summary>
+/// Verifies switch sharing: an owner can share Read/Edit by email; the recipient gets a viewer row +
+/// ownership period from share time; revoke, list, owner-cascade and viewer-leave behave; and a Read
+/// viewer cannot perform an Edit-gated mutation (deleting telemetry).
+/// </summary>
+public class SwitchSharingTests : ControllerTestBase
+{
+    private SwitchesController CreateController(ApplicationDbContext db, string userId, bool isAdmin = false)
+    {
+        var ownership = new Mock<IDeviceOwnershipService>();
+        ownership.Setup(o => o.CanUserAccessSwitchAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        var proxy = new Mock<IClientProxy>();
+        proxy.Setup(p => p.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        var clients = new Mock<IHubClients>();
+        clients.Setup(c => c.Group(It.IsAny<string>())).Returns(proxy.Object);
+        var hub = new Mock<IHubContext<DeviceHub>>();
+        hub.SetupGet(h => h.Clients).Returns(clients.Object);
+
+        var controller = new SwitchesController(db, MockMapper.Object, NullLogger<SwitchesController>.Instance, ownership.Object, hub.Object);
+        controller.ControllerContext = MakeControllerContext(userId, isAdmin);
+        return controller;
+    }
+
+    private static Switch MakeSwitch(int id = 1) => new()
+    {
+        Id = id, Name = $"socket-{id}", Type = "socket", Role = "switch",
+    };
+
+    private static User MakeUser(string id, string email) => new()
+    {
+        Id = id, UserName = id, Email = email, NormalizedEmail = email.ToUpperInvariant(),
+        FirstName = "F", LastName = "L",
+    };
+
+    private static async Task SeedOwnedSwitchAsync(ApplicationDbContext db, string ownerId, int switchId = 1)
+    {
+        db.Switches.Add(MakeSwitch(switchId));
+        db.UserSwitches.Add(new UserSwitch { UserId = ownerId, SwitchId = switchId, IsOwner = true });
+        await db.SaveChangesAsync();
+    }
+
+    private static ShareSwitchDto Share(string email, SharePermission p = SharePermission.Read) =>
+        new() { Email = email, Permission = p };
+
+    [Fact]
+    public async Task ShareSwitch_CreatesViewerRowAndOwnershipPeriod()
+    {
+        using var db = CreateDbContext();
+        db.Users.AddRange(MakeUser("owner", "owner@x"), MakeUser("viewer", "viewer@x"));
+        await SeedOwnedSwitchAsync(db, "owner");
+
+        var result = await CreateController(db, "owner").ShareSwitch(1, Share("viewer@x", SharePermission.Edit));
+
+        Assert.IsType<OkObjectResult>(result);
+        var row = db.UserSwitches.Single(us => us.UserId == "viewer" && us.SwitchId == 1);
+        Assert.False(row.IsOwner);
+        Assert.Equal(SharePermission.Edit, row.Permission);
+        var period = db.SwitchOwnershipPeriods.Single(p => p.UserId == "viewer" && p.SwitchId == 1);
+        Assert.Null(period.EndedAt);
+        Assert.NotEqual(SwitchOwnershipPeriod.FirstOwnerStart, period.StartedAt);
+    }
+
+    [Fact]
+    public async Task ShareSwitch_NotOwner_Forbid()
+    {
+        using var db = CreateDbContext();
+        db.Users.AddRange(MakeUser("owner", "owner@x"), MakeUser("stranger", "s@x"), MakeUser("viewer", "viewer@x"));
+        await SeedOwnedSwitchAsync(db, "owner");
+
+        var result = await CreateController(db, "stranger").ShareSwitch(1, Share("viewer@x"));
+
+        Assert.IsType<ForbidResult>(result);
+    }
+
+    [Fact]
+    public async Task ShareSwitch_UnknownEmail_NotFound()
+    {
+        using var db = CreateDbContext();
+        db.Users.Add(MakeUser("owner", "owner@x"));
+        await SeedOwnedSwitchAsync(db, "owner");
+
+        var result = await CreateController(db, "owner").ShareSwitch(1, Share("ghost@x"));
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task RevokeSwitchShare_RemovesAndClosesPeriod()
+    {
+        using var db = CreateDbContext();
+        db.Users.AddRange(MakeUser("owner", "owner@x"), MakeUser("viewer", "viewer@x"));
+        await SeedOwnedSwitchAsync(db, "owner");
+        await CreateController(db, "owner").ShareSwitch(1, Share("viewer@x"));
+
+        var result = await CreateController(db, "owner").RevokeSwitchShare(1, "viewer");
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.DoesNotContain(db.UserSwitches, us => us.UserId == "viewer" && us.SwitchId == 1);
+        Assert.NotNull(db.SwitchOwnershipPeriods.Single(p => p.UserId == "viewer" && p.SwitchId == 1).EndedAt);
+    }
+
+    [Fact]
+    public async Task ListSwitchShares_ReturnsRecipients()
+    {
+        using var db = CreateDbContext();
+        db.Users.AddRange(MakeUser("owner", "owner@x"), MakeUser("viewer", "viewer@x"));
+        await SeedOwnedSwitchAsync(db, "owner");
+        await CreateController(db, "owner").ShareSwitch(1, Share("viewer@x", SharePermission.Edit));
+
+        var result = await CreateController(db, "owner").ListSwitchShares(1);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var shares = Assert.IsAssignableFrom<IEnumerable<SwitchShareDto>>(ok.Value);
+        var s = Assert.Single(shares);
+        Assert.Equal("viewer", s.UserId);
+        Assert.Equal(SharePermission.Edit, s.Permission);
+    }
+
+    [Fact]
+    public async Task UnclaimSwitch_Owner_CascadesToViewers()
+    {
+        using var db = CreateDbContext();
+        db.Users.AddRange(MakeUser("owner", "owner@x"), MakeUser("viewer", "viewer@x"));
+        await SeedOwnedSwitchAsync(db, "owner");
+        await CreateController(db, "owner").ShareSwitch(1, Share("viewer@x"));
+
+        var result = await CreateController(db, "owner").UnclaimSwitch(1);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.DoesNotContain(db.UserSwitches, us => us.SwitchId == 1);
+        Assert.All(db.SwitchOwnershipPeriods.Where(p => p.SwitchId == 1), p => Assert.NotNull(p.EndedAt));
+    }
+
+    [Fact]
+    public async Task UnclaimSwitch_Viewer_LeavesOnly_OwnerIntact()
+    {
+        using var db = CreateDbContext();
+        db.Users.AddRange(MakeUser("owner", "owner@x"), MakeUser("viewer", "viewer@x"));
+        await SeedOwnedSwitchAsync(db, "owner");
+        await CreateController(db, "owner").ShareSwitch(1, Share("viewer@x"));
+
+        var result = await CreateController(db, "viewer").UnclaimSwitch(1);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.DoesNotContain(db.UserSwitches, us => us.UserId == "viewer" && us.SwitchId == 1);
+        Assert.Contains(db.UserSwitches, us => us.UserId == "owner" && us.SwitchId == 1 && us.IsOwner);
+    }
+
+    [Fact]
+    public async Task DeleteSwitchData_ReadViewer_Forbidden()
+    {
+        using var db = CreateDbContext();
+        db.Users.AddRange(MakeUser("owner", "owner@x"), MakeUser("viewer", "viewer@x"));
+        await SeedOwnedSwitchAsync(db, "owner");
+        await CreateController(db, "owner").ShareSwitch(1, Share("viewer@x", SharePermission.Read));
+
+        var result = await CreateController(db, "viewer").DeleteSwitchData(1, 999);
+
+        Assert.IsType<ForbidResult>(result);
+    }
+
+    [Fact]
+    public async Task DeleteSwitchData_EditViewer_PassesAuth()
+    {
+        // Edit share clears the auth gate; with no such data row it then 404s (proving auth passed).
+        using var db = CreateDbContext();
+        db.Users.AddRange(MakeUser("owner", "owner@x"), MakeUser("viewer", "viewer@x"));
+        await SeedOwnedSwitchAsync(db, "owner");
+        await CreateController(db, "owner").ShareSwitch(1, Share("viewer@x", SharePermission.Edit));
+
+        var result = await CreateController(db, "viewer").DeleteSwitchData(1, 999);
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+}


### PR DESCRIPTION
## Summary

Implements **device sharing** (sensors + switches) — the open half of issue #245 — and **documents** the cancel/over-quota and sharing decisions.

An owner can share a device with another Garge user by email at one of two tiers. A share is a `UserSensor`/`UserSwitch` row with `IsOwner = false` and a `SharePermission` (`Read` | `Edit`); recipients never consume their own capacity.

### Endpoints (owner only)
- `POST /sensors/{id}/share` · `DELETE /sensors/{id}/share/{userId}` · `GET /sensors/{id}/shares`
- `POST /switches/{id}/share` · `DELETE /switches/{id}/share/{userId}` · `GET /switches/{id}/shares`

### Permission model
| | Read | Edit | Owner |
|---|:--:|:--:|:--:|
| View data / history / battery / live | ✓ | ✓ | ✓ |
| Own custom name / activities / photos / alert prefs (private per-user) | ✓ | ✓ | ✓ |
| Toggle switches · automations · calibration · delete telemetry | | ✓ | ✓ |
| Suspend/activate · unclaim · share/revoke · transfer | | | ✓ |

Per-user data is keyed by user, so a recipient editing it only changes their own view — hence no Edit gate.

### Access, history, and the discovery edge
- A share opens an ownership period **from share time**, so the recipient sees data from then on, not the owner's earlier private history.
- `SensorDto.access` / `SwitchDto.access` (`owner`/`edit`/`read`) tell the client what to render. Labels centralized in `DeviceAccess`.
- A **switch owner** is a direct owner *or* an indirect owner (owns the parent sensor whose gateway discovered the switch); either can share.
- When a sensor discovers a new socket, only the sensor **owner** auto-gains access (a sensor share is not a switch share — the indirect sensor→switch path is owner-only).
- Owner **unclaim cascades** to recipients. Because indirect owners can share, sensor-unclaim also **revokes shares on any socket left ownerless** (no orphaned access). Edit gates the only user-reachable switch mutation (`DeleteSwitchData`); toggling is admin/operator/automation-only.

### Docs
`docs/access-and-quota.md` — product decision record for #245: capacity, cancel = suspension (not deletion), retention/opt-out, and the full sharing model + permission matrix + discovery behavior.

## Tests
- `SensorSharingTests` / `SwitchSharingTests`: share creates viewer row + period from share time; not-owner forbidden; unknown email 404; re-share updates tier; revoke; list; owner-unclaim cascade; recipient-leave; orphaned-socket-share cleanup; Read viewer blocked from an Edit mutation.
- `AutomationControllerTests`: Read share can't create automations, Edit can.
- `UserControllerTests`: unchanged GDPR scrub paths still green.
- **364 tests pass.** Migrations: `AddUserSensorSharePermission`, `AddUserSwitchSharePermission` (backfills existing `UserSwitches.IsOwner = true`).

## Frontend
Sensor share UI: garge-app #334. Socket share UI: follow-on.
