### PR TITLE
refactor: remove per-sensor voltage calibration

### DIFF
--- a/Controllers/BatteryHealthController.cs
+++ b/Controllers/BatteryHealthController.cs
@@ -48,19 +48,6 @@ namespace garge_api.Controllers
             return await _context.UserSensors.AnyAsync(us => us.UserId == userId && us.SensorId == sensorId);
         }
 
-        /// <summary>
-        /// Returns true when the caller may edit shared state on this sensor (owner, an Edit-tier share,
-        /// or admin). Calibration writes a global per-sensor offset, so a read-only share must not change it.
-        /// </summary>
-        private async Task<bool> UserCanEditSensorAsync(int sensorId)
-        {
-            if (IsAdmin()) return true;
-            var userId = User.UserId();
-            return await _context.UserSensors.AnyAsync(us =>
-                us.UserId == userId && us.SensorId == sensorId &&
-                (us.IsOwner || us.Permission == SharePermission.Edit));
-        }
-
         // Bound derived battery data to the caller's own ownership window(s) so a new owner of a
         // re-claimed/resold sensor never sees the previous owner's history. Admins see everything.
         private IQueryable<BatteryHealth> WithinOwnershipWindow(IQueryable<BatteryHealth> query)
@@ -120,7 +107,6 @@ namespace garge_api.Controllers
             }
 
             var dto = _mapper.Map<BatteryHealthDto>(latest);
-            dto.CalibrationOffsetV = sensor.CalibrationOffsetV;
             return Ok(dto);
         }
 
@@ -140,48 +126,6 @@ namespace garge_api.Controllers
             if (since.HasValue) query = query.Where(e => e.StartedAt >= since.Value);
             var events = await query.OrderByDescending(e => e.StartedAt).ToListAsync();
             return Ok(_mapper.Map<List<BatteryChargeEventDto>>(events));
-        }
-
-        /// <summary>Stores a per-sensor calibration offset based on a multimeter reading at the moment of calibration.</summary>
-        [HttpPost("name/{sensorName}/calibration")]
-        [SwaggerOperation(Summary = "Calibrate a voltage sensor against a multimeter reading.")]
-        [SwaggerResponse(200, "Calibration offset stored.")]
-        public async Task<IActionResult> Calibrate(string sensorName, [FromBody] CalibrationDto dto)
-        {
-            var sensor = await _context.Sensors.FirstOrDefaultAsync(s => s.Name == sensorName);
-            if (sensor == null) return NotFound(new { message = "Sensor not found!" });
-            if (!await UserCanEditSensorAsync(sensor.Id)) return Forbid();
-
-            var latest = await WithinOwnershipWindow(
-                    _context.SensorData.Where(sd => sd.SensorId == sensor.Id))
-                .OrderByDescending(sd => sd.Timestamp)
-                .Select(sd => sd.Value)
-                .FirstOrDefaultAsync();
-            if (string.IsNullOrEmpty(latest) ||
-                !float.TryParse(latest, System.Globalization.CultureInfo.InvariantCulture, out var sensorReading))
-                return BadRequest(new { message = "No recent sensor reading to calibrate against." });
-
-            sensor.CalibrationOffsetV = dto.MultimeterVoltage - sensorReading;
-            await _context.SaveChangesAsync();
-
-            _logger.LogInformation("Calibration set for {SensorName}: offset={Offset:F3}V",
-                LogSanitizer.Sanitize(sensorName), sensor.CalibrationOffsetV);
-            return Ok(new { calibrationOffsetV = sensor.CalibrationOffsetV });
-        }
-
-        /// <summary>Clears a sensor's stored calibration offset.</summary>
-        [HttpDelete("name/{sensorName}/calibration")]
-        [SwaggerOperation(Summary = "Clear a voltage sensor's calibration offset.")]
-        [SwaggerResponse(204, "Calibration cleared.")]
-        public async Task<IActionResult> ClearCalibration(string sensorName)
-        {
-            var sensor = await _context.Sensors.FirstOrDefaultAsync(s => s.Name == sensorName);
-            if (sensor == null) return NotFound(new { message = "Sensor not found!" });
-            if (!await UserCanEditSensorAsync(sensor.Id)) return Forbid();
-
-            sensor.CalibrationOffsetV = null;
-            await _context.SaveChangesAsync();
-            return NoContent();
         }
 
         /// <summary>

--- a/Dtos/Sensor/BatteryHealthDto.cs
+++ b/Dtos/Sensor/BatteryHealthDto.cs
@@ -17,10 +17,6 @@ namespace garge_api.Dtos.Sensor
         public float? DailyDropPctPerWeek { get; set; }
         public float? ChargeAcceptanceRatio { get; set; }
 
-        // Sensor-level calibration offset (volts). Frontend may add this to
-        // CurrentVoltage to display "actual" voltage.
-        public float? CalibrationOffsetV { get; set; }
-
         public DateTime Timestamp { get; set; }
     }
 
@@ -34,10 +30,5 @@ namespace garge_api.Dtos.Sensor
         public float RestingAtTime { get; set; }
         public float PeakRatio { get; set; }
         public int DurationMinutes { get; set; }
-    }
-
-    public class CalibrationDto
-    {
-        public required float MultimeterVoltage { get; set; }
     }
 }

--- a/Dtos/Sensor/ShareSensorDto.cs
+++ b/Dtos/Sensor/ShareSensorDto.cs
@@ -7,7 +7,7 @@ namespace garge_api.Dtos.Sensor
     {
         public required string Email { get; set; }
 
-        /// <summary>Read (view only) or Edit (control switches, automations, calibration).</summary>
+        /// <summary>Read (view only) or Edit (control switches and automations).</summary>
         public SharePermission Permission { get; set; } = SharePermission.Read;
     }
 

