### PR TITLE
feat: pairing token mint and claim endpoints

### DIFF
--- a/Controllers/PairingController.cs
+++ b/Controllers/PairingController.cs
@@ -1,0 +1,239 @@
+using garge_api.Constants;
+using garge_api.Dtos.Pairing;
+using garge_api.Hubs;
+using garge_api.Models;
+using garge_api.Models.Pairing;
+using garge_api.Models.Sensor;
+using garge_api.Models.Switch;
+using garge_api.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Cors;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace garge_api.Controllers
+{
+    [ApiController]
+    [Route("api/pairing")]
+    [EnableCors("AllowAllOrigins")]
+    [Authorize]
+    public class PairingController : ControllerBase
+    {
+        /// <summary>How long a freshly minted pairing token stays redeemable.</summary>
+        internal static readonly TimeSpan TokenLifetime = TimeSpan.FromMinutes(15);
+
+        /// <summary>Pairing tokens are short so a human can type them into the device setup flow.</summary>
+        internal const int TokenLength = 6;
+
+        private readonly ApplicationDbContext _context;
+        private readonly ILogger<PairingController> _logger;
+        private readonly IDeviceOwnershipService _ownership;
+        private readonly IHubContext<DeviceHub> _hub;
+
+        public PairingController(ApplicationDbContext context, ILogger<PairingController> logger, IDeviceOwnershipService ownership, IHubContext<DeviceHub> hub)
+        {
+            _context = context;
+            _logger = logger;
+            _ownership = ownership;
+            _hub = hub;
+        }
+
+        /// <summary>
+        /// Mints a short-lived, single-use pairing token for the current user. The physical device
+        /// sends the token over MQTT during setup and the operator service redeems it via
+        /// <see cref="ClaimPairing"/>. Minting a new token invalidates the user's previous
+        /// unconsumed tokens so at most one is redeemable at a time.
+        /// </summary>
+        [HttpPost("token")]
+        [Authorize(Policy = "ActiveSubscription")]
+        [SwaggerOperation(Summary = "Mints a short-lived single-use pairing token for the current user.")]
+        [SwaggerResponse(200, "The minted token and its expiry.", typeof(PairingTokenDto))]
+        public async Task<IActionResult> CreatePairingToken()
+        {
+            _logger.LogInformation("CreatePairingToken called by {@LogData}", new { CallerUserId = User.UserId() });
+
+            var userId = User.UserId();
+            var user = await _context.Users.FindAsync(userId);
+            if (user == null)
+            {
+                _logger.LogWarning("CreatePairingToken unauthorized: User not found {@LogData}", new { UserId = userId });
+                return Unauthorized();
+            }
+
+            // A new token supersedes any earlier unconsumed ones, so a lost or mistyped token can
+            // never be redeemed after the user has minted a replacement.
+            var staleTokens = await _context.PairingTokens
+                .Where(t => t.UserId == userId && t.ConsumedAt == null)
+                .ToListAsync();
+            _context.PairingTokens.RemoveRange(staleTokens);
+
+            // Checked against every stored token (not just live ones) so the candidate can never
+            // trip the unique index on Token.
+            var token = await RegistrationCode.GenerateUniqueAsync(
+                code => _context.PairingTokens.AnyAsync(t => t.Token == code), TokenLength);
+
+            var pairingToken = new PairingToken
+            {
+                Token = token,
+                UserId = userId!,
+                ExpiresAt = DateTime.UtcNow.Add(TokenLifetime)
+            };
+            _context.PairingTokens.Add(pairingToken);
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("Pairing token minted {@LogData}", new { CallerUserId = userId, pairingToken.ExpiresAt, Superseded = staleTokens.Count });
+            return Ok(new PairingTokenDto { Token = pairingToken.Token, ExpiresAt = pairingToken.ExpiresAt });
+        }
+
+        /// <summary>
+        /// Redeems a pairing token for a parent device: claims every sensor under the parent name
+        /// (and every switch its gateway discovered) for the token's user. Called by the operator
+        /// service after the device sends the token over MQTT. Devices the user already has, and
+        /// devices owned by another user, are skipped rather than stolen.
+        /// </summary>
+        [HttpPost("claim")]
+        [Authorize(Roles = $"{RoleNames.Admin},{RoleNames.SensorAdmin},{RoleNames.SwitchAdmin}")]
+        [SwaggerOperation(Summary = "Redeems a pairing token, claiming the parent device's sensors and switches for the token's user.")]
+        [SwaggerResponse(200, "The claimed device ids.", typeof(PairingClaimResultDto))]
+        [SwaggerResponse(400, "Token or parent name missing.")]
+        [SwaggerResponse(404, "Unknown token, or no devices exist yet for the parent name.")]
+        [SwaggerResponse(410, "Token expired or already consumed.")]
+        public async Task<IActionResult> ClaimPairing([FromBody] ClaimPairingTokenDto dto)
+        {
+            _logger.LogInformation("ClaimPairing called by {@LogData}", new { CallerUserId = User.UserId(), dto.ParentName });
+
+            if (string.IsNullOrWhiteSpace(dto.Token) || string.IsNullOrWhiteSpace(dto.ParentName))
+            {
+                _logger.LogWarning("ClaimPairing bad request: Token and parent name are required {@LogData}", new { CallerUserId = User.UserId() });
+                return BadRequest(new { message = "Token and parent name are required." });
+            }
+
+            // Tokens are minted from an uppercase alphabet; accept any casing from the device.
+            var normalizedToken = dto.Token.Trim().ToUpperInvariant();
+            var parentName = dto.ParentName.Trim();
+
+            var token = await _context.PairingTokens.FirstOrDefaultAsync(t => t.Token == normalizedToken);
+            if (token == null)
+            {
+                _logger.LogWarning("ClaimPairing not found: Unknown pairing token {@LogData}", new { CallerUserId = User.UserId() });
+                return NotFound(new { message = "Unknown pairing token." });
+            }
+
+            if (token.ConsumedAt != null)
+            {
+                _logger.LogWarning("ClaimPairing gone: Token already consumed {@LogData}", new { token.Id, token.ConsumedAt });
+                return StatusCode(410, new { message = "Pairing token has already been used." });
+            }
+
+            if (token.ExpiresAt <= DateTime.UtcNow)
+            {
+                _logger.LogWarning("ClaimPairing gone: Token expired {@LogData}", new { token.Id, token.ExpiresAt });
+                return StatusCode(410, new { message = "Pairing token has expired." });
+            }
+
+            var sensors = await _context.Sensors.Where(s => s.ParentName == parentName).ToListAsync();
+
+            // Switches carry no parent name of their own; they hang off a gateway through the
+            // discovered-device chain (DiscoveredBy = parent, Target = switch name), the same
+            // relation the switch controller uses for indirect ownership.
+            var switchNames = await _context.DiscoveredDevices
+                .Where(dd => dd.DiscoveredBy == parentName)
+                .Select(dd => dd.Target)
+                .Distinct()
+                .ToListAsync();
+            var switches = await _context.Switches.Where(s => switchNames.Contains(s.Name)).ToListAsync();
+
+            if (sensors.Count == 0 && switches.Count == 0)
+            {
+                // Distinct body so the operator can tell "retry later, devices not registered yet"
+                // apart from an invalid token.
+                _logger.LogWarning("ClaimPairing not found: No devices for parent {@LogData}", new { parentName });
+                return NotFound(new { message = "No devices found for that parent name.", code = "devices-not-found" });
+            }
+
+            var result = new PairingClaimResultDto();
+
+            foreach (var sensor in sensors)
+            {
+                var alreadyClaimed = await _context.UserSensors.AnyAsync(us => us.UserId == token.UserId && us.SensorId == sensor.Id);
+                var ownedByOther = await _context.UserSensors.AnyAsync(us => us.SensorId == sensor.Id && us.IsOwner && us.UserId != token.UserId);
+                if (alreadyClaimed || ownedByOther)
+                {
+                    result.Skipped++;
+                    continue;
+                }
+
+                _context.UserSensors.Add(new UserSensor { UserId = token.UserId, SensorId = sensor.Id, IsOwner = true });
+
+                // Open an ownership period that bounds which telemetry this user may read. The
+                // first-ever owner starts at the epoch sentinel (sees all history); every later
+                // (resale) owner starts now, so they never see the previous owner's readings.
+                var firstEverOwner = !await _context.SensorOwnershipPeriods.AnyAsync(p => p.SensorId == sensor.Id);
+                _context.SensorOwnershipPeriods.Add(new SensorOwnershipPeriod
+                {
+                    UserId = token.UserId,
+                    SensorId = sensor.Id,
+                    StartedAt = firstEverOwner ? SensorOwnershipPeriod.FirstOwnerStart : DateTime.UtcNow,
+                    EndedAt = null
+                });
+
+                result.ClaimedSensorIds.Add(sensor.Id);
+            }
+
+            foreach (var switchEntity in switches)
+            {
+                var alreadyClaimed = await _context.UserSwitches.AnyAsync(us => us.UserId == token.UserId && us.SwitchId == switchEntity.Id);
+                var ownedByOther = await _context.UserSwitches.AnyAsync(us => us.SwitchId == switchEntity.Id && us.IsOwner && us.UserId != token.UserId);
+                if (alreadyClaimed || ownedByOther)
+                {
+                    result.Skipped++;
+                    continue;
+                }
+
+                _context.UserSwitches.Add(new UserSwitch { UserId = token.UserId, SwitchId = switchEntity.Id, IsOwner = true });
+
+                // Open a direct ownership period that bounds which telemetry this user may read. The
+                // first-ever owner starts at the epoch sentinel (sees all history); every later
+                // (resale) owner starts now, so they never see the previous owner's readings.
+                var firstEverOwner = !await _context.SwitchOwnershipPeriods.AnyAsync(p => p.SwitchId == switchEntity.Id);
+                _context.SwitchOwnershipPeriods.Add(new SwitchOwnershipPeriod
+                {
+                    UserId = token.UserId,
+                    SwitchId = switchEntity.Id,
+                    StartedAt = firstEverOwner ? SwitchOwnershipPeriod.FirstOwnerStart : DateTime.UtcNow,
+                    EndedAt = null
+                });
+
+                result.ClaimedSwitchIds.Add(switchEntity.Id);
+            }
+
+            token.ConsumedAt = DateTime.UtcNow;
+            token.ConsumedByParentName = parentName;
+
+            await _context.SaveChangesAsync();
+
+            foreach (var sensorId in result.ClaimedSensorIds)
+            {
+                _ownership.InvalidateSensor(sensorId);
+                await _hub.Clients.Group(DeviceHub.UserGroup(token.UserId)).SendAsync("device-created", new { kind = "sensor", id = sensorId });
+            }
+            foreach (var switchId in result.ClaimedSwitchIds)
+            {
+                _ownership.InvalidateSwitch(switchId);
+                await _hub.Clients.Group(DeviceHub.UserGroup(token.UserId)).SendAsync("device-created", new { kind = "switch", id = switchId });
+            }
+
+            _logger.LogInformation("ClaimPairing devices assigned to user {@LogData}", new
+            {
+                token.UserId,
+                parentName,
+                ClaimedSensors = result.ClaimedSensorIds.Count,
+                ClaimedSwitches = result.ClaimedSwitchIds.Count,
+                result.Skipped
+            });
+            return Ok(result);
+        }
+    }
+}

