### PR TITLE
fix: clear build warnings; professionalize endpoint docs and comments

### DIFF
--- a/Controllers/AdminController.cs
+++ b/Controllers/AdminController.cs
@@ -211,7 +211,7 @@ namespace garge_api.Controllers
 
         /// <summary>
         /// Gets all users with their roles. Soft-deleted (scrubbed) accounts are hidden by default;
-        /// pass includeDeleted=true to include them (e.g. an admin "Show deleted" toggle).
+        /// pass includeDeleted=true to include them.
         /// </summary>
         /// <param name="includeDeleted">When true, also returns soft-deleted accounts.</param>
         /// <returns>A list of all users.</returns>
@@ -349,9 +349,9 @@ namespace garge_api.Controllers
         {
             _logger.LogInformation("GetStatsHistory called by {@LogData}", new { CallerUserId = User.UserId() });
 
-            // Frozen completed-day snapshots (immutable, so they outlive the per-user data they were
-            // derived from and survive the post-5y purge) plus a live row for today. The daily job
-            // freezes completed days; today is always recomputed here so same-day churn isn't lost.
+            // Frozen completed-day snapshots are immutable, so they outlive the per-user data they
+            // were derived from and survive the 5-year purge. The daily job freezes completed days;
+            // today is always recomputed here so same-day churn is not lost.
             var snapshots = await Services.StatsSnapshotService.GetHistoryAsync(_context);
 
             var result = snapshots.Select(s => (object)new

--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -96,7 +96,7 @@ namespace garge_api.Controllers
                 return Ok(new { message = genericResponse });
             }
 
-            // Use AutoMapper to map DTO to User
+            // Map the registration DTO to the User entity.
             var user = _mapper.Map<User>(registerUserDto);
             user.TermsAcceptedAt = DateTime.UtcNow;
             user.TermsVersion = registerUserDto.TermsVersion;
@@ -130,9 +130,9 @@ namespace garge_api.Controllers
 
             _logger.LogError("Register failed: {@Errors}", result.Errors);
 
-            // Return the field-keyed shape the client parses (parseValidationErrors) so a
-            // server-only failure like a taken username surfaces on its field instead of a
-            // generic "failed to register". Identity emits username / email / password codes.
+            // Return the field-keyed error shape the client parses so a server-only failure such as
+            // a taken username surfaces on its field instead of a generic "failed to register".
+            // Identity emits username, email, and password error codes.
             var fieldErrors = result.Errors
                 .GroupBy(e => RegisterErrorField(e.Code))
                 .ToDictionary(g => g.Key, g => g.Select(e => e.Description).ToArray());
@@ -414,7 +414,7 @@ namespace garge_api.Controllers
         [HttpPost("request-password-reset")]
         [AllowAnonymous]
         [SwaggerOperation(Summary = "Request a password reset code via email.")]
-        [SwaggerResponse(200, "Reset code sent (always, to prevent email enumeration).")]
+        [SwaggerResponse(200, "Always returns 200; a reset code is sent only if the email is registered.")]
         public async Task<IActionResult> RequestPasswordReset([FromBody] RequestPasswordResetDto model)
         {
             _logger.LogInformation("RequestPasswordReset called");

--- a/Controllers/AutomationController.cs
+++ b/Controllers/AutomationController.cs
@@ -44,11 +44,11 @@ namespace garge_api.Controllers
                 .Join(_context.Sensors, us => us.SensorId, s => s.Id, (us, s) => s.ParentName)
                 .ToListAsync();
 
-            // Fetch the target name (switch)
+            // Resolve the target switch's name.
             var targetSwitch = await _context.Switches.FindAsync(rule.TargetId);
             var targetName = targetSwitch?.Name;
 
-            // Check if any device the user can access has discovered this target
+            // Allow access only when a device the user can act on has discovered this target.
             var discovered = targetName != null && await _context.DiscoveredDevices
                 .AnyAsync(dd => accessibleParentNames.Contains(dd.DiscoveredBy) && dd.Target == targetName);
 
@@ -115,7 +115,7 @@ namespace garge_api.Controllers
         }
 
         /// <summary>
-        /// Marks an automation rule as triggered (called by the operator).
+        /// Records that an automation rule has been triggered.
         /// </summary>
         [HttpPatch("{id}/triggered")]
         [SwaggerOperation(Summary = "Records that an automation rule was triggered.")]
@@ -249,10 +249,10 @@ namespace garge_api.Controllers
         }
 
         /// <summary>
