### PR TITLE
fix: stats history 500 (UTC bounds for live-today query)

### DIFF
--- a/Services/StatsSnapshotService.cs
+++ b/Services/StatsSnapshotService.cs
@@ -122,7 +122,9 @@ namespace garge_api.Services
             var snapshots = await db.DailyStatSnapshots.OrderBy(s => s.Date).ToListAsync(ct);
 
             var today = DateOnly.FromDateTime(DateTime.UtcNow);
-            var todayStart = today.ToDateTime(TimeOnly.MinValue);
+            // Kind must be UTC: these bounds are compared against timestamptz columns, and Npgsql
+            // rejects a DateTime with Kind=Unspecified.
+            var todayStart = today.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
             var tomorrow = todayStart.AddDays(1);
 
             // Carry from the last completed day (yesterday after EnsureUpToDate), then apply today's


### PR DESCRIPTION
## Summary

`GET /api/admin/stats/history` returned 500 on Postgres. `GetHistoryAsync` built the live-"today" day bounds with `DateOnly.ToDateTime(TimeOnly.MinValue)`, which has `Kind=Unspecified`. Npgsql rejects an unspecified-kind `DateTime` when comparing against a `timestamptz` column (`CreatedAt`/`DeletedAt`), so the query threw. In-memory tests don't enforce this, so it wasn't caught.

Fix: build the bounds with `DateTimeKind.Utc`, matching how the rest of `AdminController` constructs date parameters.

## Note
This was the *second* fault on that endpoint. The first, seen in the dev logs, is `42P01: relation "DailyStatSnapshots" does not exist` — the `AddDailyStatSnapshot` migration has not been applied to the dev database (migrations are not applied automatically anywhere in this repo). Applying the pending migrations is required in addition to this fix.

## Tests
380 pass; builds with 0 warnings.