--- a/Migrations/20260523082723_DropSensorCalibrationOffset.Designer.cs
+++ b/Migrations/20260523082723_DropSensorCalibrationOffset.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260523082723_DropSensorCalibrationOffset")]
+    partial class DropSensorCalibrationOffset
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260523082723_DropSensorCalibrationOffset.cs
+++ b/Migrations/20260523082723_DropSensorCalibrationOffset.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class DropSensorCalibrationOffset : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CalibrationOffsetV",
+                table: "Sensors");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<float>(
+                name: "CalibrationOffsetV",
+                table: "Sensors",
+                type: "real",
+                nullable: true);
+        }
+    }
+}

--- a/Models/Anonymized/AnonymizedSeries.cs
+++ b/Models/Anonymized/AnonymizedSeries.cs
@@ -20,7 +20,10 @@ namespace garge_api.Models.Anonymized
         [MaxLength(50)]
         public required string SourceType { get; set; }
 
-        /// <summary>Per-sensor voltage calibration offset (voltage series only) so regenerated voltage matches.</summary>
+        /// <summary>
+        /// Legacy per-sensor voltage calibration offset, retained for series anonymized before sensor
+        /// calibration was removed. No longer populated; always null for new series.
+        /// </summary>
         public float? CalibrationOffsetV { get; set; }
 
         public DateTime AnonymizedAt { get; set; } = DateTime.UtcNow;

--- a/Models/Sensor/Sensor.cs
+++ b/Models/Sensor/Sensor.cs
@@ -33,12 +33,6 @@ namespace garge_api.Models.Sensor
         [Required]
         public required string ParentName { get; set; }
 
-        // User-supplied additive offset (volts) for voltage sensors with
-        // calibration drift. Frontend displays `value + offset` as the
-        // "actual" voltage; health logic itself is ratio-based so doesn't
-        // use this. Null means uncalibrated.
-        public float? CalibrationOffsetV { get; set; }
-
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     }
 }

--- a/Models/SharePermission.cs
+++ b/Models/SharePermission.cs
@@ -9,7 +9,7 @@ namespace garge_api.Models
         /// <summary>View data, history, battery health and live updates. No control or editing.</summary>
         Read = 0,
 
-        /// <summary>Read, plus toggle switches, create/edit automations, and battery calibration.</summary>
+        /// <summary>Read, plus toggle switches and create or edit automations.</summary>
         Edit = 1,
     }
 }

--- a/Services/AnonymizationService.cs
+++ b/Services/AnonymizationService.cs
@@ -56,7 +56,6 @@ namespace garge_api.Services
                 var series = new AnonymizedSeries
                 {
                     SourceType = sensor?.Type ?? "unknown",
-                    CalibrationOffsetV = sensor?.Type == "voltage" ? sensor?.CalibrationOffsetV : null,
                     AnonymizedAt = DateTime.UtcNow
                 };
                 _db.AnonymizedSeries.Add(series);

--- a/garge-api.Tests/AnonymizationServiceTests.cs
+++ b/garge-api.Tests/AnonymizationServiceTests.cs
@@ -28,7 +28,7 @@ public class AnonymizationServiceTests : ControllerTestBase
     public async Task AnonymizeSensorPeriod_MovesExclusiveReadings_DeletesOriginalsAndDerived()
     {
         using var db = CreateDbContext();
-        db.Sensors.Add(new Sensor { Id = 1, Name = "garge_volt", Type = "voltage", Role = "sensor", RegistrationCode = "rc", DefaultName = "Battery", ParentName = "gw", CalibrationOffsetV = 0.5f });
+        db.Sensors.Add(new Sensor { Id = 1, Name = "garge_volt", Type = "voltage", Role = "sensor", RegistrationCode = "rc", DefaultName = "Battery", ParentName = "gw" });
         var period = new SensorOwnershipPeriod { UserId = "user-A", SensorId = 1, StartedAt = Jan, EndedAt = Jun };
         db.SensorOwnershipPeriods.Add(period);
         db.SensorData.AddRange(
@@ -44,7 +44,7 @@ public class AnonymizationServiceTests : ControllerTestBase
         Assert.Equal(3, moved);
         var series = Assert.Single(db.AnonymizedSeries);
         Assert.Equal("voltage", series.SourceType);
-        Assert.Equal(0.5f, series.CalibrationOffsetV);
+        Assert.Null(series.CalibrationOffsetV);
         Assert.Equal(3, db.AnonymizedReadings.Count());
         Assert.Contains(db.AnonymizedReadings, r => r.Value == 12.5);
         Assert.Single(db.SensorData); // only the out-of-window Jul row remains


### PR DESCRIPTION
## Summary

Removes per-sensor voltage calibration. The offset only fed a display-only "≈ actual" annotation on two battery-health rows in the app; it was never applied to readings, the voltage chart, battery classification, `/latest-data`, or automation — so it added confusion (a user could anchor on the "actual" number when setting an automation threshold, which compares the raw value) without real value.

### Removed
- `POST`/`DELETE /battery-health/name/{sensorName}/calibration` endpoints and `CalibrationDto`.
- `BatteryHealthDto.CalibrationOffsetV` and the `Sensor.CalibrationOffsetV` column (migration `DropSensorCalibrationOffset`).
- The unused Edit-gate helper that only guarded calibration.

### Kept
- `AnonymizedSeries.CalibrationOffsetV` column, for series anonymized before this change. It is no longer populated (always null for new series) — avoids a migration on the anonymised ML store.
- The battery-health analyser's ratio-based design (already calibration-robust) is unchanged.

A better correction (applied consistently across display + automation) can be designed later if needed.

## Tests
380 pass; builds with 0 warnings. Pairs with garge-app removal of the calibrate UI.