-        /// Starts the timer on a timed automation rule (called by the operator).
+        /// Starts the timer on a timed automation rule.
         /// </summary>
         [HttpPatch("{id}/timer-start")]
-        [SwaggerOperation(Summary = "Sets TimerActivatedAt to now for a timed rule.")]
+        [SwaggerOperation(Summary = "Starts the timer on a timed automation rule.")]
         [SwaggerResponse(204, "Timer started.")]
         [SwaggerResponse(404, "Rule not found.")]
         public async Task<IActionResult> TimerStart(int id)
@@ -270,10 +270,10 @@ namespace garge_api.Controllers
         }
 
         /// <summary>
-        /// Clears the timer on a timed automation rule (called by the operator when timer expires).
+        /// Clears the timer on a timed automation rule, re-arming it.
         /// </summary>
         [HttpPatch("{id}/timer-clear")]
-        [SwaggerOperation(Summary = "Clears TimerActivatedAt, re-arming the rule.")]
+        [SwaggerOperation(Summary = "Clears the timer on a timed automation rule, re-arming it.")]
         [SwaggerResponse(204, "Timer cleared.")]
         [SwaggerResponse(404, "Rule not found.")]
         public async Task<IActionResult> TimerClear(int id)

--- a/Controllers/BatteryHealthController.cs
+++ b/Controllers/BatteryHealthController.cs
@@ -49,8 +49,8 @@ namespace garge_api.Controllers
         }
 
         /// <summary>
-        /// True when the caller may edit shared state on this sensor — owner, an Edit-tier share, or
-        /// admin. Calibration writes a global per-sensor offset, so a read-only share must not change it.
+        /// Returns true when the caller may edit shared state on this sensor (owner, an Edit-tier share,
+        /// or admin). Calibration writes a global per-sensor offset, so a read-only share must not change it.
         /// </summary>
         private async Task<bool> UserCanEditSensorAsync(int sensorId)
         {

--- a/Controllers/ElectricityController.cs
+++ b/Controllers/ElectricityController.cs
@@ -67,7 +67,7 @@ namespace garge_api.Controllers
 
             var vatRate = ElectricityPriceHelper.GetVatRate(area);
 
-            // Try serving from DB first
+            // Serve from the database when stored data is available.
             var storedEntries = await GetStoredPricesAsync(resolution, area, queryDate);
             if (storedEntries.Count > 0)
             {
@@ -76,7 +76,7 @@ namespace garge_api.Controllers
                 return Ok(dbDto);
             }
 
-            // Fall back to NordPool
+            // Fall back to the NordPool service when no stored data exists.
             _logger.LogInformation("No DB data found, fetching from NordPool {@LogData}", new { type = LogSanitizer.Sanitize(type), area = LogSanitizer.Sanitize(area), date, currency });
             var data = await _nordPoolService.FetchPricesAsync(resolution, queryDate, new List<string> { area }, currency);
 

--- a/Controllers/GroupsController.cs
+++ b/Controllers/GroupsController.cs
@@ -28,7 +28,7 @@ namespace garge_api.Controllers
         private string GetUserId() => User.UserId()!;
 
         /// <summary>
-        /// Get all groups for the current user, including their sensor and switch IDs.
+        /// Returns all groups for the current user, including their sensor and switch IDs.
         /// </summary>
         [HttpGet]
         public async Task<IActionResult> GetGroups()
@@ -52,7 +52,7 @@ namespace garge_api.Controllers
         }
 
         /// <summary>
-        /// Create a new group.
+        /// Creates a new group for the current user.
         /// </summary>
         [HttpPost]
         public async Task<IActionResult> CreateGroup([FromBody] CreateGroupDto dto)