--- a/Dtos/Pairing/ClaimPairingTokenDto.cs
+++ b/Dtos/Pairing/ClaimPairingTokenDto.cs
@@ -1,0 +1,8 @@
+namespace garge_api.Dtos.Pairing
+{
+    public class ClaimPairingTokenDto
+    {
+        public string Token { get; set; } = string.Empty;
+        public string ParentName { get; set; } = string.Empty;
+    }
+}

--- a/Dtos/Pairing/PairingClaimResultDto.cs
+++ b/Dtos/Pairing/PairingClaimResultDto.cs
@@ -1,0 +1,9 @@
+namespace garge_api.Dtos.Pairing
+{
+    public class PairingClaimResultDto
+    {
+        public List<int> ClaimedSensorIds { get; set; } = new();
+        public List<int> ClaimedSwitchIds { get; set; } = new();
+        public int Skipped { get; set; }
+    }
+}

--- a/Dtos/Pairing/PairingTokenDto.cs
+++ b/Dtos/Pairing/PairingTokenDto.cs
@@ -1,0 +1,8 @@
+namespace garge_api.Dtos.Pairing
+{
+    public class PairingTokenDto
+    {
+        public required string Token { get; set; }
+        public DateTime ExpiresAt { get; set; }
+    }
+}

--- a/Migrations/20260727092348_AddPairingTokens.Designer.cs
+++ b/Migrations/20260727092348_AddPairingTokens.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using garge_api.Models;
@@ -11,9 +12,11 @@ using garge_api.Models;
 namespace garge_api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260727092348_AddPairingTokens")]
