### PR TITLE
test: cover auth row-sets, admin role-gate attributes, share DTO JSON contract

### DIFF
--- a/garge-api.Tests/AdminRoleGateAttributeTests.cs
+++ b/garge-api.Tests/AdminRoleGateAttributeTests.cs
@@ -1,0 +1,74 @@
+using System.Reflection;
+using garge_api.Constants;
+using garge_api.Controllers;
+using Microsoft.AspNetCore.Authorization;
+using Xunit;
+
+namespace garge_api.Tests;
+
+/// <summary>
+/// Locks the declarative admin-role gates on the sensor, switch and MQTT admin-CRUD actions. The prior
+/// refactor replaced in-body <c>if (!IsAdmin()) Forbid()</c> checks with <c>[Authorize(Roles = ...)]</c>
+/// attributes. Unit-level controller calls bypass the MVC authorization pipeline, so a dropped attribute
+/// would otherwise go unnoticed. There is no integration/WebApplicationFactory harness in this project,
+/// so this asserts via reflection that each gated action still carries an <see cref="AuthorizeAttribute"/>
+/// whose Roles names exactly the expected role pair.
+/// </summary>
+public class AdminRoleGateAttributeTests
+{
+    private static readonly string SensorRoles = $"{RoleNames.Admin},{RoleNames.SensorAdmin}";
+    private static readonly string SwitchRoles = $"{RoleNames.Admin},{RoleNames.SwitchAdmin}";
+    private static readonly string MqttRoles = $"{RoleNames.Admin},{RoleNames.MqttAdmin}";
+
+    public static TheoryData<Type, string, string> GatedActions() => new()
+    {
+        // SensorController admin-CRUD actions.
+        { typeof(SensorController), nameof(SensorController.CreateSensor), SensorRoles },
+        { typeof(SensorController), nameof(SensorController.CreateSensorDataById), SensorRoles },
+        { typeof(SensorController), nameof(SensorController.CreateSensorDataByName), SensorRoles },
+        { typeof(SensorController), nameof(SensorController.UpdateSensor), SensorRoles },
+        { typeof(SensorController), nameof(SensorController.DeleteSensor), SensorRoles },
+        { typeof(SensorController), nameof(SensorController.DeleteSensorData), SensorRoles },
+        { typeof(SensorController), nameof(SensorController.DeleteAllSensorData), SensorRoles },
+
+        // SwitchesController admin-CRUD actions.
+        { typeof(SwitchesController), nameof(SwitchesController.CreateSwitch), SwitchRoles },
+        { typeof(SwitchesController), nameof(SwitchesController.UpdateSwitch), SwitchRoles },
+        { typeof(SwitchesController), nameof(SwitchesController.DeleteSwitch), SwitchRoles },
+        { typeof(SwitchesController), nameof(SwitchesController.CreateSwitchData), SwitchRoles },
+        { typeof(SwitchesController), nameof(SwitchesController.CreateSwitchDataByName), SwitchRoles },
+
+        // MqttController admin-only writes.
+        { typeof(MqttController), nameof(MqttController.CreateUser), MqttRoles },
+        { typeof(MqttController), nameof(MqttController.CreateAcl), MqttRoles },
+        { typeof(MqttController), nameof(MqttController.PostDiscoveredDevice), MqttRoles },
+    };
+
+    [Theory]
+    [MemberData(nameof(GatedActions))]
+    public void GatedAction_CarriesAuthorizeAttribute_WithExpectedRoles(Type controller, string action, string expectedRoles)
+    {
+        var method = controller.GetMethod(action, BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(method);
+
+        var authorize = method!.GetCustomAttributes<AuthorizeAttribute>(inherit: true).ToList();
+        Assert.True(
+            authorize.Count > 0,
+            $"{controller.Name}.{action} must carry [Authorize] gating it to '{expectedRoles}'.");
+
+        Assert.Contains(
+            authorize,
+            a => a.Roles == expectedRoles);
+    }
+
+    [Fact]
+    public void RoleNameConstants_AreTheCanonicalSeededStrings()
+    {
+        // The Roles strings above are only a meaningful gate if the constants hold the exact names that
+        // Identity seeds and JWTs carry. Pin them so a rename here can't silently widen access.
+        Assert.Equal("Admin", RoleNames.Admin);
+        Assert.Equal("SensorAdmin", RoleNames.SensorAdmin);
+        Assert.Equal("SwitchAdmin", RoleNames.SwitchAdmin);
+        Assert.Equal("MqttAdmin", RoleNames.MqttAdmin);
+    }
+}

--- a/garge-api.Tests/AutomationControllerTests.cs
+++ b/garge-api.Tests/AutomationControllerTests.cs
@@ -134,6 +134,58 @@ public class AutomationControllerTests : ControllerTestBase
     }
 
     [Fact]
