### PR TITLE
feat: per-user voltage color thresholds

### DIFF
--- a/Controllers/SensorController.cs
+++ b/Controllers/SensorController.cs
@@ -149,6 +149,11 @@ namespace garge_api.Controllers
                 .Where(x => x.UserId == currentUserId)
                 .ToDictionaryAsync(x => x.SensorId, x => x.CustomName, ct);
 
+            // Fetch all voltage color thresholds for the current user
+            var voltageThresholds = await _context.UserSensorVoltageThresholds
+                .Where(x => x.UserId == currentUserId)
+                .ToDictionaryAsync(x => x.SensorId, x => new { x.WarningVoltage, x.CriticalVoltage }, ct);
+
             var sensorIds = sensors.Select(s => s.Id).ToList();
             var suspendedIds = await CallerSuspendedSensorIdsAsync(sensorIds, ct);
 
@@ -166,6 +171,11 @@ namespace garge_api.Controllers
                 var dto = _mapper.Map<SensorDto>(sensor);
                 if (customNames.TryGetValue(sensor.Id, out var customName))
                     dto.CustomName = customName;
+                if (voltageThresholds.TryGetValue(sensor.Id, out var threshold))
+                {
+                    dto.WarningVoltage = threshold.WarningVoltage;
+                    dto.CriticalVoltage = threshold.CriticalVoltage;
+                }
                 dto.Suspended = suspendedIds.Contains(sensor.Id);
                 dto.Access = IsAdmin() ? DeviceAccess.Owner : (accessById.TryGetValue(sensor.Id, out var a) ? a : DeviceAccess.Owner);
                 return dto;
@@ -213,6 +223,16 @@ namespace garge_api.Controllers
 
             if (!string.IsNullOrEmpty(customName))
                 dto.CustomName = customName;
+
+            var threshold = await _context.UserSensorVoltageThresholds
+                .Where(x => x.UserId == currentUserId && x.SensorId == id)
+                .Select(x => new { x.WarningVoltage, x.CriticalVoltage })
+                .FirstOrDefaultAsync(ct);
+            if (threshold != null)
+            {
+                dto.WarningVoltage = threshold.WarningVoltage;
+                dto.CriticalVoltage = threshold.CriticalVoltage;
+            }
 
             dto.Suspended = await IsSensorSuspendedForCallerAsync(id, ct);
             dto.Access = await CallerAccessAsync(id, ct);
@@ -729,6 +749,9 @@ namespace garge_api.Controllers
                 .FirstOrDefaultAsync(x => x.UserId == userId && x.SensorId == sensorId);
             if (customName != null)
                 _context.UserSensorCustomNames.Remove(customName);
+
+            _context.UserSensorVoltageThresholds.RemoveRange(
+                _context.UserSensorVoltageThresholds.Where(x => x.UserId == userId && x.SensorId == sensorId));
 
             _context.SensorActivities.RemoveRange(_context.SensorActivities.Where(a => a.UserId == userId && a.SensorId == sensorId));
             _context.SensorPhotos.RemoveRange(_context.SensorPhotos.Where(p => p.UserId == userId && p.SensorId == sensorId));
@@ -1302,6 +1325,120 @@ namespace garge_api.Controllers
 
             _logger.LogInformation("Custom name updated for {@LogData}", new { sensorId, CallerUserId = User.UserId() });
             return Ok(resultDto);
