### PR TITLE
feat: device credential provisioning endpoint

### DIFF
--- a/Controllers/MqttController.cs
+++ b/Controllers/MqttController.cs
@@ -1,5 +1,6 @@
 ﻿using garge_api.Constants;
 using garge_api.Dtos.Mqtt;
+using garge_api.Helpers;
 using garge_api.Models;
 using garge_api.Models.Mqtt;
 using Microsoft.AspNetCore.Authorization;
@@ -8,8 +9,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
 using System.Security.Claims;
-using System.Security.Cryptography;
-using System.Text;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace garge_api.Controllers
@@ -27,21 +26,6 @@ namespace garge_api.Controllers
         {
             _context = context;
             _logger = logger;
-        }
-
-        private static string GenerateSalt(int length = 16)
-        {
-            var saltBytes = new byte[length];
-            using var rng = RandomNumberGenerator.Create();
-            rng.GetBytes(saltBytes);
-            return Convert.ToHexString(saltBytes).ToLowerInvariant();
-        }
-
-        private static string HashPasswordPBKDF2(string password, string salt, int iterations = 300_000, int hashByteSize = 32)
-        {
-            var saltBytes = Encoding.UTF8.GetBytes(salt);
-            var hash = Rfc2898DeriveBytes.Pbkdf2(password, saltBytes, iterations, HashAlgorithmName.SHA512, hashByteSize);
-            return Convert.ToHexString(hash).ToLowerInvariant();
         }
 
         /// <summary>
@@ -65,8 +49,8 @@ namespace garge_api.Controllers
                 return Conflict(new { message = "Username already exists." });
             }
 
-            var salt = GenerateSalt(16);
-            var hash = HashPasswordPBKDF2(dto.Password, salt);
+            var salt = MqttPasswordHasher.GenerateSalt(16);
+            var hash = MqttPasswordHasher.HashPasswordPBKDF2(dto.Password, salt);
 
             // IsSuperuser intentionally hardcoded to false. Broker superusers
             // bypass all ACLs; granting that flag must be done out-of-band

--- a/Controllers/PairingController.cs
+++ b/Controllers/PairingController.cs
@@ -1,7 +1,9 @@
 using garge_api.Constants;
 using garge_api.Dtos.Pairing;
+using garge_api.Helpers;
 using garge_api.Hubs;
 using garge_api.Models;
+using garge_api.Models.Mqtt;
 using garge_api.Models.Pairing;
 using garge_api.Models.Sensor;
 using garge_api.Models.Switch;
@@ -12,6 +14,8 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using Swashbuckle.AspNetCore.Annotations;
+using System.Security.Cryptography;
+using System.Text.RegularExpressions;
 
 namespace garge_api.Controllers
 {
@@ -234,6 +238,134 @@ namespace garge_api.Controllers
                 result.Skipped
             });
             return Ok(result);