+    public async Task GetRules_MixedOwnedAndEditShared_ReturnsExactCrossChainSet()
+    {
+        // The caller reaches one target switch as the gateway-sensor owner and a second target switch
+        // through an Edit share of a different gateway sensor. A third target, reachable only by a
+        // stranger, must stay out. The returned set must be exactly the two accessible targets.
+        var db = CreateDbContext();
+
+        // Chain A: caller owns sensor 5 on hub-1, which discovered switch-a (id 10).
+        db.Switches.Add(new Switch { Id = 10, Name = "switch-a", Type = "socket", Role = "switch" });
+        db.Sensors.Add(new Sensor
+        {
+            Id = 5, Name = "sensor-1", Type = "temperature", Role = "sensor",
+            RegistrationCode = "reg-1", DefaultName = "Sensor 1", ParentName = "hub-1"
+        });
+        db.UserSensors.Add(new UserSensor { UserId = "mix", SensorId = 5, IsOwner = true });
+        db.DiscoveredDevices.Add(new DiscoveredDevice { DiscoveredBy = "hub-1", Target = "switch-a", Type = "socket", Timestamp = DateTime.UtcNow });
+
+        // Chain B: caller has an Edit share of sensor 6 on hub-2, which discovered switch-b (id 20).
+        db.Switches.Add(new Switch { Id = 20, Name = "switch-b", Type = "socket", Role = "switch" });
+        db.Sensors.Add(new Sensor
+        {
+            Id = 6, Name = "sensor-2", Type = "voltage", Role = "sensor",
+            RegistrationCode = "reg-2", DefaultName = "Sensor 2", ParentName = "hub-2"
+        });
+        db.UserSensors.Add(new UserSensor { UserId = "mix", SensorId = 6, IsOwner = false, Permission = SharePermission.Edit });
+        db.DiscoveredDevices.Add(new DiscoveredDevice { DiscoveredBy = "hub-2", Target = "switch-b", Type = "socket", Timestamp = DateTime.UtcNow });
+
+        // Chain C: a stranger owns sensor 7 on hub-3, which discovered switch-c (id 30). Off-limits.
+        db.Switches.Add(new Switch { Id = 30, Name = "switch-c", Type = "socket", Role = "switch" });
+        db.Sensors.Add(new Sensor
+        {
+            Id = 7, Name = "sensor-3", Type = "voltage", Role = "sensor",
+            RegistrationCode = "reg-3", DefaultName = "Sensor 3", ParentName = "hub-3"
+        });
+        db.UserSensors.Add(new UserSensor { UserId = "stranger", SensorId = 7, IsOwner = true });
+        db.DiscoveredDevices.Add(new DiscoveredDevice { DiscoveredBy = "hub-3", Target = "switch-c", Type = "socket", Timestamp = DateTime.UtcNow });
+
+        db.AutomationRules.AddRange(
+            MakeRule(targetId: 10, sensorId: 5),   // accessible via owned chain A
+            MakeRule(targetId: 20, sensorId: 6),   // accessible via edit-shared chain B
+            MakeRule(targetId: 30, sensorId: 7),   // stranger-only chain C
+            MakeRule(targetId: 99, sensorId: 99)); // unknown target
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await CreateAutomationController(db, userId: "mix", isAdmin: false).GetRules(TestContext.Current.CancellationToken);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var rules = Assert.IsAssignableFrom<IEnumerable<AutomationRuleDto>>(ok.Value).ToList();
+        Assert.Equal(new[] { 10, 20 }, rules.Select(r => r.TargetId).OrderBy(x => x));
+    }
+
+    [Fact]
     public async Task CreateRule_AdminUser_ReturnsCreatedRule()
     {
         var db = CreateDbContext();

--- a/garge-api.Tests/ShareDtoJsonContractTests.cs
+++ b/garge-api.Tests/ShareDtoJsonContractTests.cs
@@ -1,0 +1,109 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using garge_api.Dtos.Common;
+using garge_api.Models;
+using Xunit;
+
+namespace garge_api.Tests;
+
+/// <summary>
+/// Pins the wire contract of the consolidated share DTOs (<see cref="ShareRequestDto"/> /
+/// <see cref="ShareRecipientDto"/> in Dtos/Common) that the frontend consumes. The API registers MVC's
+/// JSON options with only <c>ReferenceHandler.IgnoreCycles</c> added, leaving the framework defaults:
+/// camelCase property names and numeric enum serialization (no <see cref="JsonStringEnumConverter"/>).
+/// These tests serialize with the same options and assert the exact property names and enum encoding so a
+/// future naming-policy or enum-converter change that would break the frontend fails loudly here.
+/// </summary>
+public class ShareDtoJsonContractTests
+{
+    // Mirrors Program.cs: AddControllers().AddJsonOptions(o => o.JsonSerializerOptions.ReferenceHandler =
+    // ReferenceHandler.IgnoreCycles). MVC seeds its JsonSerializerOptions from JsonSerializerDefaults.Web
+    // (camelCase + case-insensitive); no enum converter is registered, so enums emit as numbers.
+    private static readonly JsonSerializerOptions ApiOptions = new(JsonSerializerDefaults.Web)
+    {
+        ReferenceHandler = ReferenceHandler.IgnoreCycles,
+    };
+
+    private static HashSet<string> PropertyNames(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.EnumerateObject().Select(p => p.Name).ToHashSet();
+    }
+
+    [Fact]
+    public void ShareRequestDto_SerializesWithCamelCaseNames()
+    {
+        var dto = new ShareRequestDto { Email = "viewer@x", Permission = SharePermission.Edit };
+
+        var json = JsonSerializer.Serialize(dto, ApiOptions);
+
+        Assert.Equal(new HashSet<string> { "email", "permission" }, PropertyNames(json));
+    }
+
+    [Fact]
+    public void ShareRequestDto_PermissionSerializesAsNumber()
+    {
+        var dto = new ShareRequestDto { Email = "viewer@x", Permission = SharePermission.Edit };
+
+        var json = JsonSerializer.Serialize(dto, ApiOptions);
+
+        using var doc = JsonDocument.Parse(json);
+        var permission = doc.RootElement.GetProperty("permission");
+        Assert.Equal(JsonValueKind.Number, permission.ValueKind);
+        Assert.Equal((int)SharePermission.Edit, permission.GetInt32());
+    }
+
+    [Fact]
+    public void ShareRecipientDto_SerializesWithCamelCaseNames()
+    {
+        var dto = new ShareRecipientDto
+        {
+            UserId = "viewer",
+            Email = "viewer@x",
+            FirstName = "Vee",
+            LastName = "Wer",
+            Permission = SharePermission.Read,
+            SharedAt = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc),
+        };
+
+        var json = JsonSerializer.Serialize(dto, ApiOptions);
+
+        Assert.Equal(
+            new HashSet<string> { "userId", "email", "firstName", "lastName", "permission", "sharedAt" },
+            PropertyNames(json));
+    }
+
+    [Fact]
+    public void ShareRecipientDto_PermissionSerializesAsNumber()
+    {
+        var dto = new ShareRecipientDto
+        {
+            UserId = "viewer",
+            Email = "viewer@x",
+            FirstName = "Vee",
+            LastName = "Wer",
+            Permission = SharePermission.Read,
+            SharedAt = DateTime.UtcNow,
+        };
+
+        var json = JsonSerializer.Serialize(dto, ApiOptions);
+
+        using var doc = JsonDocument.Parse(json);
+        var permission = doc.RootElement.GetProperty("permission");
+        Assert.Equal(JsonValueKind.Number, permission.ValueKind);
+        Assert.Equal((int)SharePermission.Read, permission.GetInt32());
+    }
+
+    [Fact]
+    public void ShareRequestDto_DeserializesFromCamelCaseFrontendPayload()
+    {
+        // The frontend posts the share request with camelCase names; round-trip from that shape.
+        const string body = """{ "email": "viewer@x", "permission": 1 }""";
+
+        var dto = JsonSerializer.Deserialize<ShareRequestDto>(body, ApiOptions);
+
+        Assert.NotNull(dto);
+        Assert.Equal("viewer@x", dto!.Email);
+        Assert.Equal(SharePermission.Edit, dto.Permission);
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up test coverage for the merged refactors (#283). Test code only, no production changes.

- GetRules cross-chain mixed-ownership exact-set assertion (extends the access matrix)
- Reflection guard: every migrated admin-CRUD action keeps its [Authorize(Roles=...)] (Admin,SensorAdmin / Admin,SwitchAdmin / Admin,MqttAdmin), plus a check pinning RoleNames to canonical seeded strings, so the gate can't be silently dropped
- Share DTO JSON contract: pins serialized property names for the consolidated Dtos/Common ShareRequestDto/ShareRecipientDto so the frontend contract stays stable

Tests: 458 pass (436 prior + 22), 0 xUnit1051.