### PR TITLE
fix: clear lockout on reset + show cooldown message on login

### DIFF
--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -172,14 +172,19 @@ namespace garge_api.Controllers
             if (user == null || user.IsDeleted)
             {
                 _logger.LogWarning("Login failed: Invalid credentials");
-                return Unauthorized(new { message = "Invalid credentials!" });
+                return Unauthorized(new { message = "Invalid email or password." });
             }
 
             var result = await _signInManager.PasswordSignInAsync(user.UserName ?? string.Empty, login.Password, false, lockoutOnFailure: true);
             if (!result.Succeeded)
             {
+                if (result.IsLockedOut)
+                {
+                    _logger.LogWarning("Login blocked: account locked {UserId}", user.Id);
+                    return Unauthorized(new { message = "Too many failed attempts — this login is temporarily locked. Try again later, or reset your password." });
+                }
                 _logger.LogWarning("Login failed: Invalid credentials");
-                return Unauthorized(new { message = "Invalid credentials!" });
+                return Unauthorized(new { message = "Invalid email or password." });
             }
 
             var userRoles = await _userManager.GetRolesAsync(user);

--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -486,6 +486,11 @@ namespace garge_api.Controllers
             user.PasswordResetCodeHash = null;
             user.PasswordResetCodeExpiration = null;
             user.PasswordResetAttempts = 0;
+            // A successful reset proves the user controls the account, so clear any login lockout —
+            // otherwise a user who locked themselves out with the old password still gets 401 with the
+            // new one until the lockout window expires.
+            user.LockoutEnd = null;
+            user.AccessFailedCount = 0;
             await _userManager.UpdateAsync(user);
 
             _logger.LogInformation("Password reset successfully {UserId}", user.Id);

--- a/garge-api.Tests/AuthControllerTests.cs
+++ b/garge-api.Tests/AuthControllerTests.cs
@@ -51,6 +51,22 @@ public class AuthControllerTests : ControllerTestBase
     }
 
     [Fact]
+    public async Task Login_LockedOut_ReturnsCooldownMessage()
+    {
+        var user = MakeUser();
+        MockUserManager.Setup(m => m.FindByEmailAsync(user.Email!)).ReturnsAsync(user);
+        MockSignInManager
+            .Setup(m => m.PasswordSignInAsync(user.UserName!, It.IsAny<string>(), false, true))
+            .ReturnsAsync(SignInResult.LockedOut);
+
+        var result = await CreateAuthController().Login(new LoginModel { Email = user.Email!, Password = "wrong" });
+
+        var unauthorized = Assert.IsType<UnauthorizedObjectResult>(result);
+        var message = unauthorized.Value!.GetType().GetProperty("message")!.GetValue(unauthorized.Value) as string;
+        Assert.Contains("temporarily locked", message);
+    }
+
+    [Fact]
     public async Task Login_ValidCredentials_ReturnsOkWithTokenAndRefreshToken()
     {
         var user = MakeUser();

--- a/garge-api.Tests/AuthControllerTests.cs
+++ b/garge-api.Tests/AuthControllerTests.cs
@@ -285,6 +285,41 @@ public class AuthControllerTests : ControllerTestBase
         Assert.IsType<BadRequestObjectResult>(result);
     }
 
+    private static string Sha256B64(string t)
+    {
+        using var sha = System.Security.Cryptography.SHA256.Create();
+        return Convert.ToBase64String(sha.ComputeHash(System.Text.Encoding.UTF8.GetBytes(t)));
+    }
+
+    [Fact]
+    public async Task ResetPassword_Success_ClearsLockout()
+    {
+        // A user who locked themselves out with the old password must be able to sign in with the new
+        // one immediately — the reset clears the lockout.
+        var user = new User
+        {
+            Id = "u1", UserName = "user", Email = "user@test.com", FirstName = "F", LastName = "L",
+            PasswordResetCodeHash = Sha256B64("ABCDEF"),
+            PasswordResetCodeExpiration = DateTime.UtcNow.AddMinutes(10),
+            PasswordResetAttempts = 0,
+            LockoutEnd = DateTimeOffset.UtcNow.AddMinutes(20),
+            AccessFailedCount = 3,
+        };
+        MockUserManager.Setup(m => m.FindByEmailAsync(user.Email!)).ReturnsAsync(user);
+        MockUserManager.Setup(m => m.GeneratePasswordResetTokenAsync(user)).ReturnsAsync("token");
+        MockUserManager.Setup(m => m.ResetPasswordAsync(user, "token", It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
+        MockUserManager.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+
+        var result = await CreateAuthController().ResetPassword(
+            new ResetPasswordDto { Email = user.Email!, Code = "ABCDEF", NewPassword = "Password1!" });
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Null(user.LockoutEnd);
+        Assert.Equal(0, user.AccessFailedCount);
+        Assert.Null(user.PasswordResetCodeHash);
+        Assert.Equal(0, user.PasswordResetAttempts);
+    }
+
     [Fact]
     public async Task Register_PersistsTermsFields()
     {


### PR DESCRIPTION
## Summary

Two fixes for the login lockout that caused the "password reset didn't work" report.

### 1. Clear lockout on successful password reset
Reset wrote the correct new hash but `ResetPasswordAsync` doesn't touch the lockout, so a user who locked themselves out trying the old password kept getting 401 with the new one until the 30-minute window expired. Reset now clears `LockoutEnd` and `AccessFailedCount`.

### 2. Tell a locked-out user they're on cooldown
Login returned the same generic message for a lockout, so the user couldn't tell why the correct password failed. A lockout now returns a distinct message ("temporarily locked — try again later or reset your password"); unknown-email and wrong-password keep one shared **"Invalid email or password."** so those two stay indistinguishable.

A note on enumeration: the lockout message only appears for a real account that has hit 5 failed attempts, so it's a minor account-existence signal — accepted for the UX (register and password-reset remain fully generic).

## Tests
`ResetPassword_Success_ClearsLockout`, `Login_LockedOut_ReturnsCooldownMessage`. 383 tests pass, 0 warnings.

## Ops note
The affected prod account (`testbruker`) was unlocked manually so it can sign in now; these changes prevent recurrence.