+        }
+
+        /// <summary>Chip ids are the device MAC: exactly 12 lowercase hex characters.</summary>
+        private static readonly Regex ChipIdRegex = new("^[0-9a-f]{12}$", RegexOptions.Compiled);
+
+        /// <summary>Equivalent of the provisioning script's <c>secrets.token_urlsafe(16)</c>.</summary>
+        private static string GenerateDevicePassword()
+        {
+            var bytes = RandomNumberGenerator.GetBytes(16);
+            return Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+        }
+
+        /// <summary>
+        /// Exchanges a pairing token for per-device MQTT broker credentials. Anonymous:
+        /// possession of a live pairing token is the authorization. The token is not consumed
+        /// here — it stays redeemable for the subsequent <see cref="ClaimPairing"/> step.
+        /// </summary>
+        [HttpPost("provision")]
+        [AllowAnonymous]
+        [SwaggerOperation(Summary = "Exchanges a pairing token for per-device MQTT broker credentials.")]
+        [SwaggerResponse(200, "The MQTT username and plaintext password (returned exactly once).", typeof(DeviceCredentialsDto))]
+        [SwaggerResponse(400, "Chip id is not 12 hex characters.")]
+        [SwaggerResponse(404, "Unknown token.")]
+        [SwaggerResponse(409, "Device is owned by another user.")]
+        [SwaggerResponse(410, "Token expired or already consumed.")]
+        public async Task<IActionResult> ProvisionDevice([FromBody] ProvisionDeviceDto dto)
+        {
+            var chipId = dto.ChipId?.Trim().ToLowerInvariant() ?? string.Empty;
+            if (!ChipIdRegex.IsMatch(chipId))
+            {
+                _logger.LogWarning("ProvisionDevice bad request: Invalid chip id");
+                return BadRequest(new { message = "ChipId must be 12 hexadecimal characters." });
+            }
+            var deviceName = $"garge_{chipId}";
+
+            var normalizedToken = (dto.Token ?? string.Empty).Trim().ToUpperInvariant();
+            var token = await _context.PairingTokens.FirstOrDefaultAsync(t => t.Token == normalizedToken);
+            if (token == null)
+            {
+                _logger.LogWarning("ProvisionDevice not found: Unknown pairing token {@LogData}", new { deviceName });
+                return NotFound(new { message = "Unknown pairing token." });
+            }
+
+            if (token.ConsumedAt != null)
+            {
+                _logger.LogWarning("ProvisionDevice gone: Token already consumed {@LogData}", new { token.Id, token.ConsumedAt, deviceName });
+                return StatusCode(410, new { message = "Pairing token has already been used." });
+            }
+
+            if (token.ExpiresAt <= DateTime.UtcNow)
+            {
+                _logger.LogWarning("ProvisionDevice gone: Token expired {@LogData}", new { token.Id, token.ExpiresAt, deviceName });
+                return StatusCode(410, new { message = "Pairing token has expired." });
+            }
+
+            // Rotating credentials for a device owned by someone else would let a stranger's
+            // token hijack it; unclaimed devices (including first boot, no rows yet) may proceed.
+            var sensorIds = await _context.Sensors
+                .Where(s => s.ParentName == deviceName)
+                .Select(s => s.Id)
+                .ToListAsync();
+            var sensorOwnedByOther = await _context.UserSensors
+                .AnyAsync(us => sensorIds.Contains(us.SensorId) && us.IsOwner && us.UserId != token.UserId);
+
+            // Switches have no parent name; they relate to the gateway via DiscoveredDevices.
+            var switchNames = await _context.DiscoveredDevices
+                .Where(dd => dd.DiscoveredBy == deviceName)
+                .Select(dd => dd.Target)
+                .Distinct()
+                .ToListAsync();
+            var switchIds = await _context.Switches
+                .Where(s => switchNames.Contains(s.Name))
+                .Select(s => s.Id)
+                .ToListAsync();
+            var switchOwnedByOther = await _context.UserSwitches
+                .AnyAsync(us => switchIds.Contains(us.SwitchId) && us.IsOwner && us.UserId != token.UserId);
+
+            if (sensorOwnedByOther || switchOwnedByOther)
+            {
+                _logger.LogWarning("ProvisionDevice conflict: Device owned by another user {@LogData}", new { deviceName, token.UserId });
+                return Conflict(new { message = "Device is owned by another user." });
+            }
+
+            var password = GenerateDevicePassword();
+            var salt = MqttPasswordHasher.GenerateSalt(16);
+            var hash = MqttPasswordHasher.HashPasswordPBKDF2(password, salt);
+
+            var brokerUser = await _context.EMQXMqttUsers.FirstOrDefaultAsync(u => u.Username == deviceName);
+            var rotated = brokerUser != null;
+            if (brokerUser == null)
+            {
+                // Broker superusers bypass all ACLs.
+                brokerUser = new EMQXMqttUser { IsSuperuser = false, Username = deviceName };
+                _context.EMQXMqttUsers.Add(brokerUser);
+            }
+            brokerUser.PasswordHash = hash;
+            brokerUser.Salt = salt;
+
+            // Two rows (retain 1 and 0) mirror the provisioning script; upsert is idempotent.
+            var topic = $"garge/devices/{deviceName}/#";
+            foreach (short retain in new short[] { 1, 0 })
+            {
+                var exists = await _context.EMQXMqttAcls.AnyAsync(a =>
+                    a.Username == deviceName && a.Permission == "allow" && a.Action == "all" &&
+                    a.Topic == topic && a.Qos == 0 && a.Retain == retain);
+                if (!exists)
+                {
+                    _context.EMQXMqttAcls.Add(new EMQXMqttAcl
+                    {
+                        Username = deviceName,
+                        Permission = "allow",
+                        Action = "all",
+                        Topic = topic,
+                        Qos = 0,
+                        Retain = retain
+                    });
+                }
+            }
+
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("ProvisionDevice credentials issued {@LogData}", new
+            {
+                token.UserId,
+                DeviceName = deviceName,
+                Rotated = rotated
+            });
+            return Ok(new DeviceCredentialsDto { Username = deviceName, Password = password });
         }
     }
 }