@@ -81,7 +81,7 @@ namespace garge_api.Controllers
         }
 
         /// <summary>
-        /// Update group name/icon.
+        /// Updates the name and icon of a group.
         /// </summary>
         [HttpPut("{id}")]
         public async Task<IActionResult> UpdateGroup(int id, [FromBody] UpdateGroupDto dto)
@@ -100,7 +100,7 @@ namespace garge_api.Controllers
         }
 
         /// <summary>
-        /// Delete a group and all its sensor and switch associations.
+        /// Deletes a group and all its sensor and switch associations.
         /// </summary>
         [HttpDelete("{id}")]
         public async Task<IActionResult> DeleteGroup(int id)
@@ -122,7 +122,7 @@ namespace garge_api.Controllers
         }
 
         /// <summary>
-        /// Add a sensor to a group.
+        /// Adds a sensor to a group.
         /// </summary>
         [HttpPost("{id}/sensors/{sensorId}")]
         public async Task<IActionResult> AddSensor(int id, int sensorId)
@@ -150,7 +150,7 @@ namespace garge_api.Controllers
         }
 
         /// <summary>
-        /// Remove a sensor from a group.
+        /// Removes a sensor from a group.
         /// </summary>
         [HttpDelete("{id}/sensors/{sensorId}")]
         public async Task<IActionResult> RemoveSensor(int id, int sensorId)
@@ -174,7 +174,7 @@ namespace garge_api.Controllers
         }
 
         /// <summary>
-        /// Add a switch to a group.
+        /// Adds a switch to a group.
         /// </summary>
         [HttpPost("{id}/switches/{switchId}")]
         public async Task<IActionResult> AddSwitch(int id, int switchId)
@@ -202,7 +202,7 @@ namespace garge_api.Controllers
         }
 
         /// <summary>
-        /// Remove a switch from a group.
+        /// Removes a switch from a group.
         /// </summary>
         [HttpDelete("{id}/switches/{switchId}")]
         public async Task<IActionResult> RemoveSwitch(int id, int switchId)

--- a/Controllers/SensorActivitiesController.cs
+++ b/Controllers/SensorActivitiesController.cs
@@ -46,7 +46,7 @@ namespace garge_api.Controllers
         }
 
         /// <summary>
-        /// Lists activities logged for a sensor (e.g. motorcycle voltmeter), most recent first.
+        /// Lists the activities logged for a sensor, ordered with the most recent first.
         /// </summary>
         [HttpGet]
         [SwaggerOperation(Summary = "Lists activities for a sensor.")]

--- a/Controllers/SensorController.cs
+++ b/Controllers/SensorController.cs
@@ -94,9 +94,10 @@ namespace garge_api.Controllers
         }
 
         /// <summary>
-        /// True when the caller has this owned sensor suspended (turned off / over quota). Suspended
-        /// sensors stay visible in the list but their dashboard/history reads are blocked. Admins are
-        /// never suspended. Export and unclaim/delete must never use this gate (GDPR rights).
+        /// Returns true when the caller has this owned sensor suspended (turned off or over quota).
+        /// Suspended sensors remain visible in the list, but their dashboard and history reads are
+        /// blocked. Admins are never suspended. Export and unclaim/delete must not use this gate, as
+        /// those are GDPR rights.
         /// </summary>
         private async Task<bool> IsSensorSuspendedForCallerAsync(int sensorId)
         {
@@ -105,7 +106,7 @@ namespace garge_api.Controllers
             return await _context.UserSensors.AnyAsync(us => us.UserId == userId && us.SensorId == sensorId && us.SuspendedAt != null);
         }
 