+        }
+
+        /// <summary>
+        /// Sets the caller's voltage color thresholds for a sensor. The reading is shown as a warning
+        /// below <paramref name="dto"/>.WarningVoltage and as critical below CriticalVoltage. Upserts the row.
+        /// </summary>
+        /// <param name="sensorId">The ID of the sensor.</param>
+        /// <param name="dto">The warning and critical voltages. Warning must be greater than critical.</param>
+        /// <returns>The stored thresholds.</returns>
+        [HttpPatch("{sensorId}/voltage-thresholds")]
+        [SwaggerOperation(Summary = "Sets the caller's voltage color thresholds for a sensor.")]
+        [SwaggerResponse(200, "Thresholds updated.", typeof(UserSensorVoltageThresholdDto))]
+        [SwaggerResponse(400, "Invalid thresholds.")]
+        [SwaggerResponse(404, "Sensor not found.")]
+        [SwaggerResponse(403, "User does not have access to the sensor.")]
+        public async Task<IActionResult> UpdateVoltageThresholds(
+            int sensorId,
+            [FromBody] UpdateVoltageThresholdDto dto)
+        {
+            _logger.LogInformation("UpdateVoltageThresholds called by {@LogData}", new { CallerUserId = User.UserId(), sensorId });
+
+            var sensor = await _context.Sensors.FindAsync(sensorId);
+            if (sensor == null)
+            {
+                _logger.LogWarning("UpdateVoltageThresholds not found: {@LogData}", new { sensorId });
+                return NotFound(new { message = "Sensor not found!" });
+            }
+
+            if (!await UserCanAccessSensorAsync(sensor.Id))
+            {
+                _logger.LogWarning("UpdateVoltageThresholds forbidden for {@LogData}", new { CallerUserId = User.UserId(), sensorId });
+                return Forbid();
+            }
+
+            var currentUserId = User.UserId();
+            if (string.IsNullOrEmpty(currentUserId))
+                return Unauthorized();
+
+            if (dto.WarningVoltage <= dto.CriticalVoltage)
+            {
+                _logger.LogWarning("UpdateVoltageThresholds bad request: {@LogData}", new { sensorId, CallerUserId = currentUserId });
+                return BadRequest(new { message = "WarningVoltage must be greater than CriticalVoltage." });
+            }
+
+            var entry = await _context.UserSensorVoltageThresholds
+                .FirstOrDefaultAsync(x => x.UserId == currentUserId && x.SensorId == sensorId);
+
+            if (entry == null)
+            {
+                entry = new UserSensorVoltageThreshold
+                {
+                    UserId = currentUserId,
+                    SensorId = sensorId,
+                    WarningVoltage = dto.WarningVoltage,
+                    CriticalVoltage = dto.CriticalVoltage,
+                    CreatedAt = DateTime.UtcNow
+                };
+                _context.UserSensorVoltageThresholds.Add(entry);
+            }
+            else
+            {
+                entry.WarningVoltage = dto.WarningVoltage;
+                entry.CriticalVoltage = dto.CriticalVoltage;
+            }
+
+            await _context.SaveChangesAsync();
+
+            var resultDto = new UserSensorVoltageThresholdDto
+            {
+                UserId = entry.UserId,
+                SensorId = entry.SensorId,
+                WarningVoltage = entry.WarningVoltage,
+                CriticalVoltage = entry.CriticalVoltage,
+                CreatedAt = entry.CreatedAt
+            };
+
+            _logger.LogInformation("Voltage thresholds updated for {@LogData}", new { sensorId, CallerUserId = currentUserId });
+            return Ok(resultDto);
+        }
+
+        /// <summary>
+        /// Clears the caller's voltage color thresholds for a sensor, so the reading is no longer colored.
+        /// </summary>
+        /// <param name="sensorId">The ID of the sensor.</param>
+        [HttpDelete("{sensorId}/voltage-thresholds")]
+        [SwaggerOperation(Summary = "Clears the caller's voltage color thresholds for a sensor.")]
+        [SwaggerResponse(204, "Thresholds cleared.")]
+        [SwaggerResponse(404, "Sensor not found.")]
+        [SwaggerResponse(403, "User does not have access to the sensor.")]
+        public async Task<IActionResult> ClearVoltageThresholds(int sensorId)
+        {
+            _logger.LogInformation("ClearVoltageThresholds called by {@LogData}", new { CallerUserId = User.UserId(), sensorId });
+
+            var sensor = await _context.Sensors.FindAsync(sensorId);
+            if (sensor == null)
+                return NotFound(new { message = "Sensor not found!" });
+
+            if (!await UserCanAccessSensorAsync(sensor.Id))
+                return Forbid();
+
+            var currentUserId = User.UserId();
+            if (string.IsNullOrEmpty(currentUserId))
+                return Unauthorized();
+
+            var entry = await _context.UserSensorVoltageThresholds
+                .FirstOrDefaultAsync(x => x.UserId == currentUserId && x.SensorId == sensorId);
+            if (entry != null)
+            {
+                _context.UserSensorVoltageThresholds.Remove(entry);
+                await _context.SaveChangesAsync();
+            }
+
+            _logger.LogInformation("Voltage thresholds cleared for {@LogData}", new { sensorId, CallerUserId = currentUserId });
+            return NoContent();
         }
 
         /// <summary>

