### PR TITLE
ci: set bootstrap-sha so changelog starts from last release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "pull-request-title-pattern": "chore: release ${version}",
+  "bootstrap-sha": "d60d406eef26dc2452451a216001cc7f65a57bfa",
   "packages": {
     ".": {
       "release-type": "simple",


### PR DESCRIPTION
## Summary

Set `bootstrap-sha` to the last release tag commit so the first release-please-manifest run only includes commits made after the previous release.

Without it, the generated changelog walked all history and included every prior version. `bootstrap-sha` is honored only until the first manifest release PR merges, then ignored.