--- a/Dtos/Pairing/DeviceCredentialsDto.cs
+++ b/Dtos/Pairing/DeviceCredentialsDto.cs
@@ -1,0 +1,10 @@
+namespace garge_api.Dtos.Pairing
+{
+    /// <summary>MQTT broker credentials handed to a device during provisioning. The plaintext
+    /// password is returned exactly once; only its PBKDF2 hash is stored.</summary>
+    public class DeviceCredentialsDto
+    {
+        public required string Username { get; set; }
+        public required string Password { get; set; }
+    }
+}

--- a/Dtos/Pairing/ProvisionDeviceDto.cs
+++ b/Dtos/Pairing/ProvisionDeviceDto.cs
@@ -1,0 +1,8 @@
+namespace garge_api.Dtos.Pairing
+{
+    public class ProvisionDeviceDto
+    {
+        public required string Token { get; set; }
+        public required string ChipId { get; set; }
+    }
+}

--- a/Helpers/MqttPasswordHasher.cs
+++ b/Helpers/MqttPasswordHasher.cs
@@ -1,0 +1,27 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace garge_api.Helpers
+{
+    /// <summary>
+    /// PBKDF2 hashing for EMQX broker users. Must match the broker's password_hash
+    /// configuration (SHA-512, 300k iterations, lowercase hex).
+    /// </summary>
+    internal static class MqttPasswordHasher
+    {
+        internal static string GenerateSalt(int length = 16)
+        {
+            var saltBytes = new byte[length];
+            using var rng = RandomNumberGenerator.Create();
+            rng.GetBytes(saltBytes);
+            return Convert.ToHexString(saltBytes).ToLowerInvariant();
+        }
+
+        internal static string HashPasswordPBKDF2(string password, string salt, int iterations = 300_000, int hashByteSize = 32)
+        {
+            var saltBytes = Encoding.UTF8.GetBytes(salt);
+            var hash = Rfc2898DeriveBytes.Pbkdf2(password, saltBytes, iterations, HashAlgorithmName.SHA512, hashByteSize);
+            return Convert.ToHexString(hash).ToLowerInvariant();
+        }
+    }
+}

--- a/appsettings.json
+++ b/appsettings.json
@@ -45,6 +45,7 @@
       { "Endpoint": "*:/api/subscriptions/webhook", "Period": "1m", "Limit": 200 },
       { "Endpoint": "*:/api/shop/checkout", "Period": "1m", "Limit": 10 },
       { "Endpoint": "*:/api/shop/webhook", "Period": "1m", "Limit": 200 },
+      { "Endpoint": "*:/api/pairing/provision", "Period": "1m", "Limit": 5 },
       { "Endpoint": "*:/hubs/devices/negotiate", "Period": "1m", "Limit": 30 }
     ]
   },