--- a/Controllers/UserController.cs
+++ b/Controllers/UserController.cs
@@ -158,6 +158,7 @@ namespace garge_api.Controllers
 
             _context.RefreshTokens.RemoveRange(_context.RefreshTokens.Where(t => t.UserId == userId));
             _context.UserSensorCustomNames.RemoveRange(_context.UserSensorCustomNames.Where(x => x.UserId == userId));
+            _context.UserSensorVoltageThresholds.RemoveRange(_context.UserSensorVoltageThresholds.Where(x => x.UserId == userId));
             _context.UserSwitchCustomNames.RemoveRange(_context.UserSwitchCustomNames.Where(x => x.UserId == userId));
             _context.SensorActivities.RemoveRange(_context.SensorActivities.Where(a => a.UserId == userId));
             _context.SensorPhotos.RemoveRange(_context.SensorPhotos.Where(p => p.UserId == userId));
@@ -266,6 +267,10 @@ namespace garge_api.Controllers
             var sensorCustomNames = await _context.UserSensorCustomNames
                 .Where(x => x.UserId == id)
                 .ToDictionaryAsync(x => x.SensorId, x => x.CustomName);
+
+            var voltageThresholds = await _context.UserSensorVoltageThresholds
+                .Where(x => x.UserId == id)
+                .ToDictionaryAsync(x => x.SensorId, x => new { x.WarningVoltage, x.CriticalVoltage });
 
             var sensors = await _context.UserSensors
                 .Where(us => us.UserId == id)
@@ -404,6 +409,9 @@ namespace garge_api.Controllers
                     s.Type,
                     DefaultName = s.DefaultName,
                     CustomName = sensorCustomNames.TryGetValue(s.Id, out var cn) ? cn : null,
+                    VoltageThresholds = voltageThresholds.TryGetValue(s.Id, out var vt)
+                        ? new { vt.WarningVoltage, vt.CriticalVoltage }
+                        : null,
                     Readings = sensorReadings
                         .Where(r => r.SensorId == s.Id)
                         .Select(r => new { r.Value, r.Timestamp }),

--- a/Dtos/Sensor/SensorDto.cs
+++ b/Dtos/Sensor/SensorDto.cs
@@ -13,6 +13,14 @@ namespace garge_api.Dtos.Sensor
         public required string DefaultName { get; set; }
         public required string ParentName { get; set; }
 
+        /// <summary>
+        /// The caller's voltage color thresholds for this sensor. Both are null when unset, in which
+        /// case the client leaves the reading uncolored. A reading at or above <see cref="WarningVoltage"/>
+        /// is normal, below it is a warning, and below <see cref="CriticalVoltage"/> is critical.
+        /// </summary>
+        public double? WarningVoltage { get; set; }
+        public double? CriticalVoltage { get; set; }
+
         /// <summary>True when the caller has this owned sensor turned off / over-quota suspended. Data reads are blocked while suspended.</summary>
         public bool Suspended { get; set; }
 

--- a/Dtos/Sensor/UpdateVoltageThresholdDto.cs
+++ b/Dtos/Sensor/UpdateVoltageThresholdDto.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace garge_api.Dtos.Sensor
+{
+    public class UpdateVoltageThresholdDto
+    {
+        [Range(0, 100)]
+        public required double WarningVoltage { get; set; }
+
+        [Range(0, 100)]
+        public required double CriticalVoltage { get; set; }
+    }
+}

--- a/Dtos/Sensor/UserSensorVoltageThresholdDto.cs
+++ b/Dtos/Sensor/UserSensorVoltageThresholdDto.cs
@@ -1,0 +1,11 @@
+namespace garge_api.Dtos.Sensor
+{
+    public class UserSensorVoltageThresholdDto
+    {
+        public required string UserId { get; set; }
+        public required int SensorId { get; set; }
+        public required double WarningVoltage { get; set; }
+        public required double CriticalVoltage { get; set; }
+        public required DateTime CreatedAt { get; set; }
+    }
+}