-        /// <summary>Of the given sensor ids, the subset the caller has suspended (empty for admins).</summary>
+        /// <summary>Returns the subset of the given sensor ids that the caller has suspended (empty for admins).</summary>
         private async Task<HashSet<int>> CallerSuspendedSensorIdsAsync(IEnumerable<int> sensorIds)
         {
             if (IsAdmin()) return new HashSet<int>();
@@ -150,7 +151,7 @@ namespace garge_api.Controllers
             var sensorIds = sensors.Select(s => s.Id).ToList();
             var suspendedIds = await CallerSuspendedSensorIdsAsync(sensorIds);
 
-            // The caller's owner/edit/read relationship per sensor (admins are treated as owner).
+            // The caller's owner, edit, or read relationship per sensor (admins are treated as owner).
             var accessRows = IsAdmin()
                 ? new List<UserSensor>()
                 : await _context.UserSensors
@@ -158,7 +159,7 @@ namespace garge_api.Controllers
                     .ToListAsync();
             var accessById = accessRows.ToDictionary(us => us.SensorId, us => DeviceAccess.From(us.IsOwner, us.Permission));
 
-            // Map sensors and inject the user-specific custom name + suspended + access state
+            // Map sensors and apply the user-specific custom name, suspended flag, and access state.
             var dtos = sensors.Select(sensor =>
             {
                 var dto = _mapper.Map<SensorDto>(sensor);
@@ -424,7 +425,7 @@ namespace garge_api.Controllers
             if (effectiveStart.HasValue) { whereClauses.Add("sd.\"Timestamp\" >= @startDate"); parameters.Add(new("startDate", effectiveStart.Value)); }
             if (effectiveEnd.HasValue) { whereClauses.Add("sd.\"Timestamp\" <= @endDate"); parameters.Add(new("endDate", effectiveEnd.Value)); }
 
-            // Bound to the caller's own ownership window(s) — see WithinOwnershipWindow. Admins see all.
+            // Bound to the caller's own ownership window(s); see WithinOwnershipWindow. Admins see all data.
             if (!isAdmin)
             {
                 whereClauses.Add(@"EXISTS (SELECT 1 FROM ""SensorOwnershipPeriods"" p
@@ -708,8 +709,8 @@ namespace garge_api.Controllers
 
             await CleanUserSensorDataAsync(id, userId);
 
-            // Owner unclaim cascades to every shared recipient — viewer access is tied to the owner's
-            // ownership, not their own (issue #245). A recipient unclaiming only removes themselves.
+            // An owner unclaim cascades to every shared recipient, because viewer access is tied to the
+            // owner's ownership rather than their own. A recipient unclaim removes only that recipient.
             if (callerWasOwner)
             {
                 var viewerIds = await _context.UserSensors
@@ -724,7 +725,7 @@ namespace garge_api.Controllers
             await _context.SaveChangesAsync();
 
             // Losing an owned sensor can leave a socket it discovered with no owner. Revoke any shares
-            // on now-ownerless sockets so socket access never outlives ownership (the discovery edge).
+            // on now-ownerless sockets so that socket access never outlives ownership.
             if (callerWasOwner)
             {
                 await RevokeOrphanedSwitchSharesAsync(sensor.ParentName);
@@ -736,9 +737,9 @@ namespace garge_api.Controllers
         }
 
         /// <summary>
-        /// After an owned sensor is removed, revoke shares on any socket its gateway discovered that now
-        /// has no remaining owner (no direct owner row, no other owned sensor under the gateway). Keeps
-        /// socket-share lifetime tied to ownership without needing to track who created each share.
+        /// After an owned sensor is removed, revokes shares on any socket its gateway discovered that
+        /// now has no remaining owner (no direct owner row and no other owned sensor under the gateway).
+        /// This keeps socket-share lifetime tied to ownership without tracking who created each share.
         /// </summary>
         private async Task RevokeOrphanedSwitchSharesAsync(string? parentName)
         {
@@ -760,7 +761,7 @@ namespace garge_api.Controllers
                     .Join(_context.Sensors, dd => dd.DiscoveredBy, s => s.ParentName, (dd, s) => s.Id)
                     .Join(_context.UserSensors.Where(us => us.IsOwner), sid => sid, us => us.SensorId, (sid, us) => us.UserId)
                     .AnyAsync();
-                if (hasDirectOwner || hasIndirectOwner) continue; // still owned — keep its shares
+                if (hasDirectOwner || hasIndirectOwner) continue; // Still owned; keep its shares.
 
                 var viewers = await _context.UserSwitches
                     .Where(us => us.SwitchId == sw.Id && !us.IsOwner)
@@ -783,8 +784,8 @@ namespace garge_api.Controllers
 
         /// <summary>
         /// Removes one user's membership and personal rows for a sensor: the UserSensor row, any open
-        /// ownership period (closed now), and their custom name / activities / photos / offline
-        /// notifications. Does not save or invalidate the cache — the caller batches that.
+        /// ownership period (closed now), and their custom name, activities, photos, and offline
+        /// notifications. Does not save changes or invalidate the cache; the caller is responsible for that.
         /// </summary>
         private async Task CleanUserSensorDataAsync(int sensorId, string userId)
         {
@@ -809,7 +810,7 @@ namespace garge_api.Controllers
             _context.SensorOfflineNotifications.RemoveRange(_context.SensorOfflineNotifications.Where(n => n.UserId == userId && n.SensorId == sensorId));
         }
 
-        /// <summary>True when the caller owns this sensor (admins included). Only owners may share/revoke.</summary>
+        /// <summary>Returns true when the caller owns this sensor (admins included). Only owners may share or revoke.</summary>
         private async Task<bool> UserIsSensorOwnerAsync(int sensorId)
         {
             if (IsAdmin()) return true;
@@ -818,7 +819,7 @@ namespace garge_api.Controllers
                 .AnyAsync(us => us.UserId == userId && us.SensorId == sensorId && us.IsOwner);
         }
 
-        /// <summary>True when the caller may edit shared state (owner, Edit-share, or admin).</summary>
+        /// <summary>Returns true when the caller may edit shared state (owner, Edit-tier share, or admin).</summary>
         private async Task<bool> UserCanEditSensorAsync(int sensorId)
         {
             if (IsAdmin()) return true;
@@ -828,7 +829,7 @@ namespace garge_api.Controllers
                 (us.IsOwner || us.Permission == SharePermission.Edit));
         }
 
-        /// <summary>The caller's relationship to a sensor for SensorDto.Access (admins count as owner).</summary>
+        /// <summary>Returns the caller's relationship to a sensor for SensorDto.Access (admins count as owner).</summary>
         private async Task<string> CallerAccessAsync(int sensorId)
         {
             if (IsAdmin()) return DeviceAccess.Owner;
@@ -869,7 +870,7 @@ namespace garge_api.Controllers
             {
                 if (existing.IsOwner)
                     return BadRequest(new { message = "That user already owns this sensor." });
-                existing.Permission = dto.Permission; // re-share updates the tier
+                existing.Permission = dto.Permission; // Re-sharing updates the permission tier.
             }
             else
             {

--- a/Controllers/SensorController.cs
+++ b/Controllers/SensorController.cs
@@ -69,9 +69,7 @@ namespace garge_api.Controllers
             => query.WithinSensorOwnership(_context, User.UserId(), IsAdmin());
 
         /// <summary>
-        /// Returns the caller's sensor capacity and whether they can claim another sensor — the single
-        /// source of truth for the claim button and capacity meter, so the client never re-derives
-        /// capacity or the subscription-bypass role list.
+        /// Returns the caller's sensor capacity, how much is in use, and whether they may claim another.
         /// </summary>
         [HttpGet("capacity")]
         [Authorize]
@@ -944,7 +942,7 @@ namespace garge_api.Controllers
             return Ok(shares);
         }
 
-        /// <summary>Owner turns a sensor off: blocks its data reads and frees a quota slot. Always allowed.</summary>
+        /// <summary>Turns off an owned sensor, hiding its data and freeing its capacity slot.</summary>
         [HttpPost("{id}/suspend")]
         [Authorize]
         [SwaggerOperation(Summary = "Suspend (turn off) an owned sensor.")]
@@ -967,7 +965,7 @@ namespace garge_api.Controllers
             return Ok(new { message = "Sensor turned off.", suspended = true });
         }
 
-        /// <summary>Owner turns a sensor back on. Rejected if it would exceed the current plan capacity.</summary>
+        /// <summary>Turns an owned sensor back on. Returns 400 if it would exceed the caller's capacity.</summary>
         [HttpPost("{id}/activate")]
         [Authorize]
         [SwaggerOperation(Summary = "Activate (turn on) an owned sensor.")]

--- a/Controllers/ShopController.cs
+++ b/Controllers/ShopController.cs
@@ -492,10 +492,10 @@ namespace garge_api.Controllers
             }
             else if (payload.Name == "CAPTURED" && order.Status == OrderStatus.Paid)
             {
-                // Order already Paid (admin captured first, or this is a webhook
-                // redelivery). Service is idempotent: short-circuits on a complete
-                // existing invoice, otherwise renders. Empty placeholder rows from
-                // a prior failed render are cleaned up inside the service.
+                // The order is already Paid, either because an admin captured it first or because
+                // this is a webhook redelivery. The service is idempotent: it short-circuits when a
+                // complete invoice already exists and otherwise renders one. Empty placeholder rows
+                // left by a prior failed render are cleaned up inside the service.
                 _logger.LogInformation("Webhook recovery check for order {OrderId}", order.Id);
                 await TryGenerateInvoiceAsync(order.Id, "webhook recovery");
             }

--- a/Controllers/SubscriptionsController.cs
+++ b/Controllers/SubscriptionsController.cs
@@ -54,7 +54,7 @@ namespace garge_api.Controllers
             _logger = logger;
         }
 
-        /// <summary>Admin: list every subscription with the user's name + email, plus invoice count for the in-app subscriptions admin page.</summary>
+        /// <summary>Lists every subscription with the owner's name, email, and invoice count. Admin only.</summary>
         [HttpGet("all")]
         [Authorize(Policy = "Admin")]
         public async Task<IActionResult> GetAllSubscriptions()
@@ -131,7 +131,7 @@ namespace garge_api.Controllers
                 $"invoice-{invoice.Id:D4}.pdf");
         }
 
-        /// <summary>Returns the current user's subscriptions. Stopped/Expired hidden once next-charge date passed (grace period).</summary>
+        /// <summary>Returns the current user's subscriptions. Stopped or expired subscriptions are hidden once their next-charge date has passed.</summary>
         [HttpGet("my")]
         public async Task<IActionResult> GetMySubscriptions()
         {
@@ -314,7 +314,7 @@ namespace garge_api.Controllers
             return Ok();
         }
 
-        /// <summary>Updates the quantity of an active AddOn subscription. Increases PATCH the Vipps agreement ceiling (user reconfirms in Vipps); decreases are DB-only.</summary>
+        /// <summary>Updates the quantity of an active add-on subscription. Increasing the quantity raises the Vipps charge ceiling and requires reconfirmation in Vipps.</summary>
         [HttpPatch("{id:int}/quantity")]
         public async Task<IActionResult> UpdateSubscriptionQuantity(int id, [FromBody] UpdateSubscriptionQuantityDto dto)
         {

--- a/Controllers/SwitchesController.cs
+++ b/Controllers/SwitchesController.cs
@@ -45,7 +45,7 @@ namespace garge_api.Controllers
 
         private async Task<bool> UserHasRequiredRoleAsync(Switch switchEntity)
         {
-            // Admins always have access
+            // Admins always have access.
             if (IsSwitchAdmin()) return true;
 
             var userId = User.UserId();
@@ -57,8 +57,8 @@ namespace garge_api.Controllers
         }
 
         /// <summary>
-        /// True when the user owns a sensor whose gateway discovered this switch — they own the parent
-        /// device, so they are treated as a switch owner (can share/control it).
+        /// Returns true when the user owns a sensor whose gateway discovered this switch. Owning the
+        /// parent device makes the user a switch owner, so they may share and control it.
         /// </summary>
         private async Task<bool> IsIndirectSwitchOwnerAsync(Switch sw, string userId) =>
             await _context.DiscoveredDevices
@@ -67,7 +67,7 @@ namespace garge_api.Controllers
                 .Join(_context.UserSensors.Where(us => us.IsOwner && us.UserId == userId), sid => sid, us => us.SensorId, (sid, us) => us.UserId)
                 .AnyAsync();
 
-        /// <summary>Owner = admin, a direct owned row, or an indirect (parent-sensor) owner. Only owners may share.</summary>
+        /// <summary>Returns true when the caller is an owner: an admin, a direct owned row, or an indirect (parent-sensor) owner. Only owners may share.</summary>
         private async Task<bool> UserOwnsSwitchAsync(Switch sw)
         {
             if (IsSwitchAdmin()) return true;
@@ -77,7 +77,7 @@ namespace garge_api.Controllers
             return await IsIndirectSwitchOwnerAsync(sw, userId);
         }
 
-        /// <summary>True when the caller may edit shared state (owner or a direct Edit share).</summary>
+        /// <summary>Returns true when the caller may edit shared state (owner or a direct Edit-tier share).</summary>
         private async Task<bool> UserCanEditSwitchAsync(Switch sw)
         {
             if (await UserOwnsSwitchAsync(sw)) return true;
@@ -86,7 +86,7 @@ namespace garge_api.Controllers
                 us.UserId == userId && us.SwitchId == sw.Id && us.Permission == SharePermission.Edit);
         }
 
-        /// <summary>The caller's relationship to a switch for SwitchDto.Access.</summary>
+        /// <summary>Returns the caller's relationship to a switch for SwitchDto.Access.</summary>
         private async Task<string> CallerSwitchAccessAsync(Switch sw)
         {
             if (await UserOwnsSwitchAsync(sw)) return DeviceAccess.Owner;
@@ -99,8 +99,8 @@ namespace garge_api.Controllers
         }
 
         /// <summary>
-        /// Removes one user's direct membership + personal rows for a switch: the UserSwitch row, any
-        /// open ownership period (closed now), and their custom name. Does not save or invalidate cache.
+        /// Removes one user's direct membership and personal rows for a switch: the UserSwitch row, any
+        /// open ownership period (closed now), and their custom name. Does not save changes or invalidate the cache.
         /// </summary>
         private async Task CleanUserSwitchDataAsync(int switchId, string userId)
         {
@@ -790,7 +790,7 @@ namespace garge_api.Controllers
 
             await CleanUserSwitchDataAsync(id, userId);
 
-            // Owner unclaim cascades to every direct recipient; a recipient's unclaim removes only them.
+            // An owner unclaim cascades to every direct recipient; a recipient unclaim removes only that recipient.
             if (callerWasOwner)
             {
                 var viewerIds = await _context.UserSwitches

--- a/Helpers/OwnershipWindowQueryExtensions.cs
+++ b/Helpers/OwnershipWindowQueryExtensions.cs
@@ -11,24 +11,24 @@ namespace garge_api.Helpers
     /// <c>timestamp &gt;= period.StartedAt &amp;&amp; (period.EndedAt == null || timestamp &lt; period.EndedAt)</c>,
     /// defined once here and reused by every read endpoint and the data export. All methods are plain
     /// LINQ over <see cref="IQueryable{T}"/>, so EF Core translates them to SQL like an inline predicate.
-    /// Pass <paramref name="isAdmin"/> = true to bypass the window (admins see everything).
+    /// Pass <c>isAdmin</c> = true to bypass the window (admins see everything).
     /// </summary>
     public static class OwnershipWindowQueryExtensions
     {
         public static IQueryable<SensorData> WithinSensorOwnership(
-            this IQueryable<SensorData> query, ApplicationDbContext db, string userId, bool isAdmin = false)
+            this IQueryable<SensorData> query, ApplicationDbContext db, string? userId, bool isAdmin = false)
             => isAdmin ? query : query.Where(sd => db.SensorOwnershipPeriods.Any(p =>
                 p.UserId == userId && p.SensorId == sd.SensorId
                 && sd.Timestamp >= p.StartedAt && (p.EndedAt == null || sd.Timestamp < p.EndedAt)));
 
         public static IQueryable<BatteryHealth> WithinSensorOwnership(
-            this IQueryable<BatteryHealth> query, ApplicationDbContext db, string userId, bool isAdmin = false)
+            this IQueryable<BatteryHealth> query, ApplicationDbContext db, string? userId, bool isAdmin = false)
             => isAdmin ? query : query.Where(bh => db.SensorOwnershipPeriods.Any(p =>
                 p.UserId == userId && p.SensorId == bh.SensorId
                 && bh.Timestamp >= p.StartedAt && (p.EndedAt == null || bh.Timestamp < p.EndedAt)));
 
         public static IQueryable<BatteryChargeEvent> WithinSensorOwnership(
-            this IQueryable<BatteryChargeEvent> query, ApplicationDbContext db, string userId, bool isAdmin = false)
+            this IQueryable<BatteryChargeEvent> query, ApplicationDbContext db, string? userId, bool isAdmin = false)
             => isAdmin ? query : query.Where(e => db.SensorOwnershipPeriods.Any(p =>
                 p.UserId == userId && p.SensorId == e.SensorId
                 && e.StartedAt >= p.StartedAt && (p.EndedAt == null || e.StartedAt < p.EndedAt)));
@@ -39,7 +39,7 @@ namespace garge_api.Helpers
         /// Sensor.ParentName → an owned sensor's period). Either path bounds the data to the caller's window.
         /// </summary>
         public static IQueryable<SwitchData> WithinSwitchOwnership(
-            this IQueryable<SwitchData> query, ApplicationDbContext db, string userId, bool isAdmin = false)
+            this IQueryable<SwitchData> query, ApplicationDbContext db, string? userId, bool isAdmin = false)
             => isAdmin ? query : query.Where(sd =>
                 db.SwitchOwnershipPeriods.Any(p => p.UserId == userId && p.SwitchId == sd.SwitchId
                     && sd.Timestamp >= p.StartedAt && (p.EndedAt == null || sd.Timestamp < p.EndedAt))

--- a/Services/DeviceOwnershipService.cs
+++ b/Services/DeviceOwnershipService.cs
@@ -10,7 +10,7 @@ namespace garge_api.Services
     /// (PostgresNotificationService) and the request-time access checks in
     /// SwitchesController/SensorController.
     ///
-    /// Caches results for <see cref="OwnershipCacheTtl"/>. Callers that mutate
+    /// Caches results for a short TTL. Callers that mutate
     /// UserSwitches / UserSensors must invalidate via
     /// <see cref="InvalidateSwitch"/> / <see cref="InvalidateSensor"/>.
     /// </summary>


### PR DESCRIPTION
## Summary

Clears the CI build warnings and does a full professional pass over endpoint documentation and code comments.

### Build warnings (now 0)
- **CS8604 ×5:** the ownership-window query helpers took a non-nullable `string userId` but callers pass `User.UserId()` (`string?`). The parameter is now `string?` — a null caller matches no ownership periods, which is the correct "sees nothing" result.
- **XML doc ×2:** fixed an unresolved `cref` in `IDeviceOwnershipService` and a stray `paramref` in `OwnershipWindowQueryExtensions`.

### Documentation & comment cleanup
A pass over all 18 controllers, rewriting endpoint summaries, `[SwaggerResponse]` descriptions and code comments into clear, declarative prose. Removed:
- implementation asides ("single source of truth… so the client never re-derives", "the caller batches that"),
- internal field names in summaries ("Sets TimerActivatedAt to now"),
- "(called by the operator)" / "Always allowed" notes,
- issue/phase references and first-person phrasing.

Technical rationale that matters (GDPR/retention reasoning, ownership-window rules, the password-reset anti-enumeration guarantee) was kept, just reworded.

**Text only** — no behavior, routes, status codes, `typeof(...)`, validation messages or log templates changed.

## Tests
No behavior change. Main project builds with 0 warnings; 380 tests pass.