+    partial class AddPairingTokens
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260727092348_AddPairingTokens.cs
+++ b/Migrations/20260727092348_AddPairingTokens.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace garge_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPairingTokens : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PairingTokens",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Token = table.Column<string>(type: "character varying(12)", maxLength: 12, nullable: false),
+                    UserId = table.Column<string>(type: "text", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ExpiresAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ConsumedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    ConsumedByParentName = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PairingTokens", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PairingTokens_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PairingTokens_Token",
+                table: "PairingTokens",
+                column: "Token",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PairingTokens_UserId",
+                table: "PairingTokens",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PairingTokens");
+        }
+    }
+}

--- a/Models/ApplicationDbContext.cs
+++ b/Models/ApplicationDbContext.cs
@@ -4,6 +4,7 @@ using garge_api.Models.Automation;
 using garge_api.Models.Electricity;
 using garge_api.Models.Group;
 using garge_api.Models.Mqtt;
+using garge_api.Models.Pairing;
 using garge_api.Models.Push;
 using garge_api.Models.Sensor;
 using garge_api.Models.Shop;
@@ -61,6 +62,7 @@ namespace garge_api.Models
         public DbSet<ProcessedWebhookEvent> ProcessedWebhookEvents { get; set; }
         public DbSet<Anonymized.AnonymizedSeries> AnonymizedSeries { get; set; }
         public DbSet<Anonymized.AnonymizedReading> AnonymizedReadings { get; set; }
