### PR TITLE
feat: make sensor/socket/automation stats reflect removals

### DIFF
--- a/Services/StatsSnapshotService.cs
+++ b/Services/StatsSnapshotService.cs
@@ -72,6 +72,14 @@ namespace garge_api.Services
             var switchCreated = await CountByDayAsync(db.Switches.Select(s => s.CreatedAt), ct);
             var automationCreated = await CountByDayAsync(db.AutomationRules.Select(a => a.CreatedAt), ct);
 
+            // Sensors, switches and automations are hard-deleted, so a row's removal leaves no trace and
+            // a cumulative created-count can never dip. Sample the live counts and stamp them on the
+            // latest completed day, so the series reflects removals from this point forward. Older
+            // backfilled days keep the cumulative (created-only) estimate — the past cannot be rebuilt.
+            var sensorsLive = await db.Sensors.CountAsync(ct);
+            var switchesLive = await db.Switches.CountAsync(ct);
+            var automationsLive = await db.AutomationRules.CountAsync(ct);
+
             var last = await db.DailyStatSnapshots
                 .OrderByDescending(s => s.Date)
                 .FirstOrDefaultAsync(ct);
@@ -102,7 +110,16 @@ namespace garge_api.Services
             for (var date = from; date <= yesterday; date = date.AddDays(1))
             {
                 running.Apply(date, userCreated, userDeleted, sensorCreated, switchCreated, automationCreated);
-                newRows.Add(running.ToSnapshot(date));
+                var snapshot = running.ToSnapshot(date);
+                if (date == yesterday)
+                {
+                    // Latest completed day: use the live counts so removals are reflected. Carry these
+                    // forward so the next run continues from the actual figures.
+                    snapshot.TotalSensors = running.Sensors = sensorsLive;
+                    snapshot.TotalSwitches = running.Switches = switchesLive;
+                    snapshot.TotalAutomations = running.Automations = automationsLive;
+                }
+                newRows.Add(snapshot);
             }
 
             db.DailyStatSnapshots.AddRange(newRows);
@@ -127,15 +144,16 @@ namespace garge_api.Services
             var todayStart = today.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
             var tomorrow = todayStart.AddDays(1);
 
-            // Carry from the last completed day (yesterday after EnsureUpToDate), then apply today's
-            // live deltas. Recomputed every read, so later same-day activity is always reflected.
+            // Today's live row. Users carry from the last completed day plus today's signups minus
+            // today's deletions (soft-delete keeps the full record). Sensors, switches and automations
+            // are hard-deleted, so use their live counts directly — that is what makes them dip.
             var running = snapshots.Count > 0 ? Totals.From(snapshots[^1]) : new Totals();
             running.Users += await db.Users.CountAsync(u => u.CreatedAt >= todayStart && u.CreatedAt < tomorrow, ct);
             running.Users -= await db.Users.CountAsync(
                 u => u.IsDeleted && u.DeletedAt != null && u.DeletedAt >= todayStart && u.DeletedAt < tomorrow, ct);
-            running.Sensors += await db.Sensors.CountAsync(s => s.CreatedAt >= todayStart && s.CreatedAt < tomorrow, ct);
-            running.Switches += await db.Switches.CountAsync(s => s.CreatedAt >= todayStart && s.CreatedAt < tomorrow, ct);
-            running.Automations += await db.AutomationRules.CountAsync(a => a.CreatedAt >= todayStart && a.CreatedAt < tomorrow, ct);
+            running.Sensors = await db.Sensors.CountAsync(ct);
+            running.Switches = await db.Switches.CountAsync(ct);
+            running.Automations = await db.AutomationRules.CountAsync(ct);
 
             // Don't fabricate a lone zero row when nothing has ever happened.
             if (snapshots.Count == 0 && running.IsZero) return snapshots;

--- a/garge-api.Tests/StatsSnapshotServiceTests.cs
+++ b/garge-api.Tests/StatsSnapshotServiceTests.cs
@@ -1,5 +1,6 @@
 using garge_api.Models;
 using garge_api.Models.Admin;
+using garge_api.Models.Sensor;
 using garge_api.Services;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
@@ -18,6 +19,13 @@ public class StatsSnapshotServiceTests
         CreatedAt = created.ToDateTime(new TimeOnly(12, 0)),
         IsDeleted = deleted != null,
         DeletedAt = deleted?.ToDateTime(new TimeOnly(12, 0)),
+    };
+
+    private static Sensor MakeSensor(int id, DateOnly created) => new()
+    {
+        Id = id, Name = $"s{id}", Type = "voltage", Role = "sensor",
+        RegistrationCode = $"rc{id}", DefaultName = "D", ParentName = "gw",
+        CreatedAt = created.ToDateTime(new TimeOnly(12, 0)),
     };
 
     private static DailyStatSnapshot? Frozen(ApplicationDbContext db, DateOnly date) =>
@@ -140,6 +148,29 @@ public class StatsSnapshotServiceTests
 
         Assert.Equal(0, second);
         Assert.Equal(count, db.DailyStatSnapshots.Count());
+    }
+
+    [Fact]
+    public async Task Sensors_UseLiveCount_AndDipWhenRemoved()
+    {
+        // Sensors are hard-deleted, so the series tracks the live count: today reflects removals, and
+        // the latest frozen day is stamped with the live count too.
+        using var db = NewDb();
+        var twoDaysAgo = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2);
+        var yesterday = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1);
+        db.Sensors.AddRange(MakeSensor(1, twoDaysAgo), MakeSensor(2, twoDaysAgo), MakeSensor(3, twoDaysAgo));
+        await db.SaveChangesAsync(Ct);
+
+        var before = await StatsSnapshotService.GetHistoryAsync(db, Ct);
+        Assert.Equal(3, before[^1].TotalSensors);              // today = live count
+        Assert.Equal(3, Frozen(db, yesterday)!.TotalSensors);  // latest frozen day stamped live
+
+        db.Sensors.Remove(db.Sensors.Single(s => s.Id == 3));  // hard delete
+        await db.SaveChangesAsync(Ct);
+
+        var after = await StatsSnapshotService.GetHistoryAsync(db, Ct);
+        Assert.Equal(2, after[^1].TotalSensors);               // today dips
+        Assert.Equal(3, Frozen(db, yesterday)!.TotalSensors);  // frozen day unchanged
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Makes the **sensors, sockets and automations** lines in the admin stats history go up *and* down, like the users line.

The users line already dips because users are **soft-deleted** (the `DeletedAt` record lets the series subtract them). Sensors, switches and automations are **hard-deleted** — the row is removed with no trace — so the previous cumulative created-count could only ever climb.

This samples their **live counts** and stamps them on:
- the latest completed-day snapshot (in `EnsureUpToDateAsync`), and
- the live "today" row (in `GetHistoryAsync`).

So from now on, removing a sensor, socket or automation makes the corresponding line dip.

## Limitation (inherent to hard-delete)
History **before this change** stays the created-only (monotonic) estimate — hard-deleted rows leave nothing to reconstruct from, so the past can't be made to dip. Only the period from deployment onward reflects removals. (Making the past accurate would require soft-deleting these entities — a much larger change to deletion semantics and out of scope.)

## Frontend
No change — the admin chart already plots `totalSensors` / `totalSwitches` / `totalAutomations`; the dips appear automatically.

## Tests
New `Sensors_UseLiveCount_AndDipWhenRemoved` (today reflects removals; latest frozen day stamped live; older frozen days immutable). 381 tests pass, 0 warnings.
