### PR TITLE
chore: async DB reads, declarative authorization, Mapster mappings, dedup

### DIFF
--- a/Constants/RoleNames.cs
+++ b/Constants/RoleNames.cs
@@ -2,6 +2,14 @@ namespace garge_api.Constants
 {
     public static class RoleNames
     {
+        // Canonical role names. These are the values seeded into Identity and issued in JWTs,
+        // so [Authorize(Roles = ...)] and IsInAnyRole(...) checks must use these exact strings.
+        public const string Admin = "Admin";
+        public const string SensorAdmin = "SensorAdmin";
+        public const string SwitchAdmin = "SwitchAdmin";
+        public const string MqttAdmin = "MqttAdmin";
+        public const string AutomationAdmin = "AutomationAdmin";
+
         public static readonly string[] AllRoles =
         {
             "Default", "Electricity",

--- a/Constants/SwitchStates.cs
+++ b/Constants/SwitchStates.cs
@@ -1,0 +1,18 @@
+namespace garge_api.Constants
+{
+    /// <summary>
+    /// Canonical on/off state values a switch (socket) can be set to, plus the set of valid
+    /// states accepted by the switch-data write endpoints.
+    /// </summary>
+    public static class SwitchStates
+    {
+        public const string On = "ON";
+        public const string Off = "OFF";
+
+        /// <summary>The states accepted when writing switch data.</summary>
+        public static readonly string[] Valid = { On, Off };
+
+        public static bool IsValid(string? value) =>
+            value != null && Valid.Contains(value, StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/Constants/SwitchTypes.cs
+++ b/Constants/SwitchTypes.cs
@@ -1,0 +1,19 @@
+namespace garge_api.Constants
+{
+    /// <summary>
+    /// Canonical switch device-type values. Mirrors <see cref="SensorTypes"/>. The API uses
+    /// "switch" as the device class; the only concrete type today is the socket.
+    /// </summary>
+    public static class SwitchTypes
+    {
+        public const string Socket = "socket";
+
+        public static readonly IReadOnlySet<string> Allowed = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            Socket,
+        };
+
+        public static bool IsAllowed(string? type) =>
+            !string.IsNullOrWhiteSpace(type) && Allowed.Contains(type);
+    }
+}

--- a/Controllers/AdminController.cs
+++ b/Controllers/AdminController.cs
@@ -81,11 +81,11 @@ namespace garge_api.Controllers
         [HttpGet]
         [SwaggerOperation(Summary = "Gets all roles.")]
         [SwaggerResponse(200, "Roles retrieved successfully.", typeof(IEnumerable<RoleDto>))]
-        public IActionResult GetRoles()
+        public async Task<IActionResult> GetRoles()
         {
             _logger.LogInformation("GetRoles called by {@LogData}", new { CallerUserId = User.UserId() });
 
-            var roles = _roleManager.Roles.ToList();
+            var roles = await _roleManager.Roles.ToListAsync();
             var dtos = _mapper.Map<IEnumerable<RoleDto>>(roles);
             return Ok(dtos);
         }
@@ -224,7 +224,7 @@ namespace garge_api.Controllers
 
             var query = _userManager.Users;
             if (!includeDeleted) query = query.Where(u => !u.IsDeleted);
-            var users = query.ToList();
+            var users = await query.ToListAsync();
             var dtos = new List<UserDto>();
             foreach (var user in users)
             {
@@ -421,6 +421,12 @@ namespace garge_api.Controllers
             {
                 _logger.LogWarning("AssignPermission failed: Unknown permission {@LogData}", new { permission });
                 return BadRequest(new { message = $"Unknown permission. Allowed: {string.Join(", ", Constants.RoleNames.KnownPermissions)}." });
+            }
+
+            if (await _context.RolePermissions.AnyAsync(rp => rp.RoleName == roleName && rp.Permission == permission))
+            {
+                _logger.LogInformation("AssignPermission no-op: Permission already assigned {@LogData}", new { permission, roleName });
+                return Ok(new { message = "Permission assigned successfully!" });
             }
 
             var rolePermission = new RolePermission

--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -189,7 +189,7 @@ namespace garge_api.Controllers
 
             var userRoles = await _userManager.GetRolesAsync(user);
             var tokenString = BuildJwt(user, userRoles);
-            var rawToken = IssueRefreshToken(user.Id ?? throw new InvalidOperationException("Authenticated user has no ID."));
+            var rawToken = await IssueRefreshTokenAsync(user.Id ?? throw new InvalidOperationException("Authenticated user has no ID."));
             await _context.SaveChangesAsync();
 
             _logger.LogInformation("User logged in successfully {UserId}", user.Id);
@@ -349,7 +349,7 @@ namespace garge_api.Controllers
 
             var userRoles = await _userManager.GetRolesAsync(user);
             var newTokenString = BuildJwt(user, userRoles);
-            var newRawToken = IssueRefreshToken(user.Id ?? throw new InvalidOperationException("Authenticated user has no ID."));
+            var newRawToken = await IssueRefreshTokenAsync(user.Id ?? throw new InvalidOperationException("Authenticated user has no ID."));
 
             await _context.SaveChangesAsync();
             await tx.CommitAsync();
@@ -386,15 +386,15 @@ namespace garge_api.Controllers
         /// Adds a new refresh token row for the user (capped at 5 active per user).
         /// Caller must SaveChangesAsync. Returns the raw (un-hashed) token to send to the client.
         /// </summary>
-        private string IssueRefreshToken(string userId)
+        private async Task<string> IssueRefreshTokenAsync(string userId)
         {
             var rawToken = GenerateRefreshToken();
             var hashedToken = HashText(rawToken);
 
-            var userTokens = _context.RefreshTokens
+            var userTokens = await _context.RefreshTokens
                 .Where(t => t.UserId == userId && t.Revoked == null && t.Expires > DateTime.UtcNow)
                 .OrderBy(t => t.Created)
-                .ToList();
+                .ToListAsync();
             if (userTokens.Count >= 5)
             {
                 _context.RefreshTokens.Remove(userTokens.First());

--- a/Controllers/AutomationController.cs
+++ b/Controllers/AutomationController.cs
@@ -1,6 +1,8 @@
-﻿using garge_api.Dtos.Automation;
+﻿using garge_api.Constants;
+using garge_api.Dtos.Automation;
 using garge_api.Models;
 using garge_api.Models.Automation;
+using MapsterMapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
@@ -18,19 +20,18 @@ namespace garge_api.Controllers
     {
         private readonly ApplicationDbContext _context;
         private readonly ILogger<AutomationController> _logger;
+        private readonly IMapper _mapper;
 
-        public AutomationController(ApplicationDbContext context, ILogger <AutomationController> logger)
+        public AutomationController(ApplicationDbContext context, ILogger<AutomationController> logger, IMapper mapper)
         {
             _context = context;
             _logger = logger;
+            _mapper = mapper;
         }
 
         private async Task<bool> UserHasAccessToAutomationAsync(AutomationRule rule)
         {
-            var userRoles = User.FindAll(ClaimTypes.Role).Select(r => r.Value).ToList();
-
-            if (userRoles.Contains("admin", StringComparer.OrdinalIgnoreCase) ||
-                userRoles.Contains("AutomationAdmin", StringComparer.OrdinalIgnoreCase))
+            if (User.IsInAnyRole(RoleNames.Admin, RoleNames.AutomationAdmin))
             {
                 return true;
             }
@@ -91,27 +92,7 @@ namespace garge_api.Controllers
             _context.AutomationRules.Add(rule);
             await _context.SaveChangesAsync();
 
-            var result = new AutomationRuleDto
-            {
-                Id = rule.Id,
-                TargetType = rule.TargetType,
-                TargetId = rule.TargetId,
-                SensorType = rule.SensorType,
-                SensorId = rule.SensorId,
-                Condition = rule.Condition,
-                Threshold = rule.Threshold,
-                Action = rule.Action,
-                IsEnabled = rule.IsEnabled,
-                LastTriggeredAt = rule.LastTriggeredAt,
-                ElectricityPriceCondition = rule.ElectricityPriceCondition,
-                ElectricityPriceThreshold = rule.ElectricityPriceThreshold,
-                ElectricityPriceArea = rule.ElectricityPriceArea,
-                ElectricityPriceOperator = rule.ElectricityPriceOperator,
-                TimerDurationHours = rule.TimerDurationHours,
-                TimerActivatedAt = rule.TimerActivatedAt,
-            };
-
-            return Ok(result);
+            return Ok(_mapper.Map<AutomationRuleDto>(rule));
         }
 
         /// <summary>
@@ -144,32 +125,14 @@ namespace garge_api.Controllers
         [SwaggerResponse(200, "List of rules.", typeof(IEnumerable<AutomationRuleDto>))]
         public async Task<ActionResult<IEnumerable<AutomationRuleDto>>> GetRules()
         {
-            var allRules = await _context.AutomationRules.ToListAsync();
+            var allRules = await _context.AutomationRules.AsNoTracking().ToListAsync();
             var accessibleRules = new List<AutomationRuleDto>();
 
             foreach (var rule in allRules)
             {
                 if (await UserHasAccessToAutomationAsync(rule))
                 {
-                    accessibleRules.Add(new AutomationRuleDto
-                    {
-                        Id = rule.Id,
-                        TargetType = rule.TargetType,
-                        TargetId = rule.TargetId,
-                        SensorType = rule.SensorType,
-                        SensorId = rule.SensorId,
-                        Condition = rule.Condition,
-                        Threshold = rule.Threshold,
-                        Action = rule.Action,
-                        IsEnabled = rule.IsEnabled,
-                        LastTriggeredAt = rule.LastTriggeredAt,
-                        ElectricityPriceCondition = rule.ElectricityPriceCondition,
-                        ElectricityPriceThreshold = rule.ElectricityPriceThreshold,
-                        ElectricityPriceArea = rule.ElectricityPriceArea,
-                        ElectricityPriceOperator = rule.ElectricityPriceOperator,
-                        TimerDurationHours = rule.TimerDurationHours,
-                        TimerActivatedAt = rule.TimerActivatedAt,
-                    });
+                    accessibleRules.Add(_mapper.Map<AutomationRuleDto>(rule));
                 }
             }
 
@@ -225,27 +188,7 @@ namespace garge_api.Controllers
 
             await _context.SaveChangesAsync();
 
-            var result = new AutomationRuleDto
-            {
-                Id = rule.Id,
-                TargetType = rule.TargetType,
-                TargetId = rule.TargetId,
-                SensorType = rule.SensorType,
-                SensorId = rule.SensorId,
-                Condition = rule.Condition,
-                Threshold = rule.Threshold,
-                Action = rule.Action,
-                IsEnabled = rule.IsEnabled,
-                LastTriggeredAt = rule.LastTriggeredAt,
-                ElectricityPriceCondition = rule.ElectricityPriceCondition,
-                ElectricityPriceThreshold = rule.ElectricityPriceThreshold,
-                ElectricityPriceArea = rule.ElectricityPriceArea,
-                ElectricityPriceOperator = rule.ElectricityPriceOperator,
-                TimerDurationHours = rule.TimerDurationHours,
-                TimerActivatedAt = rule.TimerActivatedAt,
-            };
-
-            return Ok(result);
+            return Ok(_mapper.Map<AutomationRuleDto>(rule));
         }
 
         /// <summary>

--- a/Controllers/BatteryHealthController.cs
+++ b/Controllers/BatteryHealthController.cs
@@ -1,4 +1,5 @@
 using MapsterMapper;
+using garge_api.Constants;
 using garge_api.Dtos.Sensor;
 using garge_api.Helpers;
 using garge_api.Models;
@@ -142,7 +143,7 @@ namespace garge_api.Controllers
         public async Task<IActionResult> ReanalyzeAll(CancellationToken ct)
         {
             var sensorIds = await _context.Sensors
-                .Where(s => s.Type == "voltage")
+                .Where(s => s.Type == SensorTypes.Voltage)
                 .Select(s => s.Id)
                 .ToListAsync(ct);
 
@@ -177,7 +178,7 @@ namespace garge_api.Controllers
         public async Task<IActionResult> ReanalyzeOne(int sensorId, CancellationToken ct)
         {
             var exists = await _context.Sensors
-                .AnyAsync(s => s.Id == sensorId && s.Type == "voltage", ct);
+                .AnyAsync(s => s.Id == sensorId && s.Type == SensorTypes.Voltage, ct);
             if (!exists) return NotFound(new { message = "Voltage sensor not found." });
 
             await _analyzer.AnalyzeSensorAsync(sensorId, ct);

--- a/Controllers/ElectricityController.cs
+++ b/Controllers/ElectricityController.cs
@@ -47,7 +47,7 @@ namespace garge_api.Controllers
 
             var userRoles = User.FindAll(ClaimTypes.Role).Select(r => r.Value).ToList();
 
-            var hasAccess = userRoles.Contains("admin", StringComparer.OrdinalIgnoreCase) ||
+            var hasAccess = User.IsInAnyRole(RoleNames.Admin) ||
                             userRoles.Any(role => RoleNames.RolePermissions.TryGetValue(role, out var permissions) && permissions.Contains("Electricity", StringComparer.OrdinalIgnoreCase));
 
             if (!hasAccess)

--- a/Controllers/GroupsController.cs
+++ b/Controllers/GroupsController.cs
@@ -2,6 +2,7 @@ using garge_api.Dtos.Group;
 using garge_api.Helpers;
 using garge_api.Models;
 using garge_api.Models.Group;
+using MapsterMapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
@@ -18,11 +19,13 @@ namespace garge_api.Controllers
     {
         private readonly ApplicationDbContext _context;
         private readonly ILogger<GroupsController> _logger;
+        private readonly IMapper _mapper;
 
-        public GroupsController(ApplicationDbContext context, ILogger<GroupsController> logger)
+        public GroupsController(ApplicationDbContext context, ILogger<GroupsController> logger, IMapper mapper)
         {
             _context = context;
             _logger = logger;
+            _mapper = mapper;
         }
 
         private string GetUserId() => User.UserId()!;
@@ -35,20 +38,13 @@ namespace garge_api.Controllers
         {
             var userId = GetUserId();
             var groups = await _context.Groups
+                .AsNoTracking()
                 .Where(g => g.UserId == userId)
                 .Include(g => g.GroupSensors)
                 .Include(g => g.GroupSwitches)
-                .Select(g => new GroupDto
-                {
-                    Id = g.Id,
-                    Name = g.Name,
-                    Icon = g.Icon,
-                    SensorIds = g.GroupSensors.Select(gs => gs.SensorId).ToList(),
-                    SwitchIds = g.GroupSwitches.Select(gs => gs.SwitchId).ToList()
-                })
                 .ToListAsync();
 
-            return Ok(groups);
+            return Ok(_mapper.Map<List<GroupDto>>(groups));
         }
 
         /// <summary>
@@ -70,14 +66,7 @@ namespace garge_api.Controllers
 
             _logger.LogInformation("Group {Name} created by {UserId}", LogSanitizer.Sanitize(group.Name), userId);
 
-            return CreatedAtAction(nameof(GetGroups), new GroupDto
-            {
-                Id = group.Id,
-                Name = group.Name,
-                Icon = group.Icon,
-                SensorIds = new List<int>(),
-                SwitchIds = new List<int>()
-            });
+            return CreatedAtAction(nameof(GetGroups), _mapper.Map<GroupDto>(group));
         }
 
         /// <summary>

--- a/Controllers/MqttController.cs
+++ b/Controllers/MqttController.cs
@@ -1,4 +1,5 @@
-﻿using garge_api.Dtos.Mqtt;
+﻿using garge_api.Constants;
+using garge_api.Dtos.Mqtt;
 using garge_api.Models;
 using garge_api.Models.Mqtt;
 using Microsoft.AspNetCore.Authorization;
@@ -20,19 +21,12 @@ namespace garge_api.Controllers
     public class MqttController : ControllerBase
     {
         private readonly ApplicationDbContext _context;
-        private static readonly List<string> AdminRoles = new() { "MqttAdmin", "admin" };
         private readonly ILogger<MqttController> _logger;
 
         public MqttController(ApplicationDbContext context, ILogger<MqttController> logger)
         {
             _context = context;
             _logger = logger;
-        }
-
-        private bool UserHasRequiredRole()
-        {
-            var userRoles = User.FindAll(ClaimTypes.Role).Select(r => r.Value).ToList();
-            return userRoles.Any(role => AdminRoles.Contains(role, StringComparer.OrdinalIgnoreCase));
         }
 
         private static string GenerateSalt(int length = 16)
@@ -56,6 +50,7 @@ namespace garge_api.Controllers
         /// <param name="dto">The user creation data.</param>
         /// <returns>The created user ID and username.</returns>
         [HttpPost("user")]
+        [Authorize(Roles = $"{RoleNames.Admin},{RoleNames.MqttAdmin}")]
         [SwaggerOperation(Summary = "Creates a new EMQX MQTT user.")]
         [SwaggerResponse(200, "User created successfully.")]
         [SwaggerResponse(403, "Forbidden.")]
@@ -63,12 +58,6 @@ namespace garge_api.Controllers
         public async Task<IActionResult> CreateUser([FromBody] CreateEMQXMqttUserDto dto)
         {
             _logger.LogInformation("CreateUser called by {@LogData}", new { CallerUserId = User.UserId(), dto.Username });
-
-            if (!UserHasRequiredRole())
-            {
-                _logger.LogWarning("CreateUser forbidden for {@LogData}", new { CallerUserId = User.UserId() });
-                return Forbid();
-            }
 
             if (await _context.EMQXMqttUsers.AnyAsync(u => u.Username == dto.Username))
             {
@@ -103,6 +92,7 @@ namespace garge_api.Controllers
         /// <param name="dto">The ACL creation data.</param>
         /// <returns>The created ACL ID.</returns>
         [HttpPost("acl")]
+        [Authorize(Roles = $"{RoleNames.Admin},{RoleNames.MqttAdmin}")]
         [SwaggerOperation(Summary = "Creates a new EMQX MQTT ACL entry.")]
         [SwaggerResponse(200, "ACL created successfully.")]
         [SwaggerResponse(403, "Forbidden.")]
@@ -120,12 +110,6 @@ namespace garge_api.Controllers
                 dto.Qos,
                 dto.Retain
             });
-
-            if (!UserHasRequiredRole())
-            {
-                _logger.LogWarning("CreateAcl forbidden for {@LogData}", new { User = User.Identity?.Name });
-                return Forbid();
-            }
 
             if (!await _context.EMQXMqttUsers.AnyAsync(u => u.Username == dto.Username))
             {
@@ -172,6 +156,7 @@ namespace garge_api.Controllers
         /// <param name="dto">The discovered device data.</param>
         /// <returns>The created device ID.</returns>
         [HttpPost("discovered-device")]
+        [Authorize(Roles = $"{RoleNames.Admin},{RoleNames.MqttAdmin}")]
         [SwaggerOperation(Summary = "Registers a discovered device.")]
         [SwaggerResponse(200, "Device registered successfully.")]
         [SwaggerResponse(403, "Forbidden.")]
@@ -186,12 +171,6 @@ namespace garge_api.Controllers
                 dto.Type,
                 dto.Timestamp
             });
-
-            if (!UserHasRequiredRole())
-            {
-                _logger.LogWarning("PostDiscoveredDevice forbidden for {@LogData}", new { User = User.Identity?.Name });
-                return Forbid();
-            }
 
             var device = new DiscoveredDevice
             {

--- a/Controllers/SensorController.cs
+++ b/Controllers/SensorController.cs
@@ -134,11 +134,12 @@ namespace garge_api.Controllers
             List<Sensor> sensors;
             if (IsAdmin())
             {
-                sensors = await _context.Sensors.ToListAsync();
+                sensors = await _context.Sensors.AsNoTracking().ToListAsync();
             }
             else
             {
                 sensors = await _context.Sensors
+                    .AsNoTracking()
                     .Where(s => _context.UserSensors.Any(us => us.UserId == currentUserId && us.SensorId == s.Id))
                     .ToListAsync();
             }
@@ -188,7 +189,7 @@ namespace garge_api.Controllers
         {
             _logger.LogInformation("GetSensor called by {@LogData}", new { CallerUserId = User.UserId(), id });
 
-            var sensor = await _context.Sensors.FindAsync(id);
+            var sensor = await _context.Sensors.AsNoTracking().FirstOrDefaultAsync(s => s.Id == id);
             if (sensor == null)
             {
                 _logger.LogWarning("GetSensor not found: {@LogData}", new { id });
@@ -242,7 +243,7 @@ namespace garge_api.Controllers
         {
             _logger.LogInformation("GetSensorData called by {@LogData}", new { CallerUserId = User.UserId(), sensorId });
 
-            var sensor = await _context.Sensors.FindAsync(sensorId);
+            var sensor = await _context.Sensors.AsNoTracking().FirstOrDefaultAsync(s => s.Id == sensorId);
             if (sensor == null)
             {
                 _logger.LogWarning("GetSensorData not found: {@LogData}", new { sensorId });
@@ -267,7 +268,7 @@ namespace garge_api.Controllers
             if (!string.IsNullOrEmpty(timeRange))
             {
                 var now = DateTime.UtcNow;
-                var timeSpan = ParseTimeRange(timeRange);
+                var timeSpan = TimeRangeParser.Parse(timeRange);
                 if (timeSpan.HasValue)
                 {
                     effectiveStart = now.Subtract(timeSpan.Value);
@@ -283,7 +284,7 @@ namespace garge_api.Controllers
             IEnumerable<SensorDataDto> result;
             int totalCount;
 
-            var groupBySpan = !string.IsNullOrEmpty(groupBy) ? ParseTimeRange(groupBy) : null;
+            var groupBySpan = !string.IsNullOrEmpty(groupBy) ? TimeRangeParser.Parse(groupBy) : null;
             if (groupBySpan.HasValue)
             {
                 var grouped = await GetAveragedDataAsync(new[] { sensorId }, (long)groupBySpan.Value.TotalSeconds, effectiveStart, effectiveEnd, User.UserId(), IsAdmin());
@@ -364,7 +365,7 @@ namespace garge_api.Controllers
             if (!string.IsNullOrEmpty(timeRange))
             {
                 var now = DateTime.UtcNow;
-                var timeSpan = ParseTimeRange(timeRange);
+                var timeSpan = TimeRangeParser.Parse(timeRange);
                 if (timeSpan.HasValue)
                 {
                     effectiveStart = now.Subtract(timeSpan.Value);
@@ -380,7 +381,7 @@ namespace garge_api.Controllers
             IEnumerable<SensorDataDto> result;
             int totalCount;
 
-            var groupBySpan = !string.IsNullOrEmpty(groupBy) ? ParseTimeRange(groupBy) : null;
+            var groupBySpan = !string.IsNullOrEmpty(groupBy) ? TimeRangeParser.Parse(groupBy) : null;
             if (groupBySpan.HasValue)
             {
                 var grouped = await GetAveragedDataAsync(visibleSensorIds, (long)groupBySpan.Value.TotalSeconds, effectiveStart, effectiveEnd, User.UserId(), IsAdmin());
@@ -481,57 +482,20 @@ namespace garge_api.Controllers
             return CleanIntervals[^1];
         }
 
-        private static DateTime GetGroupingKey(DateTime timestamp, string? groupBy)
+        private Task<string> GenerateSensorRegistrationCodeAsync(int length = 10) =>
+            RegistrationCode.GenerateUniqueAsync(
+                code => _context.Sensors.AnyAsync(s => s.RegistrationCode == code), length);
+
+        /// <summary>
+        /// Validates a raw sensor-data value as a number. Returns true and the parsed value on
+        /// success; otherwise false. Both data-write endpoints (by id and by name) use this so they
+        /// reject invalid input identically with a 400 rather than throwing a 500.
+        /// </summary>
+        private static bool TryParseSensorValue(string? raw, out double value)
         {
-            if (string.IsNullOrEmpty(groupBy))
-                return timestamp;
-
-            var timeSpan = ParseTimeRange(groupBy);
-            if (timeSpan.HasValue)
-            {
-                var ticks = (timestamp.Ticks / timeSpan.Value.Ticks) * timeSpan.Value.Ticks;
-                return new DateTime(ticks, DateTimeKind.Utc);
-            }
-
-            return timestamp;
-        }
-
-        private static TimeSpan? ParseTimeRange(string timeRange)
-        {
-            if (string.IsNullOrEmpty(timeRange) || timeRange.Length < 2)
-                return null;
-
-            var value = timeRange.Substring(0, timeRange.Length - 1);
-            var unit = timeRange.Substring(timeRange.Length - 1).ToLower();
-
-            if (!int.TryParse(value, out var intValue))
-                return null;
-
-            return unit switch
-            {
-                "m" => TimeSpan.FromMinutes(intValue),
-                "h" => TimeSpan.FromHours(intValue),
-                "d" => TimeSpan.FromDays(intValue),
-                "w" => TimeSpan.FromDays(intValue * 7),
-                "y" => TimeSpan.FromDays(intValue * 365),
-                _ => null,
-            };
-        }
-
-        private async Task<string> GenerateSensorRegistrationCodeAsync(int length = 10)
-        {
-            const string chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
-            string code;
-            bool exists;
-
-            do
-            {
-                code = new string(Enumerable.Range(0, length)
-                    .Select(_ => chars[System.Security.Cryptography.RandomNumberGenerator.GetInt32(chars.Length)]).ToArray());
-                exists = await _context.Sensors.AnyAsync(s => s.RegistrationCode == code);
-            } while (exists);
-
-            return code;
+            value = 0;
+            return !string.IsNullOrWhiteSpace(raw)
+                && double.TryParse(raw, NumberStyles.Any, CultureInfo.InvariantCulture, out value);
         }
 
         private static string GenerateParentName(string name)
@@ -546,15 +510,10 @@ namespace garge_api.Controllers
         }
 
         [HttpPost("generate-missing-codes")]
+        [Authorize(Roles = $"{RoleNames.Admin},{RoleNames.SensorAdmin}")]
         public async Task<IActionResult> GenerateMissingRegistrationCodes()
         {
             _logger.LogInformation("GenerateMissingRegistrationCodes called by {@LogData}", new { CallerUserId = User.UserId() });
-
-            if (!IsAdmin())
-            {
-                _logger.LogWarning("GenerateMissingRegistrationCodes forbidden for {@LogData}", new { CallerUserId = User.UserId() });
-                return Forbid();
-            }
 
             var sensorsWithoutCode = await _context.Sensors
                 .Where(s => string.IsNullOrEmpty(s.RegistrationCode))
@@ -586,15 +545,10 @@ namespace garge_api.Controllers
         /// </summary>
         /// <returns>The number of sensors updated.</returns>
         [HttpPost("generate-missing-parent-names")]
+        [Authorize(Roles = $"{RoleNames.Admin},{RoleNames.SensorAdmin}")]
         public async Task<IActionResult> GenerateMissingParentNames()
         {
             _logger.LogInformation("GenerateMissingParentNames called by {@LogData}", new { CallerUserId = User.UserId() });
-
-            if (!IsAdmin())
-            {
-                _logger.LogWarning("GenerateMissingParentNames forbidden for {@LogData}", new { CallerUserId = User.UserId() });
-                return Forbid();
-            }
 
             var sensorsWithoutParentName = await _context.Sensors
                 .Where(s => string.IsNullOrEmpty(s.ParentName))
@@ -1011,15 +965,10 @@ namespace garge_api.Controllers
         }
 
         [HttpPost("generate-missing-default-names")]
+        [Authorize(Roles = $"{RoleNames.Admin},{RoleNames.SensorAdmin}")]
         public async Task<IActionResult> GenerateMissingDefaultNames()
         {
             _logger.LogInformation("GenerateMissingDefaultNames called by {@LogData}", new { CallerUserId = User.UserId() });
-
-            if (!IsAdmin())
-            {
-                _logger.LogWarning("GenerateMissingDefaultNames forbidden for {@LogData}", new { CallerUserId = User.UserId() });
-                return Forbid();
-            }
 
             var sensorsWithoutDefaultName = await _context.Sensors
                 .Where(s => string.IsNullOrEmpty(s.DefaultName))
@@ -1045,18 +994,13 @@ namespace garge_api.Controllers
         /// <param name="sensorDto">The sensor to create.</param>
         /// <returns>The created sensor.</returns>
         [HttpPost]
+        [Authorize(Roles = $"{RoleNames.Admin},{RoleNames.SensorAdmin}")]
         [SwaggerOperation(Summary = "Creates a new sensor.")]
         [SwaggerResponse(201, "The created sensor.", typeof(SensorDto))]
         [SwaggerResponse(409, "Sensor name already exists.")]
         public async Task<IActionResult> CreateSensor([FromBody] CreateSensorDto sensorDto)
         {
             _logger.LogInformation("CreateSensor called by {@LogData}", new { CallerUserId = User.UserId(), sensorDto.Name, sensorDto.Type });
-
-            if (!IsAdmin())
-            {
-                _logger.LogWarning("CreateSensor forbidden for {@LogData}", new { CallerUserId = User.UserId() });
-                return Forbid();
-            }
 
             if (!SensorTypes.IsAllowed(sensorDto.Type))
             {
@@ -1097,19 +1041,15 @@ namespace garge_api.Controllers
         /// <param name="sensorDataDto">The data to create.</param>
         /// <returns>The created sensor data.</returns>
         [HttpPost("{sensorId}/data")]
+        [Authorize(Roles = $"{RoleNames.Admin},{RoleNames.SensorAdmin}")]
         [SwaggerOperation(Summary = "Creates new data for a specific sensor using sensorId.")]
         [SwaggerResponse(201, "The created sensor data.", typeof(SensorDataDto))]
+        [SwaggerResponse(400, "Invalid value format.")]
         [SwaggerResponse(404, "Sensor not found.")]
         [SwaggerResponse(403, "User does not have the required role.")]
         public async Task<IActionResult> CreateSensorDataById(int sensorId, [FromBody] CreateSensorDataDto sensorDataDto)
         {
             _logger.LogInformation("CreateSensorDataById called by {@LogData}", new { CallerUserId = User.UserId(), sensorId });
-
-            if (!IsAdmin())
-            {
-                _logger.LogWarning("CreateSensorDataById forbidden for {@LogData}", new { CallerUserId = User.UserId(), sensorId });
-                return Forbid();
-            }
 
             var sensor = await _context.Sensors.FindAsync(sensorId);
             if (sensor == null)
@@ -1118,10 +1058,16 @@ namespace garge_api.Controllers
                 return NotFound(new { message = "Sensor not found!" });
             }
 
+            if (!TryParseSensorValue(sensorDataDto.Value, out var parsedValue))
+            {
+                _logger.LogWarning("CreateSensorDataById bad request: Invalid value {@LogData}", new { sensorDataDto.Value, sensorId });
+                return BadRequest(new { message = "Value must be a valid number." });
+            }
+
             var sensorData = new SensorData
             {
                 SensorId = sensorId,
-                Value = Math.Round(double.Parse(sensorDataDto.Value), 3).ToString(CultureInfo.InvariantCulture),
+                Value = Math.Round(parsedValue, 3).ToString(CultureInfo.InvariantCulture),
                 Timestamp = DateTime.UtcNow
             };
 
@@ -1140,19 +1086,15 @@ namespace garge_api.Controllers
         /// <param name="sensorDataDto">The data to create.</param>
         /// <returns>The created sensor data.</returns>
         [HttpPost("name/{sensorName}/data")]
+        [Authorize(Roles = $"{RoleNames.Admin},{RoleNames.SensorAdmin}")]
         [SwaggerOperation(Summary = "Creates new data for a specific sensor using sensorName.")]
         [SwaggerResponse(201, "The created sensor data.", typeof(SensorDataDto))]
+        [SwaggerResponse(400, "Invalid value format.")]
         [SwaggerResponse(404, "Sensor not found.")]
         [SwaggerResponse(403, "User does not have the required role.")]
         public async Task<IActionResult> CreateSensorDataByName(string sensorName, [FromBody] CreateSensorDataDto sensorDataDto)
         {
             _logger.LogInformation("CreateSensorDataByName called by {@LogData}", new { CallerUserId = User.UserId(), sensorName });
-
-            if (!IsAdmin())
-            {
-                _logger.LogWarning("CreateSensorDataByName forbidden for {@LogData}", new { CallerUserId = User.UserId(), sensorName });
-                return Forbid();
-            }
 
             var sensor = await _context.Sensors.FirstOrDefaultAsync(s => s.Name == sensorName);
             if (sensor == null)
@@ -1161,7 +1103,7 @@ namespace garge_api.Controllers
                 return NotFound(new { message = "Sensor not found!" });
             }
 
-            if (string.IsNullOrWhiteSpace(sensorDataDto.Value) || !double.TryParse(sensorDataDto.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out var parsedValue))
+            if (!TryParseSensorValue(sensorDataDto.Value, out var parsedValue))
             {
                 _logger.LogWarning("CreateSensorDataByName bad request: Invalid value {@LogData}", new { sensorDataDto.Value, sensorName });
                 return BadRequest(new { message = "Value must be a valid number." });
@@ -1170,7 +1112,7 @@ namespace garge_api.Controllers
             var sensorData = new SensorData
             {
                 SensorId = sensor.Id,
-                Value = Math.Round(double.Parse(sensorDataDto.Value), 3).ToString(CultureInfo.InvariantCulture),
+                Value = Math.Round(parsedValue, 3).ToString(CultureInfo.InvariantCulture),
                 Timestamp = DateTime.UtcNow
             };
 
@@ -1189,6 +1131,7 @@ namespace garge_api.Controllers
         /// <param name="sensorDto">The updated sensor data.</param>
         /// <returns>No content.</returns>
         [HttpPut("{id}")]
+        [Authorize(Roles = $"{RoleNames.Admin},{RoleNames.SensorAdmin}")]
         [SwaggerOperation(Summary = "Updates an existing sensor.")]
         [SwaggerResponse(204, "No content.")]
         [SwaggerResponse(400, "Bad request.")]
@@ -1197,12 +1140,6 @@ namespace garge_api.Controllers
         public async Task<IActionResult> UpdateSensor(int id, [FromBody] UpdateSensorDto sensorDto)
         {
             _logger.LogInformation("UpdateSensor called by {@LogData}", new { CallerUserId = User.UserId(), id });
-
-            if (!IsAdmin())
-            {
-                _logger.LogWarning("UpdateSensor forbidden for {@LogData}", new { CallerUserId = User.UserId(), id });
-                return Forbid();
-            }
 
             var existingSensor = await _context.Sensors.FindAsync(id);
             if (existingSensor == null)
@@ -1228,6 +1165,7 @@ namespace garge_api.Controllers
         /// <param name="id">The ID of the sensor to delete.</param>
         /// <returns>No content.</returns>
         [HttpDelete("{id}")]
+        [Authorize(Roles = $"{RoleNames.Admin},{RoleNames.SensorAdmin}")]
         [SwaggerOperation(Summary = "Deletes a sensor by its ID.")]
         [SwaggerResponse(204, "No content.")]
         [SwaggerResponse(404, "Sensor not found.")]
@@ -1235,12 +1173,6 @@ namespace garge_api.Controllers
         public async Task<IActionResult> DeleteSensor(int id)
         {
             _logger.LogInformation("DeleteSensor called by {@LogData}", new { CallerUserId = User.UserId(), id });
-
-            if (!IsAdmin())
-            {
-                _logger.LogWarning("DeleteSensor forbidden for {@LogData}", new { CallerUserId = User.UserId(), id });
-                return Forbid();
-            }
 
             var sensor = await _context.Sensors.FindAsync(id);
             if (sensor == null)
@@ -1263,6 +1195,7 @@ namespace garge_api.Controllers
         /// <param name="dataId">The ID of the sensor data to delete.</param>
         /// <returns>No content.</returns>
         [HttpDelete("{sensorId}/data/{dataId}")]
+        [Authorize(Roles = $"{RoleNames.Admin},{RoleNames.SensorAdmin}")]
         [SwaggerOperation(Summary = "Deletes specific sensor data by its ID.")]
         [SwaggerResponse(204, "No content.")]
         [SwaggerResponse(404, "Sensor or sensor data not found.")]
@@ -1270,12 +1203,6 @@ namespace garge_api.Controllers
         public async Task<IActionResult> DeleteSensorData(int sensorId, int dataId)
         {
             _logger.LogInformation("DeleteSensorData called by {@LogData}", new { CallerUserId = User.UserId(), sensorId, dataId });
-
-            if (!IsAdmin())
-            {
-                _logger.LogWarning("DeleteSensorData forbidden for {@LogData}", new { CallerUserId = User.UserId(), sensorId });
-                return Forbid();
-            }
 
             var sensor = await _context.Sensors.FindAsync(sensorId);
             if (sensor == null)
@@ -1304,6 +1231,7 @@ namespace garge_api.Controllers
         /// <param name="sensorId">The ID of the sensor.</param>
         /// <returns>No content.</returns>
         [HttpDelete("{sensorId}/data")]
+        [Authorize(Roles = $"{RoleNames.Admin},{RoleNames.SensorAdmin}")]
         [SwaggerOperation(Summary = "Deletes all sensor data for a specific sensor.")]
         [SwaggerResponse(204, "No content.")]
         [SwaggerResponse(404, "Sensor not found.")]
@@ -1311,12 +1239,6 @@ namespace garge_api.Controllers
         public async Task<IActionResult> DeleteAllSensorData(int sensorId)
         {
             _logger.LogInformation("DeleteAllSensorData called by {@LogData}", new { CallerUserId = User.UserId(), sensorId });
-
-            if (!IsAdmin())
-            {
-                _logger.LogWarning("DeleteAllSensorData forbidden for {@LogData}", new { CallerUserId = User.UserId(), sensorId });
-                return Forbid();
-            }
 
             var sensor = await _context.Sensors.FindAsync(sensorId);
             if (sensor == null)

--- a/Controllers/SwitchesController.cs
+++ b/Controllers/SwitchesController.cs
@@ -1,4 +1,5 @@
-﻿using garge_api.Dtos.Switch;
+﻿using garge_api.Constants;
+using garge_api.Dtos.Switch;
 using garge_api.Helpers;
 using garge_api.Hubs;
 using garge_api.Models;
@@ -36,12 +37,8 @@ namespace garge_api.Controllers
             _hub = hub;
         }
 
-        private bool IsSwitchAdmin()
-        {
-            var userRoles = User.FindAll(ClaimTypes.Role).Select(r => r.Value).ToList();
-            return userRoles.Contains("admin", StringComparer.OrdinalIgnoreCase) ||
-                   userRoles.Contains("SwitchAdmin", StringComparer.OrdinalIgnoreCase);
-        }
+        private bool IsSwitchAdmin() =>
+            User.IsInAnyRole(RoleNames.Admin, RoleNames.SwitchAdmin);
 
         private async Task<bool> UserHasRequiredRoleAsync(Switch switchEntity)
         {
@@ -140,7 +137,8 @@ namespace garge_api.Controllers
             _logger.LogInformation("GetAllSwitches called by {@LogData}", new { CallerUserId = User.UserId() });
 
             var allSwitches = await _context.Switches
-                .Where(sw => sw.Type.ToUpper() == "SOCKET")
+                .AsNoTracking()
+                .Where(sw => sw.Type.ToLower() == SwitchTypes.Socket)
                 .ToListAsync();
             var accessibleSwitches = new List<Switch>();
 
@@ -214,20 +212,13 @@ namespace garge_api.Controllers
         /// Creates a new switch.
         /// </summary>
         [HttpPost]
+        [Authorize(Roles = $"{RoleNames.Admin},{RoleNames.SwitchAdmin}")]
         [SwaggerOperation(Summary = "Creates a new switch.")]
         [SwaggerResponse(201, "The created switch.", typeof(SwitchDto))]
         [SwaggerResponse(409, "Switch name already exists.")]
         public async Task<IActionResult> CreateSwitch([FromBody] CreateSwitchDto switchDto)
         {
             _logger.LogInformation("CreateSwitch called by {@LogData}", new { CallerUserId = User.UserId(), switchDto.Name, switchDto.Type });
-
-            var userRoles = User.FindAll(ClaimTypes.Role).Select(r => r.Value).ToList();
-            if (!userRoles.Contains("SwitchAdmin", StringComparer.OrdinalIgnoreCase) &&
-                !userRoles.Contains("admin", StringComparer.OrdinalIgnoreCase))
-            {
-                _logger.LogWarning("CreateSwitch forbidden for {@LogData}", new { CallerUserId = User.UserId() });
-                return Forbid();
-            }
 
             var switchEntity = _mapper.Map<Switch>(switchDto);
             switchEntity.Role = switchDto.Name;
@@ -254,6 +245,7 @@ namespace garge_api.Controllers
         /// Updates an existing switch.
         /// </summary>
         [HttpPut("{id}")]
+        [Authorize(Roles = $"{RoleNames.Admin},{RoleNames.SwitchAdmin}")]
         [SwaggerOperation(Summary = "Updates an existing switch.")]
         [SwaggerResponse(204, "No content.")]
         [SwaggerResponse(400, "Bad request.")]
@@ -262,12 +254,6 @@ namespace garge_api.Controllers
         public async Task<IActionResult> UpdateSwitch(int id, [FromBody] UpdateSwitchDto switchDto)
         {
             _logger.LogInformation("UpdateSwitch called by {@LogData}", new { CallerUserId = User.UserId(), id });
-
-            if (!IsSwitchAdmin())
-            {
-                _logger.LogWarning("UpdateSwitch forbidden for {@LogData}", new { CallerUserId = User.UserId(), id });
-                return Forbid();
-            }
 
             if (id != switchDto.Id)
             {
@@ -295,6 +281,7 @@ namespace garge_api.Controllers
         /// Deletes a switch by its ID.
         /// </summary>
         [HttpDelete("{id}")]
+        [Authorize(Roles = $"{RoleNames.Admin},{RoleNames.SwitchAdmin}")]
         [SwaggerOperation(Summary = "Deletes a switch by its ID.")]
         [SwaggerResponse(204, "No content.")]
         [SwaggerResponse(404, "Switch not found.")]
@@ -302,12 +289,6 @@ namespace garge_api.Controllers
         public async Task<IActionResult> DeleteSwitch(int id)
         {
             _logger.LogInformation("DeleteSwitch called by {@LogData}", new { CallerUserId = User.UserId(), id });
-
-            if (!IsSwitchAdmin())
-            {
-                _logger.LogWarning("DeleteSwitch forbidden for {@LogData}", new { CallerUserId = User.UserId(), id });
-                return Forbid();
-            }
 
             var switchEntity = await _context.Switches.FindAsync(id);
             if (switchEntity == null)
@@ -335,7 +316,7 @@ namespace garge_api.Controllers
         {
             _logger.LogInformation("GetSwitchData called by {@LogData}", new { CallerUserId = User.UserId(), switchId });
 
-            var switchEntity = await _context.Switches.FindAsync(switchId);
+            var switchEntity = await _context.Switches.AsNoTracking().FirstOrDefaultAsync(s => s.Id == switchId);
             if (switchEntity == null)
             {
                 _logger.LogWarning("GetSwitchData not found: {@LogData}", new { switchId });
@@ -354,7 +335,7 @@ namespace garge_api.Controllers
             if (!string.IsNullOrEmpty(timeRange))
             {
                 var now = DateTime.UtcNow;
-                var timeSpan = ParseTimeRange(timeRange);
+                var timeSpan = TimeRangeParser.Parse(timeRange);
                 if (timeSpan.HasValue)
                     query = query.Where(sd => sd.Timestamp >= now.Subtract(timeSpan.Value));
             }
@@ -419,6 +400,7 @@ namespace garge_api.Controllers
         /// Creates new data for a specific switch.
         /// </summary>
         [HttpPost("{switchId}/data")]
+        [Authorize(Roles = $"{RoleNames.Admin},{RoleNames.SwitchAdmin}")]
         [SwaggerOperation(Summary = "Creates new data for a specific switch.")]
         [SwaggerResponse(201, "The created switch data.", typeof(SwitchDataDto))]
         [SwaggerResponse(400, "Invalid value format.")]
@@ -428,12 +410,6 @@ namespace garge_api.Controllers
         {
             _logger.LogInformation("CreateSwitchData called by {@LogData}", new { CallerUserId = User.UserId(), switchId });
 
-            if (!IsSwitchAdmin())
-            {
-                _logger.LogWarning("CreateSwitchData forbidden for {@LogData}", new { CallerUserId = User.UserId(), switchId });
-                return Forbid();
-            }
-
             var switchEntity = await _context.Switches.FindAsync(switchId);
             if (switchEntity == null)
             {
@@ -441,8 +417,7 @@ namespace garge_api.Controllers
                 return NotFound(new { message = "Switch not found!" });
             }
 
-            var validStates = new[] { "ON", "OFF" };
-            if (!validStates.Contains(switchDataDto.Value, StringComparer.OrdinalIgnoreCase))
+            if (!SwitchStates.IsValid(switchDataDto.Value))
             {
                 _logger.LogWarning("CreateSwitchData bad request: Invalid value {@LogData}", new { switchDataDto.Value, switchId });
                 return BadRequest(new { message = "The value must be either 'ON' or 'OFF'." });
@@ -496,7 +471,7 @@ namespace garge_api.Controllers
             if (!string.IsNullOrEmpty(timeRange))
             {
                 var now = DateTime.UtcNow;
-                var timeSpan = ParseTimeRange(timeRange);
+                var timeSpan = TimeRangeParser.Parse(timeRange);
                 if (timeSpan.HasValue)
                     query = query.Where(sd => sd.Timestamp >= now.Subtract(timeSpan.Value));
             }
@@ -558,6 +533,7 @@ namespace garge_api.Controllers
         /// Creates new data for a specific switch using switchName.
         /// </summary>
         [HttpPost("name/{switchName}/data")]
+        [Authorize(Roles = $"{RoleNames.Admin},{RoleNames.SwitchAdmin}")]
         [SwaggerOperation(Summary = "Creates new data for a specific switch using switchName.")]
         [SwaggerResponse(201, "The created switch data.", typeof(SwitchDataDto))]
         [SwaggerResponse(400, "Invalid value format.")]
@@ -567,12 +543,6 @@ namespace garge_api.Controllers
         {
             _logger.LogInformation("CreateSwitchDataByName called by {@LogData}", new { CallerUserId = User.UserId(), switchName });
 
-            if (!IsSwitchAdmin())
-            {
-                _logger.LogWarning("CreateSwitchDataByName forbidden for {@LogData}", new { CallerUserId = User.UserId(), switchName });
-                return Forbid();
-            }
-
             var switchEntity = await _context.Switches.FirstOrDefaultAsync(s => s.Name == switchName);
             if (switchEntity == null)
             {
@@ -580,8 +550,7 @@ namespace garge_api.Controllers
                 return NotFound(new { message = "Switch not found!" });
             }
 
-            var validStates = new[] { "ON", "OFF" };
-            if (!validStates.Contains(switchDataDto.Value, StringComparer.OrdinalIgnoreCase))
+            if (!SwitchStates.IsValid(switchDataDto.Value))
             {
                 _logger.LogWarning("CreateSwitchDataByName bad request: Invalid value {@LogData}", new { switchDataDto.Value, switchName });
                 return BadRequest(new { message = "The value must be either 'ON' or 'OFF'." });
@@ -632,43 +601,6 @@ namespace garge_api.Controllers
 
             _logger.LogInformation("All switch data deleted for {@LogData}", new { switchId });
             return NoContent();
-        }
-
-        private static DateTime GetGroupingKey(DateTime timestamp, string? groupBy)
-        {
-            if (string.IsNullOrEmpty(groupBy))
-                return timestamp;
-
-            var timeSpan = ParseTimeRange(groupBy);
-            if (timeSpan.HasValue)
-            {
-                var ticks = (timestamp.Ticks / timeSpan.Value.Ticks) * timeSpan.Value.Ticks;
-                return new DateTime(ticks, DateTimeKind.Utc);
-            }
-
-            return timestamp;
-        }
-
-        private static TimeSpan? ParseTimeRange(string timeRange)
-        {
-            if (string.IsNullOrEmpty(timeRange) || timeRange.Length < 2)
-                return null;
-
-            var value = timeRange.Substring(0, timeRange.Length - 1);
-            var unit = timeRange.Substring(timeRange.Length - 1).ToLower();
-
-            if (!int.TryParse(value, out var intValue))
-                return null;
-
-            return unit switch
-            {
-                "m" => TimeSpan.FromMinutes(intValue),
-                "h" => TimeSpan.FromHours(intValue),
-                "d" => TimeSpan.FromDays(intValue),
-                "w" => TimeSpan.FromDays(intValue * 7),
-                "y" => TimeSpan.FromDays(intValue * 365),
-                _ => null,
-            };
         }
 
         /// <summary>
@@ -909,18 +841,8 @@ namespace garge_api.Controllers
             return Ok(shares);
         }
 
-        private async Task<string> GenerateSwitchRegistrationCodeAsync(int length = 10)
-        {
-            const string chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
-            string code;
-            bool exists;
-            do
-            {
-                code = new string(Enumerable.Range(0, length)
-                    .Select(_ => chars[System.Security.Cryptography.RandomNumberGenerator.GetInt32(chars.Length)]).ToArray());
-                exists = await _context.Switches.AnyAsync(s => s.RegistrationCode == code);
-            } while (exists);
-            return code;
-        }
+        private Task<string> GenerateSwitchRegistrationCodeAsync(int length = 10) =>
+            RegistrationCode.GenerateUniqueAsync(
+                code => _context.Switches.AnyAsync(s => s.RegistrationCode == code), length);
     }
 }

--- a/Controllers/UserController.cs
+++ b/Controllers/UserController.cs
@@ -1,4 +1,5 @@
 using MapsterMapper;
+using garge_api.Constants;
 using garge_api.Dtos.User;
 using garge_api.Helpers;
 using garge_api.Hubs;
@@ -124,7 +125,7 @@ namespace garge_api.Controllers
             await using var tx = await _context.Database.BeginTransactionAsync();
 
             await AnonymizeUserTelemetryAsync(id);
-            ClearUserOwnedRows(id);
+            await ClearUserOwnedRowsAsync(id);
             await ScrubUserPiiAsync(user);
 
             var result = await _userManager.UpdateAsync(user);
@@ -148,12 +149,12 @@ namespace garge_api.Controllers
         /// names, refresh tokens, push subs, etc.). Add new user-owned tables
         /// here when introduced.
         /// </summary>
-        private void ClearUserOwnedRows(string userId)
+        private async Task ClearUserOwnedRowsAsync(string userId)
         {
             // Capture associated device ids before removing the rows so we
             // can invalidate the ownership cache once the changes commit.
-            var sensorIds = _context.UserSensors.Where(us => us.UserId == userId).Select(us => us.SensorId).ToList();
-            var switchIds = _context.UserSwitches.Where(us => us.UserId == userId).Select(us => us.SwitchId).ToList();
+            var sensorIds = await _context.UserSensors.Where(us => us.UserId == userId).Select(us => us.SensorId).ToListAsync();
+            var switchIds = await _context.UserSwitches.Where(us => us.UserId == userId).Select(us => us.SwitchId).ToListAsync();
 
             _context.RefreshTokens.RemoveRange(_context.RefreshTokens.Where(t => t.UserId == userId));
             _context.UserSensorCustomNames.RemoveRange(_context.UserSensorCustomNames.Where(x => x.UserId == userId));
@@ -173,7 +174,7 @@ namespace garge_api.Controllers
         /// Moves the user's exclusive telemetry into the anonymized ML store before their ownership
         /// rows are removed. This is the GDPR-erasure path: the readings leave personal scope (no link
         /// back to the user/device) while co-owned ranges are preserved for the other owner. Each call
-        /// consumes (deletes) the ownership period it processes. Run before <see cref="ClearUserOwnedRows"/>.
+        /// consumes (deletes) the ownership period it processes. Run before <see cref="ClearUserOwnedRowsAsync"/>.
         /// </summary>
         private async Task AnonymizeUserTelemetryAsync(string userId)
         {
@@ -337,7 +338,7 @@ namespace garge_api.Controllers
 
             var automationRules = await _context.AutomationRules
                 .Where(r => sensorIds.Contains(r.SensorId)
-                            || (r.TargetType == "socket" && switchIds.Contains(r.TargetId)))
+                            || (r.TargetType == SwitchTypes.Socket && switchIds.Contains(r.TargetId)))
                 .ToListAsync();
 
             var groups = await _context.Groups

--- a/Helpers/ClaimsPrincipalExtensions.cs
+++ b/Helpers/ClaimsPrincipalExtensions.cs
@@ -11,5 +11,19 @@ namespace garge_api.Helpers
         /// <summary>True when the caller's NameIdentifier matches the supplied id.</summary>
         public static bool IsCallerOf(this ClaimsPrincipal user, string id) =>
             user.UserId() == id;
+
+        /// <summary>
+        /// True when the caller holds at least one of the supplied roles. Matching is
+        /// case-insensitive so legacy/lower-cased role claims continue to authorize. Pass the
+        /// canonical names from <see cref="garge_api.Constants.RoleNames"/>.
+        /// </summary>
+        public static bool IsInAnyRole(this ClaimsPrincipal user, params string[] roles)
+        {
+            if (roles is null || roles.Length == 0)
+                return false;
+
+            var userRoles = user.FindAll(ClaimTypes.Role).Select(r => r.Value);
+            return userRoles.Any(r => roles.Contains(r, StringComparer.OrdinalIgnoreCase));
+        }
     }
 }

--- a/Helpers/RegistrationCode.cs
+++ b/Helpers/RegistrationCode.cs
@@ -1,0 +1,41 @@
+using System.Security.Cryptography;
+
+namespace garge_api.Helpers
+{
+    /// <summary>
+    /// Generates device registration codes from an unambiguous alphabet (no easily confused
+    /// characters such as I/1, O/0). Shared by the sensor and switch controllers so both use the
+    /// same alphabet and uniqueness loop.
+    /// </summary>
+    public static class RegistrationCode
+    {
+        /// <summary>Alphabet used for registration codes: excludes I, O, 0 and 1 to avoid ambiguity.</summary>
+        public const string Alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+
+        /// <summary>
+        /// Produces a cryptographically random code of the requested length that does not already
+        /// exist, as determined by the supplied <paramref name="existsAsync"/> predicate. The
+        /// predicate is awaited for each candidate until a free code is found.
+        /// </summary>
+        /// <param name="existsAsync">Returns true when a candidate code is already taken.</param>
+        /// <param name="length">The number of characters in the generated code.</param>
+        public static async Task<string> GenerateUniqueAsync(Func<string, Task<bool>> existsAsync, int length = 10)
+        {
+            string code;
+            bool exists;
+            do
+            {
+                code = Generate(length);
+                exists = await existsAsync(code);
+            } while (exists);
+
+            return code;
+        }
+
+        /// <summary>Produces a single cryptographically random code of the requested length.</summary>
+        public static string Generate(int length = 10) =>
+            new(Enumerable.Range(0, length)
+                .Select(_ => Alphabet[RandomNumberGenerator.GetInt32(Alphabet.Length)])
+                .ToArray());
+    }
+}

--- a/Helpers/TimeRangeParser.cs
+++ b/Helpers/TimeRangeParser.cs
@@ -1,0 +1,37 @@
+namespace garge_api.Helpers
+{
+    /// <summary>
+    /// Parses compact time-range strings such as "5m", "1h", "2d", "1w", "1y" into a
+    /// <see cref="TimeSpan"/>. Shared by the sensor and switch data endpoints so both honour
+    /// identical range semantics.
+    /// </summary>
+    public static class TimeRangeParser
+    {
+        /// <summary>
+        /// Converts a compact time-range string (e.g. "5m", "1h", "2d", "1w", "1y") into a
+        /// <see cref="TimeSpan"/>. Returns <c>null</c> when the input is empty, too short, or
+        /// uses an unrecognised unit/value.
+        /// </summary>
+        public static TimeSpan? Parse(string timeRange)
+        {
+            if (string.IsNullOrEmpty(timeRange) || timeRange.Length < 2)
+                return null;
+
+            var value = timeRange.Substring(0, timeRange.Length - 1);
+            var unit = timeRange.Substring(timeRange.Length - 1).ToLowerInvariant();
+
+            if (!int.TryParse(value, out var intValue))
+                return null;
+
+            return unit switch
+            {
+                "m" => TimeSpan.FromMinutes(intValue),
+                "h" => TimeSpan.FromHours(intValue),
+                "d" => TimeSpan.FromDays(intValue),
+                "w" => TimeSpan.FromDays(intValue * 7),
+                "y" => TimeSpan.FromDays(intValue * 365),
+                _ => null,
+            };
+        }
+    }
+}

--- a/Profiles/MappingProfile.cs
+++ b/Profiles/MappingProfile.cs
@@ -1,14 +1,18 @@
 using Mapster;
 using garge_api.Dtos.Admin;
 using garge_api.Dtos.Auth;
+using garge_api.Dtos.Automation;
 using garge_api.Dtos.Electricity;
+using garge_api.Dtos.Group;
 using garge_api.Dtos.Sensor;
 using garge_api.Dtos.Shop;
 using garge_api.Dtos.Subscription;
 using garge_api.Dtos.Switch;
 using garge_api.Dtos.User;
 using garge_api.Models.Admin;
+using garge_api.Models.Automation;
 using garge_api.Models.Electricity;
+using garge_api.Models.Group;
 using garge_api.Models.Sensor;
 using garge_api.Models.Shop;
 using garge_api.Models.Subscription;
@@ -51,6 +55,17 @@ public class MappingProfile : IRegister
         config.NewConfig<UpdateSwitchDto, Switch>();
         config.NewConfig<SwitchData, SwitchDataDto>().TwoWays();
         config.NewConfig<CreateSwitchDataDto, SwitchData>();
+
+        // Automation mappings. All AutomationRuleDto members share the entity's names (the entity's
+        // extra CreatedAt is simply not present on the DTO), so a default name-based map reproduces
+        // the previous hand-written projection field-for-field.
+        config.NewConfig<AutomationRule, AutomationRuleDto>();
+
+        // Group mappings. Id/Name/Icon map by name; the sensor/switch id lists are flattened from
+        // the join navigations, matching the previous manual projection.
+        config.NewConfig<Group, GroupDto>()
+            .Map(d => d.SensorIds, s => s.GroupSensors.Select(gs => gs.SensorId).ToList())
+            .Map(d => d.SwitchIds, s => s.GroupSwitches.Select(gs => gs.SwitchId).ToList());
 
         // User mappings
         config.NewConfig<UserProfile, UserProfileDto>()

--- a/Services/AnonymizationService.cs
+++ b/Services/AnonymizationService.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using garge_api.Constants;
 using garge_api.Models;
 using garge_api.Models.Anonymized;
 using Microsoft.EntityFrameworkCore;
@@ -114,7 +115,7 @@ namespace garge_api.Services
                 var switchEntity = await _db.Switches.FirstOrDefaultAsync(s => s.Id == switchId, ct);
                 var series = new AnonymizedSeries
                 {
-                    SourceType = switchEntity?.Type ?? "socket",
+                    SourceType = switchEntity?.Type ?? SwitchTypes.Socket,
                     AnonymizedAt = DateTime.UtcNow
                 };
                 _db.AnonymizedSeries.Add(series);

--- a/Services/BatteryHealthAnalyzerService.cs
+++ b/Services/BatteryHealthAnalyzerService.cs
@@ -1,3 +1,4 @@
+using garge_api.Constants;
 using garge_api.Helpers;
 using garge_api.Models;
 using garge_api.Models.Sensor;
@@ -92,7 +93,7 @@ namespace garge_api.Services
             using var scope = _scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
             var sensor = await db.Sensors.FindAsync(new object?[] { sensorId }, ct);
-            if (sensor == null || !sensor.Type.Equals("voltage", StringComparison.OrdinalIgnoreCase))
+            if (sensor == null || !sensor.Type.Equals(SensorTypes.Voltage, StringComparison.OrdinalIgnoreCase))
                 return;
 
             await RunForSensorAsync(db, sensor, ct);
@@ -105,7 +106,7 @@ namespace garge_api.Services
             var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
             var voltageSensors = await db.Sensors
-                .Where(s => s.Type == "voltage")
+                .Where(s => s.Type == SensorTypes.Voltage)
                 .ToListAsync(ct);
 
             var cutoff = DateTime.UtcNow - StalenessThreshold;

--- a/Services/DevDataSeeder.cs
+++ b/Services/DevDataSeeder.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using garge_api.Constants;
 using garge_api.Models;
 using garge_api.Models.Sensor;
 using Microsoft.EntityFrameworkCore;
@@ -47,7 +48,7 @@ namespace garge_api.Services
                 var sensor = new Sensor
                 {
                     Name = name,
-                    Type = "voltage",
+                    Type = SensorTypes.Voltage,
                     Role = name,
                     RegistrationCode = $"DEV{code}", // stable + obvious in logs
                     DefaultName = $"Garge {code} voltage",

--- a/garge-api.Tests/AdminControllerTests.cs
+++ b/garge-api.Tests/AdminControllerTests.cs
@@ -393,4 +393,25 @@ public class AdminControllerTests : ControllerTestBase
         Assert.IsType<BadRequestObjectResult>(result);
         Assert.Empty(db.RolePermissions);
     }
+
+    [Fact]
+    public async Task AssignPermission_AlreadyAssigned_DoesNotInsertDuplicate()
+    {
+        var db = CreateDbContext();
+        db.RolePermissions.Add(new RolePermission { RoleName = "Default", Permission = "Electricity" });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var roleManager = CreateRoleManagerMock();
+        roleManager.Setup(r => r.RoleExistsAsync("Default")).ReturnsAsync(true);
+
+        var controller = new AdminController(
+            roleManager.Object, MockUserManager.Object, db,
+            NullLogger<AdminController>.Instance, MockMapper.Object, MockEmailService.Object);
+        controller.ControllerContext = MakeControllerContext(isAdmin: true);
+
+        var result = await controller.AssignPermission("Default", "Electricity");
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Single(db.RolePermissions);
+    }
 }

--- a/garge-api.Tests/ControllerTestBase.cs
+++ b/garge-api.Tests/ControllerTestBase.cs
@@ -1,3 +1,4 @@
+using Mapster;
 using MapsterMapper;
 using garge_api.Controllers;
 using garge_api.Models;
@@ -26,7 +27,22 @@ public abstract class ControllerTestBase
     protected Mock<SignInManager<User>> MockSignInManager { get; }
     protected Mock<IEmailService> MockEmailService { get; } = new();
     protected Mock<IMapper> MockMapper { get; } = new();
+
+    /// <summary>
+    /// A real Mapster-backed mapper built from the production <see cref="MappingProfile"/>. Use this
+    /// where a controller now relies on <c>_mapper.Map&lt;&gt;()</c> for its response shape and the
+    /// test asserts mapped field values (e.g. AutomationController, GroupsController).
+    /// </summary>
+    protected static IMapper RealMapper { get; } = BuildRealMapper();
+
     protected IConfiguration Configuration { get; }
+
+    private static IMapper BuildRealMapper()
+    {
+        var config = new TypeAdapterConfig();
+        new MappingProfile().Register(config);
+        return new Mapper(config);
+    }
 
     protected ControllerTestBase()
     {
@@ -55,7 +71,7 @@ public abstract class ControllerTestBase
     protected static AutomationController CreateAutomationController(
         ApplicationDbContext db, string userId = "user-1", bool isAdmin = false)
     {
-        var controller = new AutomationController(db, NullLogger<AutomationController>.Instance);
+        var controller = new AutomationController(db, NullLogger<AutomationController>.Instance, RealMapper);
         controller.ControllerContext = MakeControllerContext(userId, isAdmin);
         return controller;
     }

--- a/garge-api.Tests/MappingProfileTests.cs
+++ b/garge-api.Tests/MappingProfileTests.cs
@@ -1,0 +1,127 @@
+using garge_api.Dtos.Automation;
+using garge_api.Dtos.Group;
+using garge_api.Models.Automation;
+using garge_api.Models.Group;
+using MapsterMapper;
+using Xunit;
+
+namespace garge_api.Tests;
+
+/// <summary>
+/// Verifies the Mapster configurations that replaced hand-written projections map field-for-field.
+/// </summary>
+public class MappingProfileTests : ControllerTestBase
+{
+    private static IMapper Mapper => RealMapper;
+
+    [Fact]
+    public void AutomationRule_MapsAllDtoFields()
+    {
+        var rule = new AutomationRule
+        {
+            Id = 7,
+            TargetType = "switch",
+            TargetId = 10,
+            SensorType = "sensor",
+            SensorId = 5,
+            Condition = ">",
+            Threshold = 12.5,
+            Action = "on",
+            IsEnabled = false,
+            LastTriggeredAt = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc),
+            ElectricityPriceCondition = "below",
+            ElectricityPriceThreshold = 0.42,
+            ElectricityPriceArea = "NO1",
+            ElectricityPriceOperator = "<",
+            TimerDurationHours = 3.5,
+            TimerActivatedAt = new DateTime(2026, 1, 3, 0, 0, 0, DateTimeKind.Utc),
+        };
+
+        var dto = Mapper.Map<AutomationRuleDto>(rule);
+
+        Assert.Equal(rule.Id, dto.Id);
+        Assert.Equal(rule.TargetType, dto.TargetType);
+        Assert.Equal(rule.TargetId, dto.TargetId);
+        Assert.Equal(rule.SensorType, dto.SensorType);
+        Assert.Equal(rule.SensorId, dto.SensorId);
+        Assert.Equal(rule.Condition, dto.Condition);
+        Assert.Equal(rule.Threshold, dto.Threshold);
+        Assert.Equal(rule.Action, dto.Action);
+        Assert.Equal(rule.IsEnabled, dto.IsEnabled);
+        Assert.Equal(rule.LastTriggeredAt, dto.LastTriggeredAt);
+        Assert.Equal(rule.ElectricityPriceCondition, dto.ElectricityPriceCondition);
+        Assert.Equal(rule.ElectricityPriceThreshold, dto.ElectricityPriceThreshold);
+        Assert.Equal(rule.ElectricityPriceArea, dto.ElectricityPriceArea);
+        Assert.Equal(rule.ElectricityPriceOperator, dto.ElectricityPriceOperator);
+        Assert.Equal(rule.TimerDurationHours, dto.TimerDurationHours);
+        Assert.Equal(rule.TimerActivatedAt, dto.TimerActivatedAt);
+    }
+
+    [Fact]
+    public void AutomationRule_NullableFieldsMapAsNull()
+    {
+        var rule = new AutomationRule
+        {
+            Id = 1,
+            TargetType = "switch",
+            TargetId = 10,
+            SensorType = "sensor",
+            SensorId = 5,
+            Condition = ">",
+            Threshold = 20,
+            Action = "off",
+        };
+
+        var dto = Mapper.Map<AutomationRuleDto>(rule);
+
+        Assert.Null(dto.LastTriggeredAt);
+        Assert.Null(dto.ElectricityPriceCondition);
+        Assert.Null(dto.ElectricityPriceThreshold);
+        Assert.Null(dto.ElectricityPriceArea);
+        Assert.Null(dto.ElectricityPriceOperator);
+        Assert.Null(dto.TimerDurationHours);
+        Assert.Null(dto.TimerActivatedAt);
+        Assert.True(dto.IsEnabled); // entity default
+    }
+
+    [Fact]
+    public void Group_MapsScalarsAndFlattensSensorAndSwitchIds()
+    {
+        var group = new Group
+        {
+            Id = 3,
+            Name = "Garage",
+            Icon = "house",
+            UserId = "user-1",
+            GroupSensors = new List<GroupSensor>
+            {
+                new() { GroupId = 3, SensorId = 11 },
+                new() { GroupId = 3, SensorId = 12 },
+            },
+            GroupSwitches = new List<GroupSwitch>
+            {
+                new() { GroupId = 3, SwitchId = 21 },
+            },
+        };
+
+        var dto = Mapper.Map<GroupDto>(group);
+
+        Assert.Equal(3, dto.Id);
+        Assert.Equal("Garage", dto.Name);
+        Assert.Equal("house", dto.Icon);
+        Assert.Equal(new[] { 11, 12 }, dto.SensorIds);
+        Assert.Equal(new[] { 21 }, dto.SwitchIds);
+    }
+
+    [Fact]
+    public void Group_NoAssociations_MapsEmptyIdLists()
+    {
+        var group = new Group { Id = 1, Name = "Empty", Icon = null, UserId = "user-1" };
+
+        var dto = Mapper.Map<GroupDto>(group);
+
+        Assert.Null(dto.Icon);
+        Assert.Empty(dto.SensorIds);
+        Assert.Empty(dto.SwitchIds);
+    }
+}

--- a/garge-api.Tests/RegistrationCodeTests.cs
+++ b/garge-api.Tests/RegistrationCodeTests.cs
@@ -1,0 +1,51 @@
+using garge_api.Helpers;
+using Xunit;
+
+namespace garge_api.Tests;
+
+public class RegistrationCodeTests
+{
+    [Theory]
+    [InlineData(6)]
+    [InlineData(10)]
+    [InlineData(12)]
+    public void Generate_ProducesCodeOfRequestedLengthFromAlphabet(int length)
+    {
+        var code = RegistrationCode.Generate(length);
+
+        Assert.Equal(length, code.Length);
+        Assert.All(code, c => Assert.Contains(c, RegistrationCode.Alphabet));
+    }
+
+    [Fact]
+    public void Alphabet_ExcludesAmbiguousCharacters()
+    {
+        Assert.DoesNotContain('I', RegistrationCode.Alphabet);
+        Assert.DoesNotContain('O', RegistrationCode.Alphabet);
+        Assert.DoesNotContain('0', RegistrationCode.Alphabet);
+        Assert.DoesNotContain('1', RegistrationCode.Alphabet);
+    }
+
+    [Fact]
+    public async Task GenerateUniqueAsync_RetriesUntilPredicateAllows()
+    {
+        // Reject the first two candidates, accept the third. Verifies the loop keeps trying.
+        var calls = 0;
+        var code = await RegistrationCode.GenerateUniqueAsync(_ =>
+        {
+            calls++;
+            return Task.FromResult(calls < 3);
+        });
+
+        Assert.Equal(3, calls);
+        Assert.Equal(10, code.Length);
+    }
+
+    [Fact]
+    public async Task GenerateUniqueAsync_ReturnsImmediatelyWhenFree()
+    {
+        var code = await RegistrationCode.GenerateUniqueAsync(_ => Task.FromResult(false));
+
+        Assert.Equal(10, code.Length);
+    }
+}

--- a/garge-api.Tests/SensorControllerCreateTests.cs
+++ b/garge-api.Tests/SensorControllerCreateTests.cs
@@ -2,6 +2,7 @@ using garge_api.Controllers;
 using garge_api.Dtos.Sensor;
 using garge_api.Hubs;
 using garge_api.Models;
+using garge_api.Models.Sensor;
 using garge_api.Services;
 using MapsterMapper;
 using Microsoft.AspNetCore.Mvc;
@@ -72,5 +73,86 @@ public class SensorControllerCreateTests : ControllerTestBase
         Assert.IsNotType<BadRequestObjectResult>(result);
         Assert.Single(db.Sensors);
         Assert.Equal(type, db.Sensors.Single().Type);
+    }
+
+    private static Sensor SeedSensor(ApplicationDbContext db, int id = 1, string name = "garge_test_voltage")
+    {
+        var sensor = new Sensor
+        {
+            Id = id,
+            Name = name,
+            Type = "voltage",
+            Role = "sensor",
+            RegistrationCode = $"rc-{id}",
+            DefaultName = "Battery",
+            ParentName = "garge_test",
+        };
+        db.Sensors.Add(sensor);
+        db.SaveChanges();
+        return sensor;
+    }
+
+    // The by-id endpoint previously used double.Parse (a 500 on bad input). It must now reject
+    // invalid input with a 400, exactly like its by-name sibling.
+    [Theory]
+    [InlineData("abc")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task CreateSensorDataById_InvalidValue_Returns400(string value)
+    {
+        using var db = CreateDbContext();
+        var sensor = SeedSensor(db);
+        var controller = CreateController(db);
+
+        var result = await controller.CreateSensorDataById(sensor.Id, new CreateSensorDataDto { Value = value });
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Empty(db.SensorData);
+    }
+
+    [Theory]
+    [InlineData("abc")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task CreateSensorDataByName_InvalidValue_Returns400(string value)
+    {
+        using var db = CreateDbContext();
+        var sensor = SeedSensor(db);
+        var controller = CreateController(db);
+
+        var result = await controller.CreateSensorDataByName(sensor.Name, new CreateSensorDataDto { Value = value });
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Empty(db.SensorData);
+    }
+
+    [Fact]
+    public async Task CreateSensorDataById_ValidValue_PersistsRoundedValue()
+    {
+        using var db = CreateDbContext();
+        var sensor = SeedSensor(db);
+        MockMapper.Setup(m => m.Map<SensorDataDto>(It.IsAny<SensorData>()))
+            .Returns(new SensorDataDto { Id = 1, Value = "0", Timestamp = DateTime.UtcNow });
+        var controller = CreateController(db);
+
+        var result = await controller.CreateSensorDataById(sensor.Id, new CreateSensorDataDto { Value = "12.34567" });
+
+        Assert.IsNotType<BadRequestObjectResult>(result);
+        Assert.Equal("12.346", db.SensorData.Single().Value);
+    }
+
+    [Fact]
+    public async Task CreateSensorDataByName_ValidValue_PersistsRoundedValue()
+    {
+        using var db = CreateDbContext();
+        var sensor = SeedSensor(db);
+        MockMapper.Setup(m => m.Map<SensorDataDto>(It.IsAny<SensorData>()))
+            .Returns(new SensorDataDto { Id = 1, Value = "0", Timestamp = DateTime.UtcNow });
+        var controller = CreateController(db);
+
+        var result = await controller.CreateSensorDataByName(sensor.Name, new CreateSensorDataDto { Value = "12.34567" });
+
+        Assert.IsNotType<BadRequestObjectResult>(result);
+        Assert.Equal("12.346", db.SensorData.Single().Value);
     }
 }

--- a/garge-api.Tests/TimeRangeParserTests.cs
+++ b/garge-api.Tests/TimeRangeParserTests.cs
@@ -1,0 +1,43 @@
+using garge_api.Helpers;
+using Xunit;
+
+namespace garge_api.Tests;
+
+public class TimeRangeParserTests
+{
+    [Theory]
+    [InlineData("5m", 5 * 60)]
+    [InlineData("1h", 60 * 60)]
+    [InlineData("2d", 2 * 24 * 60 * 60)]
+    [InlineData("1w", 7 * 24 * 60 * 60)]
+    [InlineData("1y", 365 * 24 * 60 * 60)]
+    public void Parse_ValidRange_ReturnsExpectedSeconds(string input, double expectedSeconds)
+    {
+        var result = TimeRangeParser.Parse(input);
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedSeconds, result!.Value.TotalSeconds);
+    }
+
+    [Theory]
+    [InlineData("5M", 5 * 60)]
+    [InlineData("1H", 60 * 60)]
+    public void Parse_UppercaseUnit_IsCaseInsensitive(string input, double expectedSeconds)
+    {
+        var result = TimeRangeParser.Parse(input);
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedSeconds, result!.Value.TotalSeconds);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("m")]
+    [InlineData("5x")]
+    [InlineData("xh")]
+    [InlineData("5")]
+    public void Parse_InvalidRange_ReturnsNull(string input)
+    {
+        Assert.Null(TimeRangeParser.Parse(input));
+    }
+}


### PR DESCRIPTION
## Summary

Safe high-value cleanup pass on the API.

- Convert sync-over-async DB calls to async (`IssueRefreshToken` on the login path, `ClearUserOwnedRows`, admin reads)
- Add `.AsNoTracking()` to read-only GET queries that map entity to DTO
- Replace pure-role `if (!IsAdmin()) Forbid()` body-guards with declarative `[Authorize(Roles=...)]`; add `IsInAnyRole` extension + canonical `RoleNames` constants (resource-logic role checks left intact, routed through the same helper)
- Add Mapster config for `AutomationRule`/`Group` and drop the hand-rolled mapping
- **Bug fix:** `CreateSensorDataById` returned 500 on non-numeric input; now validates like its sibling (400) via a shared parse helper
- Extract `TimeRangeParser` and `RegistrationCode` helpers; remove dead `GetGroupingKey`
- Move magic strings to constants (`SwitchTypes`, `SwitchStates`, `SensorTypes.Voltage`)
- Guard `AssignPermission` against duplicate rows

Build: 0 errors, no new warnings. Tests: 414 pass (+31, incl. validation, mapping, and helper coverage).

Deferred as follow-ups: N+1 list-endpoint refactors, CancellationToken threading, generic sensor/switch sharing service, DTO consolidation, time-range IQueryable extension.