+        public DbSet<PairingToken> PairingTokens { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -408,6 +410,16 @@ namespace garge_api.Models
 
             modelBuilder.Entity<ProcessedWebhookEvent>()
                 .HasIndex(p => p.ProcessedAt);
+
+            modelBuilder.Entity<PairingToken>()
+                .HasIndex(t => t.Token)
+                .IsUnique();
+
+            modelBuilder.Entity<PairingToken>()
+                .HasOne(t => t.User)
+                .WithMany()
+                .HasForeignKey(t => t.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
         }
         public void EnsureTriggers()
         {

--- a/Models/Pairing/PairingToken.cs
+++ b/Models/Pairing/PairingToken.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace garge_api.Models.Pairing
+{
+    /// <summary>
+    /// A short-lived, single-use code a logged-in user mints in the app to pair a physical device.
+    /// The device sends the token over MQTT during setup and the operator service calls back into
+    /// this API (<c>POST /api/pairing/claim</c>) to claim the device's sensors and switches for the
+    /// minting user. Consumed tokens are kept (with <see cref="ConsumedAt"/> set) as an audit trail.
+    /// </summary>
+    public class PairingToken
+    {
+        [Key]
+        public int Id { get; set; }
+
+        [Required]
+        [MaxLength(12)]
+        public required string Token { get; set; }
+
+        [Required]
+        public required string UserId { get; set; }
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+        public DateTime ExpiresAt { get; set; }
+
+        /// <summary>When the operator redeemed this token, or null while still unused.</summary>
+        public DateTime? ConsumedAt { get; set; }
+
+        /// <summary>The parent device name the token was redeemed for, for auditing.</summary>
+        [MaxLength(100)]
+        public string? ConsumedByParentName { get; set; }
+
+        [ForeignKey(nameof(UserId))]
+        public User? User { get; set; }
+    }
+}

--- a/garge-api.Tests/PairingControllerTests.cs
+++ b/garge-api.Tests/PairingControllerTests.cs
@@ -1,0 +1,275 @@
+using garge_api.Controllers;
+using garge_api.Dtos.Pairing;
+using garge_api.Helpers;
+using garge_api.Hubs;
+using garge_api.Models;
+using garge_api.Models.Mqtt;
+using garge_api.Models.Pairing;
+using garge_api.Models.Sensor;
+using garge_api.Models.Switch;
+using garge_api.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace garge_api.Tests;
+
+/// <summary>
+/// Verifies the pairing-token flow: a user mints a short-lived single-use token (superseding any
+/// earlier unconsumed ones); the operator redeems it for a parent device name, which claims every
+/// sensor/switch under that parent for the token's user without stealing devices owned by others.
+/// </summary>
+public class PairingControllerTests : ControllerTestBase
+{
+    private PairingController CreateController(ApplicationDbContext db, string userId)
+    {
+        var ownership = new Mock<IDeviceOwnershipService>();
+
+        var proxy = new Mock<IClientProxy>();
+        proxy.Setup(p => p.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        var clients = new Mock<IHubClients>();
+        clients.Setup(c => c.Group(It.IsAny<string>())).Returns(proxy.Object);
+        var hub = new Mock<IHubContext<DeviceHub>>();
+        hub.SetupGet(h => h.Clients).Returns(clients.Object);
+
+        var controller = new PairingController(db, NullLogger<PairingController>.Instance, ownership.Object, hub.Object);
+        controller.ControllerContext = MakeControllerContext(userId);
+        return controller;
+    }
+
+    private static Sensor MakeSensor(int id, string parentName = "gw") => new()
+    {
+        Id = id, Name = $"garge_volt_{id}", Type = "voltage", Role = "sensor",
+        RegistrationCode = $"rc{id}", DefaultName = "Battery", ParentName = parentName
+    };
+
+    private static Switch MakeSwitch(int id) => new()
+    {
+        Id = id, Name = $"garge_socket_{id}", Type = "switch", Role = "switch", RegistrationCode = $"sw{id}"
+    };
+
+    private static PairingToken MakeToken(
+        string userId, string token = "ABC234", DateTime? expiresAt = null, DateTime? consumedAt = null) => new()
+    {
+        Token = token,
+        UserId = userId,
+        ExpiresAt = expiresAt ?? DateTime.UtcNow.AddMinutes(15),
+        ConsumedAt = consumedAt
+    };
+
+    private static ClaimPairingTokenDto Claim(string token = "ABC234", string parentName = "gw") =>
+        new() { Token = token, ParentName = parentName };
+
+    [Fact]
+    public async Task CreatePairingToken_MintsSixCharTokenWithFifteenMinuteExpiry()
+    {
+        using var db = CreateDbContext();
+        db.Users.Add(MakeUser("user-1"));
+        await db.SaveChangesAsync();
+
+        var result = await CreateController(db, "user-1").CreatePairingToken();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var dto = Assert.IsType<PairingTokenDto>(ok.Value);
+        Assert.Equal(PairingController.TokenLength, dto.Token.Length);
+        Assert.All(dto.Token, c => Assert.Contains(c, RegistrationCode.Alphabet));
+        Assert.InRange(dto.ExpiresAt, DateTime.UtcNow.AddMinutes(14), DateTime.UtcNow.AddMinutes(16));
+
+        var row = db.PairingTokens.Single();
+        Assert.Equal(dto.Token, row.Token);
+        Assert.Equal("user-1", row.UserId);
+        Assert.Null(row.ConsumedAt);
+    }
+
+    [Fact]
+    public async Task CreatePairingToken_SupersedesPreviousUnconsumedTokens_KeepsConsumedOnes()
+    {
+        using var db = CreateDbContext();
+        db.Users.Add(MakeUser("user-1"));
+        db.PairingTokens.Add(MakeToken("user-1", "OLDPQR"));
+        db.PairingTokens.Add(MakeToken("user-1", "USEDXY", consumedAt: DateTime.UtcNow.AddMinutes(-5)));
+        await db.SaveChangesAsync();
+
+        var result = await CreateController(db, "user-1").CreatePairingToken();
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.DoesNotContain(db.PairingTokens, t => t.Token == "OLDPQR"); // superseded
+        Assert.Contains(db.PairingTokens, t => t.Token == "USEDXY"); // consumed rows are audit trail
+        Assert.Single(db.PairingTokens.Where(t => t.ConsumedAt == null));
+    }
+
+    [Fact]
+    public async Task CreatePairingToken_UnknownUser_Unauthorized()
+    {
+        using var db = CreateDbContext();
+
+        var result = await CreateController(db, "ghost").CreatePairingToken();
+
+        Assert.IsType<UnauthorizedResult>(result);
+    }
+
+    [Fact]
+    public async Task ClaimPairing_MissingTokenOrParentName_BadRequest()
+    {
+        using var db = CreateDbContext();
+
+        Assert.IsType<BadRequestObjectResult>(await CreateController(db, "op").ClaimPairing(Claim(token: " ")));
+        Assert.IsType<BadRequestObjectResult>(await CreateController(db, "op").ClaimPairing(Claim(parentName: "")));
+    }
+
+    [Fact]
+    public async Task ClaimPairing_UnknownToken_NotFound()
+    {
+        using var db = CreateDbContext();
+
+        var result = await CreateController(db, "op").ClaimPairing(Claim("NOPE22"));
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task ClaimPairing_ExpiredToken_Gone()
+    {
+        using var db = CreateDbContext();
+        db.Users.Add(MakeUser("user-1"));
+        db.PairingTokens.Add(MakeToken("user-1", expiresAt: DateTime.UtcNow.AddMinutes(-1)));
+        await db.SaveChangesAsync();
+
+        var result = await CreateController(db, "op").ClaimPairing(Claim());
+
+        var status = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(410, status.StatusCode);
+    }
+
+    [Fact]
+    public async Task ClaimPairing_ConsumedToken_Gone()
+    {
+        using var db = CreateDbContext();
+        db.Users.Add(MakeUser("user-1"));
+        db.PairingTokens.Add(MakeToken("user-1", consumedAt: DateTime.UtcNow.AddMinutes(-1)));
+        await db.SaveChangesAsync();
+
+        var result = await CreateController(db, "op").ClaimPairing(Claim());
+
+        var status = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(410, status.StatusCode);
+    }
+
+    [Fact]
+    public async Task ClaimPairing_NoDevicesForParent_NotFoundWithDistinctCode()
+    {
+        using var db = CreateDbContext();
+        db.Users.Add(MakeUser("user-1"));
+        db.PairingTokens.Add(MakeToken("user-1"));
+        await db.SaveChangesAsync();
+
+        var result = await CreateController(db, "op").ClaimPairing(Claim(parentName: "no-such-gw"));
+
+        var notFound = Assert.IsType<NotFoundObjectResult>(result);
+        var code = notFound.Value!.GetType().GetProperty("code")?.GetValue(notFound.Value);
+        Assert.Equal("devices-not-found", code);
+        Assert.Null(db.PairingTokens.Single().ConsumedAt); // token stays redeemable for a retry
+    }
+
+    [Fact]
+    public async Task ClaimPairing_ClaimsSensorsAndDiscoveredSwitches_FirstOwnerGetsEpochStart()
+    {
+        using var db = CreateDbContext();
+        db.Users.Add(MakeUser("user-1"));
+        db.Sensors.Add(MakeSensor(1));
+        db.Switches.Add(MakeSwitch(2));
+        db.DiscoveredDevices.Add(new DiscoveredDevice { DiscoveredBy = "gw", Target = "garge_socket_2", Type = "switch", Timestamp = DateTime.UtcNow });
+        db.PairingTokens.Add(MakeToken("user-1"));
+        await db.SaveChangesAsync();
+
+        // Lowercase token exercises the case-insensitive match.
+        var result = await CreateController(db, "op").ClaimPairing(Claim("abc234"));
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var dto = Assert.IsType<PairingClaimResultDto>(ok.Value);
+        Assert.Equal(new[] { 1 }, dto.ClaimedSensorIds);
+        Assert.Equal(new[] { 2 }, dto.ClaimedSwitchIds);
+        Assert.Equal(0, dto.Skipped);
+
+        var userSensor = db.UserSensors.Single(us => us.UserId == "user-1" && us.SensorId == 1);
+        Assert.True(userSensor.IsOwner);
+        var userSwitch = db.UserSwitches.Single(us => us.UserId == "user-1" && us.SwitchId == 2);
+        Assert.True(userSwitch.IsOwner);
+
+        // First-ever owners see all history from the device's birth.
+        Assert.Equal(SensorOwnershipPeriod.FirstOwnerStart, db.SensorOwnershipPeriods.Single().StartedAt);
+        Assert.Equal(SwitchOwnershipPeriod.FirstOwnerStart, db.SwitchOwnershipPeriods.Single().StartedAt);
+
+        var token = db.PairingTokens.Single();
+        Assert.NotNull(token.ConsumedAt);
+        Assert.Equal("gw", token.ConsumedByParentName);
+    }
+
+    [Fact]
+    public async Task ClaimPairing_DeviceOwnedByAnotherUser_IsSkippedNotStolen()
+    {
+        using var db = CreateDbContext();
+        db.Users.AddRange(MakeUser("user-1"), MakeUser("other", "other@example.com"));
+        db.Sensors.AddRange(MakeSensor(1), MakeSensor(2));
+        db.UserSensors.Add(new UserSensor { UserId = "other", SensorId = 1, IsOwner = true });
+        db.SensorOwnershipPeriods.Add(new SensorOwnershipPeriod
+        {
+            UserId = "other", SensorId = 1, StartedAt = SensorOwnershipPeriod.FirstOwnerStart, EndedAt = null
+        });
+        db.PairingTokens.Add(MakeToken("user-1"));
+        await db.SaveChangesAsync();
+
+        var result = await CreateController(db, "op").ClaimPairing(Claim());
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var dto = Assert.IsType<PairingClaimResultDto>(ok.Value);
+        Assert.Equal(new[] { 2 }, dto.ClaimedSensorIds);
+        Assert.Equal(1, dto.Skipped);
+        Assert.DoesNotContain(db.UserSensors, us => us.UserId == "user-1" && us.SensorId == 1);
+        Assert.NotNull(db.PairingTokens.Single().ConsumedAt);
+    }
+
+    [Fact]
+    public async Task ClaimPairing_ResoldSensor_LaterOwnerPeriodStartsNow()
+    {
+        using var db = CreateDbContext();
+        db.Users.Add(MakeUser("user-1"));
+        db.Sensors.Add(MakeSensor(1));
+        // A previous, since-closed ownership stint: the new owner must not see that history.
+        db.SensorOwnershipPeriods.Add(new SensorOwnershipPeriod
+        {
+            UserId = "previous-owner", SensorId = 1,
+            StartedAt = SensorOwnershipPeriod.FirstOwnerStart, EndedAt = DateTime.UtcNow.AddDays(-1)
+        });
+        db.PairingTokens.Add(MakeToken("user-1"));
+        await db.SaveChangesAsync();
+
+        var result = await CreateController(db, "op").ClaimPairing(Claim());
+
+        Assert.IsType<OkObjectResult>(result);
+        var period = db.SensorOwnershipPeriods.Single(p => p.UserId == "user-1" && p.SensorId == 1);
+        Assert.NotEqual(SensorOwnershipPeriod.FirstOwnerStart, period.StartedAt); // from now, not the full-history epoch
+        Assert.Null(period.EndedAt);
+    }
+
+    [Fact]
+    public async Task ClaimPairing_UserAlreadyHasDevice_SkipsWithoutDuplicateRows()
+    {
+        using var db = CreateDbContext();
+        db.Users.Add(MakeUser("user-1"));
+        db.Sensors.Add(MakeSensor(1));
+        db.UserSensors.Add(new UserSensor { UserId = "user-1", SensorId = 1, IsOwner = true });
+        db.PairingTokens.Add(MakeToken("user-1"));
+        await db.SaveChangesAsync();
+
+        var result = await CreateController(db, "op").ClaimPairing(Claim());
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var dto = Assert.IsType<PairingClaimResultDto>(ok.Value);
+        Assert.Empty(dto.ClaimedSensorIds);
+        Assert.Equal(1, dto.Skipped);
+        Assert.Single(db.UserSensors.Where(us => us.UserId == "user-1" && us.SensorId == 1));
+    }
+}


### PR DESCRIPTION
Part of the device-pairing feature (companion PRs in firmware, garge-operator, garge-app).

- `POST /api/pairing/token` (ActiveSubscription): mints single-use 6-char token, 15 min TTL, one redeemable per user.
- `POST /api/pairing/claim` (Admin/SensorAdmin/SwitchAdmin, called by operator): claims all sensors/switches under `parentName` for the token's user, reusing existing owner-row + ownership-period logic; skips devices owned by others; 410 expired/consumed; retryable 404 `{code:"devices-not-found"}` when device rows not created yet; emits existing `device-created` SignalR event.
- Switches resolved via `DiscoveredDevices` chain (Switch has no ParentName).
- Migration `AddPairingTokens` (applied to dev DB; prod needs it at deploy).