--- a/garge-api.Tests/PairingControllerTests.cs
+++ b/garge-api.Tests/PairingControllerTests.cs
@@ -62,6 +62,12 @@ public class PairingControllerTests : ControllerTestBase
     private static ClaimPairingTokenDto Claim(string token = "ABC234", string parentName = "gw") =>
         new() { Token = token, ParentName = parentName };
 
+    private const string ChipId = "a1b2c3d4e5f6";
+    private const string DeviceName = $"garge_{ChipId}";
+
+    private static ProvisionDeviceDto Provision(string token = "ABC234", string chipId = ChipId) =>
+        new() { Token = token, ChipId = chipId };
+
     [Fact]
     public async Task CreatePairingToken_MintsSixCharTokenWithFifteenMinuteExpiry()
     {
@@ -271,5 +277,111 @@ public class PairingControllerTests : ControllerTestBase
         Assert.Empty(dto.ClaimedSensorIds);
         Assert.Equal(1, dto.Skipped);
         Assert.Single(db.UserSensors.Where(us => us.UserId == "user-1" && us.SensorId == 1));
+    }
+
+    [Fact]
+    public async Task ProvisionDevice_FirstBoot_CreatesBrokerUserAndAcls()
+    {
+        using var db = CreateDbContext();
+        db.Users.Add(MakeUser("user-1"));
+        db.PairingTokens.Add(MakeToken("user-1"));
+        await db.SaveChangesAsync();
+
+        var result = await CreateController(db, "device").ProvisionDevice(Provision());
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var creds = Assert.IsType<DeviceCredentialsDto>(ok.Value);
+        Assert.Equal(DeviceName, creds.Username);
+        Assert.Equal(22, creds.Password.Length); // secrets.token_urlsafe(16) equivalent
+        Assert.All(creds.Password, c => Assert.Contains(c, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"));
+
+        var user = db.EMQXMqttUsers.Single();
+        Assert.Equal(DeviceName, user.Username);
+        Assert.False(user.IsSuperuser);
+        // Only the PBKDF2 hash is stored; the returned plaintext must verify against it.
+        Assert.Equal(MqttPasswordHasher.HashPasswordPBKDF2(creds.Password, user.Salt!), user.PasswordHash);
+
+        var acls = db.EMQXMqttAcls.OrderBy(a => a.Retain).ToList();
+        Assert.Equal(2, acls.Count);
+        Assert.Equal(new short?[] { 0, 1 }, acls.Select(a => a.Retain));
+        Assert.All(acls, a =>
+        {
+            Assert.Equal(DeviceName, a.Username);
+            Assert.Equal($"garge/devices/{DeviceName}/#", a.Topic);
+            Assert.Equal("all", a.Action);
+            Assert.Equal("allow", a.Permission);
+            Assert.Equal((short)0, a.Qos);
+        });
+
+        // The token is only consumed by the later claim step.
+        Assert.Null(db.PairingTokens.Single().ConsumedAt);
+    }
+
+    [Fact]
+    public async Task ProvisionDevice_ExistingBrokerUser_RotatesPasswordWithoutDuplicates()
+    {
+        using var db = CreateDbContext();
+        db.Users.Add(MakeUser("user-1"));
+        db.PairingTokens.Add(MakeToken("user-1"));
+        db.EMQXMqttUsers.Add(new EMQXMqttUser { Username = DeviceName, PasswordHash = "old-hash", Salt = "old-salt", IsSuperuser = false });
+        db.EMQXMqttAcls.Add(new EMQXMqttAcl { Username = DeviceName, Permission = "allow", Action = "all", Topic = $"garge/devices/{DeviceName}/#", Qos = 0, Retain = 1 });
+        db.EMQXMqttAcls.Add(new EMQXMqttAcl { Username = DeviceName, Permission = "allow", Action = "all", Topic = $"garge/devices/{DeviceName}/#", Qos = 0, Retain = 0 });
+        await db.SaveChangesAsync();
+
+        // Uppercase chip id exercises the lowercase normalization.
+        var result = await CreateController(db, "device").ProvisionDevice(Provision(chipId: ChipId.ToUpperInvariant()));
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var creds = Assert.IsType<DeviceCredentialsDto>(ok.Value);
+        Assert.Equal(DeviceName, creds.Username);
+
+        var user = db.EMQXMqttUsers.Single(); // rotated in place, not duplicated
+        Assert.NotEqual("old-hash", user.PasswordHash);
+        Assert.NotEqual("old-salt", user.Salt);
+        Assert.Equal(MqttPasswordHasher.HashPasswordPBKDF2(creds.Password, user.Salt!), user.PasswordHash);
+
+        Assert.Equal(2, db.EMQXMqttAcls.Count()); // upsert respects the unique composite index
+    }
+
+    [Fact]
+    public async Task ProvisionDevice_DeviceOwnedByAnotherUser_Conflict()
+    {
+        using var db = CreateDbContext();
+        db.Users.AddRange(MakeUser("user-1"), MakeUser("other", "other@example.com"));
+        db.Sensors.Add(MakeSensor(1, parentName: DeviceName));
+        db.UserSensors.Add(new UserSensor { UserId = "other", SensorId = 1, IsOwner = true });
+        db.PairingTokens.Add(MakeToken("user-1"));
+        await db.SaveChangesAsync();
+
+        var result = await CreateController(db, "device").ProvisionDevice(Provision());
+
+        Assert.IsType<ConflictObjectResult>(result);
+        Assert.Empty(db.EMQXMqttUsers); // no credentials minted for a device someone else owns
+        Assert.Empty(db.EMQXMqttAcls);
+    }
+
+    [Fact]
+    public async Task ProvisionDevice_ExpiredToken_Gone()
+    {
+        using var db = CreateDbContext();
+        db.Users.Add(MakeUser("user-1"));
+        db.PairingTokens.Add(MakeToken("user-1", expiresAt: DateTime.UtcNow.AddMinutes(-1)));
+        await db.SaveChangesAsync();
+
+        var result = await CreateController(db, "device").ProvisionDevice(Provision());
+
+        var status = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(410, status.StatusCode);
+        Assert.Empty(db.EMQXMqttUsers);
+    }
+
+    [Fact]
+    public async Task ProvisionDevice_InvalidChipId_BadRequest()
+    {
+        using var db = CreateDbContext();
+
+        Assert.IsType<BadRequestObjectResult>(await CreateController(db, "device").ProvisionDevice(Provision(chipId: "nothex")));
+        Assert.IsType<BadRequestObjectResult>(await CreateController(db, "device").ProvisionDevice(Provision(chipId: "a1b2c3d4e5f6aa"))); // too long
+        Assert.IsType<BadRequestObjectResult>(await CreateController(db, "device").ProvisionDevice(Provision(chipId: "g1b2c3d4e5f6"))); // non-hex char
     }
 }


### PR DESCRIPTION
Part of the device-provisioning feature (companion PR in firmware). Devices exchange their pairing token for broker credentials instead of requiring manual credential flashing.

- `POST /api/pairing/provision` (anonymous; a valid unexpired pairing token is the authorization): creates or rotates the device's `EMQXMqttUser` (PBKDF2, same convention as the provisioning script) and upserts the two topic ACL rows, returning `{username, password}` once. The token is not consumed — the claim step does that.
- Guards: chipId format (400), unknown token (404), expired/consumed (410), device owned by another user (409, resolved via sensors' ParentName and the switches DiscoveredDevices chain). Rate limited 5/min.
- Hashing extracted to `MqttPasswordHasher`, shared with `MqttController` (verbatim move).
- No migration; uses existing MQTT credential tables.