--- a/Migrations/20260629140340_AddUserSensorVoltageThresholds.Designer.cs
+++ b/Migrations/20260629140340_AddUserSensorVoltageThresholds.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260629140340_AddUserSensorVoltageThresholds")]
+    partial class AddUserSensorVoltageThresholds
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260629140340_AddUserSensorVoltageThresholds.cs
+++ b/Migrations/20260629140340_AddUserSensorVoltageThresholds.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserSensorVoltageThresholds : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserSensorVoltageThresholds",
+                columns: table => new
+                {
+                    UserId = table.Column<string>(type: "text", nullable: false),
+                    SensorId = table.Column<int>(type: "integer", nullable: false),
+                    WarningVoltage = table.Column<double>(type: "double precision", nullable: false),
+                    CriticalVoltage = table.Column<double>(type: "double precision", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserSensorVoltageThresholds", x => new { x.UserId, x.SensorId });
+                    table.ForeignKey(
+                        name: "FK_UserSensorVoltageThresholds_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_UserSensorVoltageThresholds_Sensors_SensorId",
+                        column: x => x.SensorId,
+                        principalTable: "Sensors",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserSensorVoltageThresholds_SensorId",
+                table: "UserSensorVoltageThresholds",
+                column: "SensorId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserSensorVoltageThresholds");
+        }
+    }
+}

--- a/Models/ApplicationDbContext.cs
+++ b/Models/ApplicationDbContext.cs
@@ -31,6 +31,7 @@ namespace garge_api.Models
         public DbSet<SwitchData> SwitchData { get; set; }
         public DbSet<RefreshToken> RefreshTokens { get; set; }
         public DbSet<UserSensorCustomName> UserSensorCustomNames { get; set; }
+        public DbSet<UserSensorVoltageThreshold> UserSensorVoltageThresholds { get; set; }
         public DbSet<SensorActivity> SensorActivities { get; set; }
         public DbSet<EMQXMqttUser> EMQXMqttUsers { get; set; }
         public DbSet<EMQXMqttAcl> EMQXMqttAcls { get; set; }
@@ -114,6 +115,19 @@ namespace garge_api.Models
                 .HasForeignKey(x => x.UserId);
 
             modelBuilder.Entity<UserSensorCustomName>()
+                .HasOne(x => x.Sensor)
+                .WithMany()
+                .HasForeignKey(x => x.SensorId);
+
+            modelBuilder.Entity<UserSensorVoltageThreshold>()
+                .HasKey(x => new { x.UserId, x.SensorId });
+
+            modelBuilder.Entity<UserSensorVoltageThreshold>()
+                .HasOne(x => x.User)
+                .WithMany()
+                .HasForeignKey(x => x.UserId);
+
+            modelBuilder.Entity<UserSensorVoltageThreshold>()
                 .HasOne(x => x.Sensor)
                 .WithMany()
                 .HasForeignKey(x => x.SensorId);

--- a/Models/Sensor/UserSensorVoltageThreshold.cs
+++ b/Models/Sensor/UserSensorVoltageThreshold.cs
@@ -1,0 +1,13 @@
+namespace garge_api.Models.Sensor
+{
+    public class UserSensorVoltageThreshold
+    {
+        public string UserId { get; set; } = default!;
+        public int SensorId { get; set; }
+        public double WarningVoltage { get; set; }
+        public double CriticalVoltage { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public User User { get; set; } = default!;
+        public Sensor Sensor { get; set; } = default!;
+    }
+}


### PR DESCRIPTION
## Summary

Stores optional warning/critical voltage thresholds per user and sensor so the client can color a voltage reading. Thresholds are unset by default — no coloring until the user configures them.

- New `UserSensorVoltageThreshold` entity (composite key UserId+SensorId), DbSet, and fluent config mirroring `UserSensorCustomName`, with an EF migration.
- `PATCH`/`DELETE /sensors/{id}/voltage-thresholds`, access-gated, validating that warning is above critical.
- `WarningVoltage`/`CriticalVoltage` merged into `SensorDto` in `GetAllSensors`/`GetSensor` so the list carries them without an extra round-trip.
- GDPR: cleared on unclaim and account deletion (Art 17), included in the data export (Art 20); user-row deletion cascades via the UserId FK.
